### PR TITLE
Add clippy as an optional dependency

### DIFF
--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -18,6 +18,10 @@ plugin = true
 rocket = { version = "0.1.4", path = "../lib/" }
 log = "^0.3"
 
+[dependencies.clippy]
+version = ">=0.0.106"
+optional = true
+
 [dev-dependencies]
 compiletest_rs = "^0.2"
 

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -95,6 +95,9 @@
 #![feature(i128_type)]
 #![allow(unused_attributes)]
 #![allow(deprecated)]
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
+#![cfg_attr(feature="clippy", allow(needless_lifetimes))]
 
 #[macro_use] extern crate syntax;
 #[macro_use] extern crate log;

--- a/contrib/Cargo.toml
+++ b/contrib/Cargo.toml
@@ -33,3 +33,7 @@ handlebars = { version = "^0.23", optional = true, features = ["serde_type"] }
 glob = { version = "^0.2", optional = true }
 lazy_static = { version = "^0.2", optional = true }
 tera = { version = "^0.6", optional = true }
+
+[dependencies.clippy]
+version = ">=0.0.106"
+optional = true

--- a/contrib/src/lib.rs
+++ b/contrib/src/lib.rs
@@ -29,6 +29,10 @@
 //! This crate is expected to grow with time, bringing in outside crates to be
 //! officially supported by Rocket.
 
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
+#![cfg_attr(feature="clippy", allow(needless_lifetimes))]
+
 #[macro_use] extern crate log;
 #[macro_use] extern crate rocket;
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -20,6 +20,10 @@ url = "^1"
 toml = "^0.2"
 # cookie = "^0.3"
 
+[dependencies.clippy]
+version = ">=0.0.106"
+optional = true
+
 [dependencies.hyper]
 version = "^0.9"
 default-features = false

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -4,6 +4,9 @@
 #![feature(associated_consts)]
 #![feature(const_fn)]
 #![feature(type_ascription)]
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
+#![cfg_attr(feature="clippy", allow(needless_lifetimes))]
 
 //! # Rocket - Core API Documentation
 //!


### PR DESCRIPTION
This is a PR to add clippy as an optional dependency which can be enabled via `cargo build --features clippy`. The reason for this PR is that adding clippy as a dependency appears to scan through more of the code than `cargo clippy` (which may be a bug in `cargo clippy`).

This PR does not fix any lints, just adds clippy as a dependency to all three crates within Rocket.