### PR TITLE
Add tests for the errors example

### DIFF
--- a/examples/errors/Cargo.toml
+++ b/examples/errors/Cargo.toml
@@ -7,3 +7,6 @@ workspace = "../../"
 [dependencies]
 rocket = { path = "../../lib" }
 rocket_codegen = { path = "../../codegen" }
+
+[dev-dependencies]
+rocket = { path = "../../lib", features = ["testing"] }

--- a/examples/errors/src/main.rs
+++ b/examples/errors/src/main.rs
@@ -3,6 +3,9 @@
 
 extern crate rocket;
 
+#[cfg(test)]
+mod tests;
+
 #[get("/hello/<name>/<age>")]
 fn hello(name: &str, age: i8) -> String {
     format!("Hello, {} year old named {}!", age, name)

--- a/examples/errors/src/tests.rs
+++ b/examples/errors/src/tests.rs
@@ -1,0 +1,32 @@
+use super::rocket;
+use rocket::testing::MockRequest;
+use rocket::http::{Method, Status};
+
+fn test(uri: &str, status: Status, body: String) {
+    let rocket = rocket::ignite()
+        .mount("/", routes![super::hello])
+        .catch(errors![super::not_found]);
+    let mut req = MockRequest::new(Method::Get, uri);
+    let mut response = req.dispatch_with(&rocket);
+
+    assert_eq!(response.status(), status);
+    assert_eq!(response.body().and_then(|b| b.into_string()), Some(body));
+}
+
+#[test]
+fn test_hello() {
+    let (name, age) = ("Arthur", 42);
+    let uri = format!("/hello/{}/{}", name, age);
+    test(&uri, Status::Ok, format!("Hello, {} year old named {}!", age, name));
+}
+
+#[test]
+fn test_hello_invalid_age() {
+    for &(name, age) in &[("Ford", -129), ("Trillian", 128)] {
+        let uri = format!("/hello/{}/{}", name, age);
+        let body = format!("<p>Sorry, but '{}' is not a valid path!</p>
+            <p>Try visiting /hello/&lt;name&gt;/&lt;age&gt; instead.</p>",
+                           uri);
+        test(&uri, Status::NotFound, body);
+    }
+}


### PR DESCRIPTION
Relates to #62.

I took notes on the tests that @sethlopezme has written for #81 and copied much of his style and naming for the sake of consistency in tests. If that's not acceptable please let me know.

#### Test output:
```
[22:56:29] tucker@khanti:~/Projects/Rocket/examples/errors git:(errors_example_tests) $ cargo test
    Finished debug [unoptimized + debuginfo] target(s) in 0.0 secs
     Running /home/tucker/Projects/Rocket/target/debug/deps/errors-8588ece63a5bfd6e

running 2 tests
test tests::test_hello ... ok
test tests::test_hello_invalid_age ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured
```

For the record, the testing library is fantastic. Thanks for including it!