### PR TITLE
Add config option to disable emojis

### DIFF
--- a/examples/config/Rocket.toml
+++ b/examples/config/Rocket.toml
@@ -4,7 +4,7 @@
 [development]
 address = "localhost"
 port = 8000
-disable_emojis = true
+disable_emojis = false
 log = "normal"
 hi = "Hello!"
 is_extra = true

--- a/examples/config/Rocket.toml
+++ b/examples/config/Rocket.toml
@@ -4,6 +4,7 @@
 [development]
 address = "localhost"
 port = 8000
+disable_emojis = true
 log = "normal"
 hi = "Hello!"
 is_extra = true

--- a/lib/src/config/config.rs
+++ b/lib/src/config/config.rs
@@ -20,6 +20,8 @@ pub struct Config {
     pub log_level: LoggingLevel,
     /// The environment that this configuration corresponds to.
     pub env: Environment,
+    /// Is rocket allowed to print emojis?
+    pub disable_emojis: bool,
     session_key: RwLock<Option<String>>,
     extras: HashMap<String, Value>,
     filepath: String,
@@ -53,6 +55,7 @@ impl Config {
                     session_key: RwLock::new(None),
                     extras: HashMap::new(),
                     env: env,
+                    disable_emojis: true,
                     filepath: filepath.to_string(),
                 }
             }
@@ -64,6 +67,7 @@ impl Config {
                     session_key: RwLock::new(None),
                     extras: HashMap::new(),
                     env: env,
+                    disable_emojis: true,
                     filepath: filepath.to_string(),
                 }
             }
@@ -75,6 +79,7 @@ impl Config {
                     session_key: RwLock::new(None),
                     extras: HashMap::new(),
                     env: env,
+                    disable_emojis: true,
                     filepath: filepath.to_string(),
                 }
             }
@@ -134,6 +139,8 @@ impl Config {
                 Err(_) => return Err(self.bad_type(name, val,
                                 "log level ('normal', 'critical', 'debug')"))
             };
+        } else if name == "disable_emojis" {
+            self.disable_emojis = parse!(self, name, val, as_bool, "an boolean")?;
         } else {
             self.extras.insert(name.into(), val.clone());
         }

--- a/lib/src/config/config.rs
+++ b/lib/src/config/config.rs
@@ -55,7 +55,7 @@ impl Config {
                     session_key: RwLock::new(None),
                     extras: HashMap::new(),
                     env: env,
-                    disable_emojis: true,
+                    disable_emojis: false,
                     filepath: filepath.to_string(),
                 }
             }
@@ -67,7 +67,7 @@ impl Config {
                     session_key: RwLock::new(None),
                     extras: HashMap::new(),
                     env: env,
-                    disable_emojis: true,
+                    disable_emojis: false,
                     filepath: filepath.to_string(),
                 }
             }
@@ -79,7 +79,7 @@ impl Config {
                     session_key: RwLock::new(None),
                     extras: HashMap::new(),
                     env: env,
-                    disable_emojis: true,
+                    disable_emojis: false,
                     filepath: filepath.to_string(),
                 }
             }

