### PR TITLE
fix decoding from form values: replace `+` with ` ` before percent decoding

### DIFF
--- a/examples/forms/src/main.rs
+++ b/examples/forms/src/main.rs
@@ -12,7 +12,7 @@ use rocket::response::Redirect;
 #[derive(FromForm)]
 struct UserLogin<'r> {
     username: &'r str,
-    password: &'r str,
+    password: String, // use String here to apply form url decoding
     age: Result<usize, &'r str>,
 }
 
@@ -27,10 +27,12 @@ fn login<'a>(user_form: Form<'a, UserLogin<'a>>) -> Result<Redirect, String> {
     };
 
     if user.username == "Sergio" {
-        match user.password {
+        match user.password.as_str() {
             "password" => Ok(Redirect::to("/user/Sergio")),
             _ => Err("Wrong password!".to_string())
         }
+    } else if user.username == "print_passsword" {
+        Err(format!("{}", user.password))
     } else {
         Err(format!("Unrecognized user, '{}'.", user.username))
     }

--- a/examples/forms/src/tests.rs
+++ b/examples/forms/src/tests.rs
@@ -13,7 +13,7 @@ fn test_login(username: &str, password: &str, age: isize, status: Status,
     let mut response = req.dispatch_with(&rocket);
     let body_str = response.body().and_then(|body| body.into_string());
 
-    println!("Checking: {:?}/{:?}", username, password);
+    println!("Checking: {:?}/{:?}/{:?}/{:?}", username, password, age, body_str);
     assert_eq!(response.status(), status);
 
     if let Some(string) = body {
@@ -35,6 +35,11 @@ fn test_bad_login() {
     test_login("Sergio", "jk", -100, OK, Some("'-100' is not a valid integer."));
     test_login("Sergio", "ok", 30, OK, Some("Wrong password!"));
     test_login("Mike", "password", 30, OK, Some("Unrecognized user, 'Mike'."));
+    // request parameters are url-encoded (normally by browser)
+    test_login("print_passsword", "password", 100, OK, Some("password"));
+    test_login("print_passsword", "1+1", 100, OK, Some("1 1"));
+    test_login("print_passsword", "1%2B1", 100, OK, Some("1+1"));
+    test_login("print_passsword", "%3Fa%3D1%26b%3D2", 100, OK, Some("?a=1&b=2"));
 }
 
 #[test]

--- a/lib/src/request/form/from_form_value.rs
+++ b/lib/src/request/form/from_form_value.rs
@@ -73,21 +73,11 @@ impl<'v> FromFormValue<'v> for String {
 
     // This actually parses the value according to the standard.
     fn from_form_value(v: &'v str) -> Result<Self, Self::Error> {
-        let result = URI::percent_decode(v.as_bytes());
+        let replaced = v.replace("+", " "); // keep `v` as is, so we may return it
+        let result = URI::percent_decode(replaced.as_bytes());
         match result {
             Err(_) => Err(v),
-            Ok(mut string) => Ok({
-                // Entirely safe because we're changing the single-byte '+'.
-                unsafe {
-                    for c in string.to_mut().as_mut_vec() {
-                        if *c == b'+' {
-                            *c = b' ';
-                        }
-                    }
-                }
-
-                string.into_owned()
-            })
+            Ok(string) => Ok(string.into_owned())
         }
     }
 }


### PR DESCRIPTION
I'v added some tests, too.

# problem before this pr

people input text `1+1` in a form field in a web page, then submit, then the browser encode it as `1%2B1`, then `percent_decode()` decode it back to `1+1`, then `+` is replaced by ` `(a space), so the end result is `1 1`, which is wrong! (should be `1+1`, the same value as people input).

# works after this pr

- `1+1` =(browser encode)=> `1%2B1` =(repace `+`)=> `1%2B1` =(percent decode)=> `1+1`
- `1 1` =(browser encode)=> `1+1` =(repace `+`)=> `1 1` =(percent decode)=> `1 1`
- `?a=1&b=2` =(browser encode)=> `%3Fa%3D1%26b%3D2` =(repace `+`)=> `%3Fa%3D1%26b%3D2` =(percent decode)=> `?a=1&b=2`