### PR TITLE
Fix security issue with _method to block GET requests.

### DIFF
--- a/lib/src/rocket.rs
+++ b/lib/src/rocket.rs
@@ -148,6 +148,7 @@ impl Rocket {
 
             let mut form_items = FormItems(form);
             if let Some(("_method", value)) = form_items.next() {
+                if req.method() != Method::Post { return; }
                 if let Ok(method) = value.parse() {
                     req.set_method(method);
                 }

--- a/lib/src/rocket.rs
+++ b/lib/src/rocket.rs
@@ -141,14 +141,13 @@ impl Rocket {
         // field which we use to reinterpret the request's method.
         let data_len = data.peek().len();
         let (min_len, max_len) = ("_method=get".len(), "_method=delete".len());
-        if req.content_type().is_form() && data_len >= min_len {
+        if req.method() == Method::Post && req.content_type().is_form() && data_len >= min_len {
             let form = unsafe {
                 from_utf8_unchecked(&data.peek()[..min(data_len, max_len)])
             };
 
             let mut form_items = FormItems(form);
             if let Some(("_method", value)) = form_items.next() {
-                if req.method() != Method::Post { return; }
                 if let Ok(method) = value.parse() {
                     req.set_method(method);
                 }

--- a/lib/tests/form_method-issue-45.rs
+++ b/lib/tests/form_method-issue-45.rs
@@ -24,11 +24,24 @@ use rocket::http::ContentType;
 fn method_eval() {
     let rocket = rocket::ignite().mount("/", routes![bug]);
 
-    let mut req = MockRequest::new(Patch, "/")
+    let mut req = MockRequest::new(Post, "/")
         .header(ContentType::Form)
         .body("_method=patch&form_data=Form+data");
 
     let mut response = req.dispatch_with(&rocket);
     let body_str = response.body().and_then(|b| b.into_string());
     assert_eq!(body_str, Some("OK".to_string()));
+}
+
+#[test]
+fn method_eval_with_Get_should_fail() {
+    let rocket = rocket::ignite().mount("/", routes![bug]);
+
+    let mut req = MockRequest::new(Get, "/")
+        .header(ContentType::Form)
+        .body("_method=patch&form_data=Form+data");
+
+    let mut response = req.dispatch_with(&rocket);
+    let body_str = response.body().and_then(|b| b.into_string());
+    assert_ne!(body_str, Some("OK".to_string()));
 }

--- a/lib/tests/form_method-issue-45.rs
+++ b/lib/tests/form_method-issue-45.rs
@@ -4,6 +4,7 @@
 extern crate rocket;
 
 use rocket::request::Form;
+use rocket::http::Status;
 
 #[derive(FromForm)]
 struct FormData {
@@ -34,7 +35,7 @@ fn method_eval() {
 }
 
 #[test]
-fn method_eval_with_Get_should_fail() {
+fn get_passes_through() {
     let rocket = rocket::ignite().mount("/", routes![bug]);
 
     let mut req = MockRequest::new(Get, "/")
@@ -42,6 +43,5 @@ fn method_eval_with_Get_should_fail() {
         .body("_method=patch&form_data=Form+data");
 
     let mut response = req.dispatch_with(&rocket);
-    let body_str = response.body().and_then(|b| b.into_string());
-    assert_ne!(body_str, Some("OK".to_string()));
+    assert_eq!(response.status(), Status::NotFound);
 }


### PR DESCRIPTION
Security risk:

Currently, it is possible to use _method override to change a GET request into a POST/DELETE/PUT/etc. which is unsafe.
```
curl -H "Content-Type: application/x-www-form-urlencoded" -d "_method=DELETE" localhost:8000
```

Fix:

This PullRequest checks to ensure that only a POST is allowed when using _method override.

(This is also my first Rust PR, so, be gentle if I didn't go the best job :-)
