### PR TITLE
Config port to u16

### DIFF
--- a/lib/src/config/config.rs
+++ b/lib/src/config/config.rs
@@ -120,7 +120,7 @@ impl Config {
             }
 
             if port > (u16::max_value() as i64) {
-                return Err(self.bad_type(name, val, "too large"))
+                return Err(self.bad_type(name, val, "an integer larger than 65535"))
             }
 
             self.port = port as u16;

--- a/lib/src/config/config.rs
+++ b/lib/src/config/config.rs
@@ -99,7 +99,7 @@ impl Config {
     /// returned:
     ///
     ///   * **address**: String
-    ///   * **port**: Integer
+    ///   * **port**: Integer (16-bit unsigned)
     ///   * **session_key**: String (192-bit base64)
     ///   * **log**: String
     ///

--- a/lib/src/config/config.rs
+++ b/lib/src/config/config.rs
@@ -99,7 +99,7 @@ impl Config {
     /// returned:
     ///
     ///   * **address**: String
-    ///   * **port**: Unsigned 16bit Integer
+    ///   * **port**: Integer
     ///   * **session_key**: String (192-bit base64)
     ///   * **log**: String
     ///
@@ -120,7 +120,7 @@ impl Config {
             }
 
             if port > (u16::max_value() as i64) {
-                return Err(self.bad_type(name, val, "an integer larger than 65535"))
+                return Err(self.bad_type(name, val, "a 16-bit unsigned integer"))
             }
 
             self.port = port as u16;

--- a/lib/src/config/config.rs
+++ b/lib/src/config/config.rs
@@ -15,7 +15,7 @@ pub struct Config {
     /// The address to serve on.
     pub address: String,
     /// The port to serve on.
-    pub port: usize,
+    pub port: u16,
     /// How much information to log.
     pub log_level: LoggingLevel,
     /// The environment that this configuration corresponds to.
@@ -119,7 +119,11 @@ impl Config {
                 return Err(self.bad_type(name, val, "an unsigned integer"));
             }
 
-            self.port = port as usize;
+            if port > (u16::max_value() as i64) {
+                return Err(self.bad_type(name, val, "too large"))
+            }
+
+            self.port = port as u16;
         } else if name == "session_key" {
             let key = parse!(self, name, val, as_str, "a string")?;
             if key.len() != 32 {
@@ -231,7 +235,7 @@ impl Config {
 
     /// Sets the `port` in `self` to `var` and returns the structure.
     #[inline(always)]
-    pub fn port(mut self, var: usize) -> Self {
+    pub fn port(mut self, var: u16) -> Self {
         self.port = var;
         self
     }
@@ -284,4 +288,3 @@ impl PartialEq for Config {
             && self.filepath == other.filepath
     }
 }
-

--- a/lib/src/config/config.rs
+++ b/lib/src/config/config.rs
@@ -99,7 +99,7 @@ impl Config {
     /// returned:
     ///
     ///   * **address**: String
-    ///   * **port**: Integer
+    ///   * **port**: Unsigned 16bit Integer
     ///   * **session_key**: String (192-bit base64)
     ///   * **log**: String
     ///

--- a/lib/src/config/mod.rs
+++ b/lib/src/config/mod.rs
@@ -33,7 +33,7 @@
 //!   * **address**: _[string]_ an IP address or host the application will
 //!     listen on
 //!     * examples: `"localhost"`, `"0.0.0.0"`, `"1.2.3.4"`
-//!   * **port**: _[u16]_ a port number to listen on
+//!   * **port**: _[integer]_ a port number to listen on
 //!     * examples: `"8000"`, `"80"`, `"4242"`
 //!   * **log**: _[string]_ how much information to log; one of `"normal"`,
 //!     `"debug"`, or `"critical"`

--- a/lib/src/config/mod.rs
+++ b/lib/src/config/mod.rs
@@ -567,6 +567,13 @@ mod test {
                       "#.to_string(), TEST_CONFIG_FILENAME), {
                           default_config(Staging).port(6000)
                       });
+
+        check_config!(RocketConfig::parse(r#"
+                          [stage]
+                          port = 65535
+                      "#.to_string(), TEST_CONFIG_FILENAME), {
+                          default_config(Staging).port(65535)
+                      });
     }
 
     #[test]
@@ -588,6 +595,11 @@ mod test {
         assert!(RocketConfig::parse(r#"
             [staging]
             port = -1
+        "#.to_string(), TEST_CONFIG_FILENAME).is_err());
+
+        assert!(RocketConfig::parse(r#"
+            [staging]
+            port = 65536
         "#.to_string(), TEST_CONFIG_FILENAME).is_err());
     }
 

--- a/lib/src/config/mod.rs
+++ b/lib/src/config/mod.rs
@@ -33,7 +33,7 @@
 //!   * **address**: _[string]_ an IP address or host the application will
 //!     listen on
 //!     * examples: `"localhost"`, `"0.0.0.0"`, `"1.2.3.4"`
-//!   * **port**: _[integer]_ a port number to listen on
+//!   * **port**: _[u16]_ a port number to listen on
 //!     * examples: `"8000"`, `"80"`, `"4242"`
 //!   * **log**: _[string]_ how much information to log; one of `"normal"`,
 //!     `"debug"`, or `"critical"`

--- a/lib/src/config/mod.rs
+++ b/lib/src/config/mod.rs
@@ -601,6 +601,11 @@ mod test {
             [staging]
             port = 65536
         "#.to_string(), TEST_CONFIG_FILENAME).is_err());
+
+        assert!(RocketConfig::parse(r#"
+            [staging]
+            port = 105836
+        "#.to_string(), TEST_CONFIG_FILENAME).is_err());
     }
 
     #[test]

--- a/lib/src/rocket.rs
+++ b/lib/src/rocket.rs
@@ -25,7 +25,7 @@ use http::uri::URI;
 /// application.
 pub struct Rocket {
     address: String,
-    port: usize,
+    port: u16,
     router: Router,
     default_catchers: HashMap<u16, Catcher>,
     catchers: HashMap<u16, Catcher>,


### PR DESCRIPTION
Converts the Config struct's `port` field to a `u16` from a `usize` to better represent the correct field options to be used.

- Changed initial field type
    - corrected type errors
- updated docs to use "Unsigned 16 bit Integer"
- tests
    - added a test for the edge case bad value
    - added a test for the edge case good value
- generated a good error message `"an integer larger than 65535"`


closes #119