### PR TITLE
add a command line parameter to test only files matching a certain string

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ This will build and test the `core`, `codegen`, and `contrib` libraries as well
 as all of the examples. This is the script that gets run by Travis CI. To test a
 crate individually, run `cargo test --all-features`.
 
+You can also test only certain files by passing a parameter to the testing script.
+For example, `.scripts/test.sh hello_world` will run tests only in files that have
+`hello_world` in their full path.
+
 ### Core
 
 Testing for the core library is done inline in the corresponding module. For

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -8,21 +8,27 @@ source $SCRIPT_DIR/config.sh
 # Add Cargo to PATH.
 export PATH=${HOME}/.cargo/bin:${PATH}
 
+# Only build and test files whose path matches $FILTER_PARAM
+FILTER_PARAM=$1
+
 # Builds and tests the Cargo project at $1
 function build_and_test() {
   local dir=$1
-  if [ -z "${dir}" ] || ! [ -d "${dir}" ]; then
-    echo "Tried to build and test inside '${dir}', but it is an invalid path."
-    exit 1
+
+  if [ -z $FILTER_PARAM ] || [[ $dir == *"${FILTER_PARAM}"* ]]; then
+    if [ -z "${dir}" ] || ! [ -d "${dir}" ]; then
+      echo "Tried to build and test inside '${dir}', but it is an invalid path."
+      exit 1
+    fi
+
+    pushd ${dir}
+    echo ":: Building '${PWD}'..."
+    RUST_BACKTRACE=1 cargo build --all-features
+
+    echo ":: Running unit tests in '${PWD}'..."
+    RUST_BACKTRACE=1 cargo test --all-features $FILTER_PARAMS
+    popd
   fi
-
-  pushd ${dir}
-  echo ":: Building '${PWD}'..."
-  RUST_BACKTRACE=1 cargo build --all-features
-
-  echo ":: Running unit tests in '${PWD}'..."
-  RUST_BACKTRACE=1 cargo test --all-features
-  popd
 }
 
 # Checks that the versions for Cargo projects $@ all match

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -26,7 +26,7 @@ function build_and_test() {
     RUST_BACKTRACE=1 cargo build --all-features
 
     echo ":: Running unit tests in '${PWD}'..."
-    RUST_BACKTRACE=1 cargo test --all-features $FILTER_PARAMS
+    RUST_BACKTRACE=1 cargo test --all-features
     popd
   fi
 }
@@ -81,18 +81,20 @@ for file in ${EXAMPLES_DIR}/*; do
   if [ -d "${file}" ]; then
     bootstrap_script="${file}/bootstrap.sh"
     if [ -x "${bootstrap_script}" ]; then
-      echo ":: Bootstrapping ${file}..."
+      if [ -z $FILTER_PARAM ] || [[ $bootstrap_script == *"${FILTER_PARAM}"* ]]; then
+        echo ":: Bootstrapping ${file}..."
 
-      # We're just going to leave this commented out for next time...
-      # if [ "$(basename $file)" = "todo" ]; then
-      #   echo ":: Skipping todo example due to broken Diesel..."
-      #   continue
-      # fi
+        # We're just going to leave this commented out for next time...
+        # if [ "$(basename $file)" = "todo" ]; then
+        #   echo ":: Skipping todo example due to broken Diesel..."
+        #   continue
+        # fi
 
-      if ! ${bootstrap_script}; then
-        echo ":: Running bootstrap script (${bootstrap_script}) failed!"
-        echo ":: Skipping ${file}."
-        continue
+        if ! ${bootstrap_script}; then
+          echo ":: Running bootstrap script (${bootstrap_script}) failed!"
+          echo ":: Skipping ${file}."
+          continue
+        fi
       fi
     fi
 


### PR DESCRIPTION
I grew tired of waiting for all of the tests to finish when I was making my own test, so I added a flag to filter the tests by :)
* `./scripts/test.sh hello_w` will only build/bootstrap/run tests matching with `hello_w` in their full path
* `./scripts/test.sh` is unchanged.
* Right now, I just use the first parameter `$1` for the filter parameter, but I'm happy to make that `-f FILTER_PARAM` instead, if that future proofs this.
* Also, the `$FILTER_PARAM` expression is in two places. Instead, we should put the bootstrapping code inside of `build_and_test` so that we can only check in one spot whether the directory matches `$FILTER_PARAM`