### PR TITLE
Use ContentType::Plain for String responses

### DIFF
--- a/lib/src/response/responder.rs
+++ b/lib/src/response/responder.rs
@@ -188,12 +188,12 @@ impl<'r> Responder<'r> for &'r str {
     }
 }
 
-/// Returns a response with Content-Type `text/html` and a fized-size body
+/// Returns a response with Content-Type `text/plain` and a fixed-size body
 /// containing the string `self`. Always returns `Ok`.
 impl Responder<'static> for String {
     fn respond(self) -> Result<Response<'static>, Status> {
         Response::build()
-            .header(ContentType::HTML)
+            .header(ContentType::Plain)
             .sized_body(Cursor::new(self))
             .ok()
     }


### PR DESCRIPTION
There is an inconsistency between `&str` and `String` responses. `&str` responses use `Content-Type: text/plain` and `String` responses use `Content-Type: text/html`, which may be unexpected.

This commit changes `String` responses to use `Content-Type: text/plain`.

Fixes #49