### PR TITLE
autoescape vars in .html.tera files

### DIFF
--- a/contrib/src/templates/tera_templates.rs
+++ b/contrib/src/templates/tera_templates.rs
@@ -8,11 +8,10 @@ use super::{TemplateInfo, TEMPLATE_DIR};
 lazy_static! {
     static ref TERA: Result<tera::Tera, String> = {
         let path: PathBuf = [&*TEMPLATE_DIR, "**", "*.tera"].iter().collect();
-        let escape_ext = [".html.tera", ".htm.tera", ".xml.tera",
-                          ".html", ".htm", ".xml"];
+        let ext = [".html.tera", ".htm.tera", ".xml.tera", ".html", ".htm", ".xml"];
         tera::Tera::new(path.to_str().unwrap())
             .map(|mut tera| {
-                tera.autoescape_on(escape_ext.to_vec());
+                tera.autoescape_on(ext.to_vec());
                 tera
             })
             .map_err(|e| format!("{:?}", e))

--- a/contrib/src/templates/tera_templates.rs
+++ b/contrib/src/templates/tera_templates.rs
@@ -8,15 +8,12 @@ use super::{TemplateInfo, TEMPLATE_DIR};
 lazy_static! {
     static ref TERA: Result<tera::Tera, String> = {
         let path: PathBuf = [&*TEMPLATE_DIR, "**", "*.tera"].iter().collect();
+        let escape_ext = [".html.tera", ".htm.tera", ".xml.tera",
+                          ".html", ".htm", ".xml"];
         tera::Tera::new(path.to_str().unwrap())
-            .map(|mut t| {
-                t.autoescape_on(vec![
-                    // defaults with .tera extension
-                    ".html.tera",".htm.tera",".xml.tera",
-                    // keep tera default extensions
-                    ".html",".htm",".xml"
-                ]);
-                t
+            .map(|mut tera| {
+                tera.autoescape_on(escape_ext.to_vec());
+                tera
             })
             .map_err(|e| format!("{:?}", e))
     };

--- a/contrib/src/templates/tera_templates.rs
+++ b/contrib/src/templates/tera_templates.rs
@@ -8,7 +8,17 @@ use super::{TemplateInfo, TEMPLATE_DIR};
 lazy_static! {
     static ref TERA: Result<tera::Tera, String> = {
         let path: PathBuf = [&*TEMPLATE_DIR, "**", "*.tera"].iter().collect();
-        tera::Tera::new(path.to_str().unwrap()).map_err(|e| format!("{:?}", e))
+        tera::Tera::new(path.to_str().unwrap())
+            .map(|mut t| {
+                t.autoescape_on(vec![
+                    // defaults with .tera extension
+                    ".html.tera",".htm.tera",".xml.tera",
+                    // keep tera default extensions
+                    ".html",".htm",".xml"
+                ]);
+                t
+            })
+            .map_err(|e| format!("{:?}", e))
     };
 }
 


### PR DESCRIPTION
Add .html.tera to list of file extensions that tera should
autoescape.  This should allow the same default XSS protection
provided by tera defaults, with the added the .tera extension.

Fixes #73 