--- a/lib/src/rocket.rs
+++ b/lib/src/rocket.rs
@@ -26,6 +26,7 @@ use http::uri::URI;
 pub struct Rocket {
     address: String,
     port: usize,
+    disable_emojis: bool,
     router: Router,
     default_catchers: HashMap<u16, Catcher>,
     catchers: HashMap<u16, Catcher>,
@@ -304,7 +305,11 @@ impl Rocket {
     /// # }
     /// ```
     pub fn custom(config: &Config) -> Rocket {
-        info!("🔧  Configured for {}.", config.env);
+        let mut wrench = "🔧";
+        if config.disable_emojis {
+            wrench = "=>";
+        }
+        info!("{}  Configured for {}.", White.paint(wrench), config.env);
         info_!("listening: {}:{}",
                White.paint(&config.address),
                White.paint(&config.port));
@@ -324,6 +329,7 @@ impl Rocket {
         Rocket {
             address: config.address.clone(),
             port: config.port,
+            disable_emojis: config.disable_emojis,
             router: Router::new(),
             default_catchers: catcher::defaults::get(),
             catchers: catcher::defaults::get(),
@@ -382,7 +388,11 @@ impl Rocket {
     /// # }
     /// ```
     pub fn mount(mut self, base: &str, routes: Vec<Route>) -> Self {
-        info!("🛰  {} '{}':", Magenta.paint("Mounting"), base);
+        let mut satellite = "🛰";
+        if self.disable_emojis {
+            satellite = "=>";
+        }
+        info!("{}  {} '{}':", White.paint(satellite), Magenta.paint("Mounting"), base);
 
         if base.contains('<') {
             error_!("Bad mount point: '{}'.", base);
@@ -431,7 +441,11 @@ impl Rocket {
     /// }
     /// ```
     pub fn catch(mut self, catchers: Vec<Catcher>) -> Self {
-        info!("👾  {}:", Magenta.paint("Catchers"));
+        let mut bug = "👾";
+        if self.disable_emojis {
+            bug = "=>";
+        }
+        info!("{}  {}:", White.paint(bug), Magenta.paint("Catchers"));
         for c in catchers {
             if self.catchers.get(&c.code).map_or(false, |e| !e.is_default()) {
                 let msg = "(warning: duplicate catcher!)";
@@ -475,7 +489,12 @@ impl Rocket {
             }
         };
 
-        info!("🚀  {} {}{}...",
+        let mut rocket = "🚀";
+        if self.disable_emojis {
+            rocket = "=>";
+        }
+        info!("{}  {} {}{}...",
+              White.paint(rocket),
               White.paint("Rocket has launched from"),
               White.bold().paint("http://"),
               White.bold().paint(&full_addr));

--- a/lib/src/rocket.rs
+++ b/lib/src/rocket.rs
@@ -305,10 +305,10 @@ impl Rocket {
     /// # }
     /// ```
     pub fn custom(config: &Config) -> Rocket {
-        let mut wrench = "🔧";
-        if config.disable_emojis {
-            wrench = "=>";
-        }
+        let wrench = match config.disable_emojis {
+            true => "=>",
+            _ => "🔧"
+        };
         info!("{}  Configured for {}.", White.paint(wrench), config.env);
         info_!("listening: {}:{}",
                White.paint(&config.address),
@@ -388,10 +388,10 @@ impl Rocket {
     /// # }
     /// ```
     pub fn mount(mut self, base: &str, routes: Vec<Route>) -> Self {
-        let mut satellite = "🛰";
-        if self.disable_emojis {
-            satellite = "=>";
-        }
+        let satellite = match self.disable_emojis {
+            true => "=>",
+            _ => "🛰"
+        };
         info!("{}  {} '{}':", White.paint(satellite), Magenta.paint("Mounting"), base);
 
         if base.contains('<') {
@@ -441,10 +441,10 @@ impl Rocket {
     /// }
     /// ```
     pub fn catch(mut self, catchers: Vec<Catcher>) -> Self {
-        let mut bug = "👾";
-        if self.disable_emojis {
-            bug = "=>";
-        }
+        let bug = match self.disable_emojis {
+            true => "=>",
+            _ => "👾"
+        };
         info!("{}  {}:", White.paint(bug), Magenta.paint("Catchers"));
         for c in catchers {
             if self.catchers.get(&c.code).map_or(false, |e| !e.is_default()) {
@@ -489,10 +489,10 @@ impl Rocket {
             }
         };
 
-        let mut rocket = "🚀";
-        if self.disable_emojis {
-            rocket = "=>";
-        }
+        let rocket = match self.disable_emojis {
+            true => "=>",
+            _ => "🚀"
+        };
         info!("{}  {} {}{}...",
               White.paint(rocket),
               White.paint("Rocket has launched from"),


### PR DESCRIPTION
I personally don't like the emojis on the console output, so I wrote a patch to make it possible to disable them.

Alternative path I was considering was to add some "replace emojis with blanks" on the logger part, but that would have affected the performance. As there were only couple of places where the emojis were used this seemed like a sensible way of handling this.