### PR TITLE
Fix clippy lints within rocket_codegen

### DIFF
--- a/codegen/src/decorators/error.rs
+++ b/codegen/src/decorators/error.rs
@@ -32,8 +32,8 @@ impl ErrorGenerateExt for ErrorParams {
         // (Imperfectly) inspect the types to figure which params to pass in.
         let args = input_args.iter().map(|arg| &arg.ty).filter_map(|ty| {
             match ty.node {
-                TyKind::Rptr(..) => Some(req.clone()),
-                TyKind::Path(..) => Some(err.clone()),
+                TyKind::Rptr(..) => Some(req),
+                TyKind::Path(..) => Some(err),
                 _ => {
                     ecx.struct_span_err(ty.span, "unexpected error handler argument")
                         .help(arg_help).emit();

--- a/codegen/src/decorators/route.rs
+++ b/codegen/src/decorators/route.rs
@@ -58,7 +58,7 @@ impl RouteGenerateExt for RouteParams {
         if param.is_none() {
             return None;
         } else if arg.is_none() {
-            self.missing_declared_err(ecx, &param.unwrap());
+            self.missing_declared_err(ecx, param.unwrap());
             return None;
         }
 
@@ -80,7 +80,7 @@ impl RouteGenerateExt for RouteParams {
         if param.is_none() {
             return None;
         } else if arg.is_none() {
-            self.missing_declared_err(ecx, &param.unwrap());
+            self.missing_declared_err(ecx, param.unwrap());
             return None;
         }
 
@@ -120,7 +120,7 @@ impl RouteGenerateExt for RouteParams {
         // Generate a statement for every declared paramter in the path.
         let mut declared_set = HashSet::new();
         for (i, param) in self.path_params(ecx).enumerate() {
-            declared_set.insert(param.ident().name.clone());
+            declared_set.insert(param.ident().name);
             let ty = match self.annotated_fn.find_input(&param.ident().name) {
                 Some(arg) => strip_ty_lifetimes(arg.ty.clone()),
                 None => {

--- a/codegen/src/parser/function.rs
+++ b/codegen/src/parser/function.rs
@@ -35,7 +35,7 @@ impl Function {
     }
 
     pub fn find_input<'a>(&'a self, name: &Name) -> Option<&'a Arg> {
-        self.decl().inputs.iter().filter(|arg| arg.named(name)).next()
+        self.decl().inputs.iter().find(|arg| arg.named(name))
     }
 }
 

--- a/codegen/src/parser/param.rs
+++ b/codegen/src/parser/param.rs
@@ -46,7 +46,7 @@ impl<'s, 'a, 'c> Iterator for ParamIter<'s, 'a, 'c> {
     fn next(&mut self) -> Option<Param> {
         let err = |ecx: &ExtCtxt, sp: Span, msg: &str| {
             ecx.span_err(sp,  msg);
-            return None;
+            None
         };
 
         // Find the start and end indexes for the next parameter, if any.
@@ -65,9 +65,10 @@ impl<'s, 'a, 'c> Iterator for ParamIter<'s, 'a, 'c> {
 
         // Calculate the parameter's ident.
         let full_param = &self.string[(start + 1)..end];
-        let (is_many, param) = match full_param.ends_with("..") {
-            true => (true, &full_param[..(full_param.len() - 2)]),
-            false => (false, full_param)
+        let (is_many, param) = if full_param.ends_with("..") {
+            (true, &full_param[..(full_param.len() - 2)])
+        } else {
+            (false, full_param)
         };
 
         let mut param_span = self.span;
@@ -83,7 +84,7 @@ impl<'s, 'a, 'c> Iterator for ParamIter<'s, 'a, 'c> {
             err(self.ctxt, param_span, "parameter names cannot be empty")
         } else if !is_valid_ident(param) {
             err(self.ctxt, param_span, "parameter names must be valid identifiers")
-        } else if param.starts_with("_") {
+        } else if param.starts_with('_') {
             err(self.ctxt, param_span, "parameters cannot be ignored")
         } else if is_many && !self.string.is_empty() {
             let sp = self.span.shorten_to(self.string.len());
@@ -93,9 +94,10 @@ impl<'s, 'a, 'c> Iterator for ParamIter<'s, 'a, 'c> {
             None
         } else {
             let spanned_ident = span(Ident::from_str(param), param_span);
-            match is_many {
-                true => Some(Param::Many(spanned_ident)),
-                false => Some(Param::Single(spanned_ident))
+            if is_many {
+                Some(Param::Many(spanned_ident))
+            } else {
+                Some(Param::Single(spanned_ident))
             }
         }
 

--- a/codegen/src/parser/route.rs
+++ b/codegen/src/parser/route.rs
@@ -75,7 +75,7 @@ impl RouteParams {
         let mut seen_keys = HashSet::new();
         let (mut rank, mut data, mut format) = Default::default();
         for param in &attr_params[1..] {
-            let kv_opt = kv_from_nested(&param);
+            let kv_opt = kv_from_nested(param);
             if kv_opt.is_none() {
                 ecx.span_err(param.span(), "expected key = value");
                 continue;
@@ -183,7 +183,7 @@ fn parse_method(ecx: &ExtCtxt, meta_item: &NestedMetaItem) -> Spanned<Method> {
         .help("valid methods are: GET, PUT, POST, DELETE, PATCH")
         .emit();
 
-    return dummy_spanned(Method::Get);
+    dummy_spanned(Method::Get)
 }
 
 fn parse_path(ecx: &ExtCtxt, meta_item: &NestedMetaItem) -> (Spanned<String>, Option<Spanned<Ident>>) {
@@ -230,9 +230,8 @@ fn parse_data(ecx: &ExtCtxt, kv: &KVSpanned<LitKind>) -> Ident {
     let mut ident = Ident::from_str("unknown");
     if let LitKind::Str(ref s, _) = *kv.value() {
         ident = Ident::from_str(&s.as_str());
-        match param_string_to_ident(ecx, span(&s.as_str(), kv.value.span)) {
-            Some(ident) => return ident,
-            _ => { /* fall through if not an ident */ }
+        if let Some(ident) = param_string_to_ident(ecx, span(&s.as_str(), kv.value.span)) {
+            return ident;
         }
     }
 

--- a/codegen/tests/tests.rs
+++ b/codegen/tests/tests.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 fn run_mode(mode: &'static str) {
     let mut config = compiletest::default_config();
-    let cfg_mode = mode.parse().ok().expect("Invalid mode");
+    let cfg_mode = mode.parse().expect("Invalid mode");
 
     config.mode = cfg_mode;
     config.src_base = PathBuf::from(format!("tests/{}", mode));


### PR DESCRIPTION
Some of these warnings were in code that rocket's macros would produce,
and so would also produce extraneous clippy warnings in crates using rocket's macros.