### PR TITLE
Prevent bypassing safe guard in pathbuf segments

### DIFF
--- a/lib/src/request/param.rs
+++ b/lib/src/request/param.rs
@@ -290,11 +290,13 @@ impl<'a> FromSegments<'a> for PathBuf {
     fn from_segments(segments: Segments<'a>) -> Result<PathBuf, Utf8Error> {
         let mut buf = PathBuf::new();
         for segment in segments {
-            let decoded = URI::percent_decode(segment.as_bytes())?;
-            if decoded == ".." {
-                buf.pop();
-            } else if !(decoded.starts_with('.') || decoded.starts_with('*')) {
-                buf.push(&*decoded)
+            let decoded_seg = URI::percent_decode(segment.as_bytes())?;
+            for decoded in Segments(&decoded_seg) {
+                if decoded == ".." {
+                    buf.pop();
+                } else if !(decoded.starts_with('.') || decoded.starts_with('*')) {
+                    buf.push(&*decoded)
+                }
             }
         }
 

--- a/lib/tests/secure-pathbuf-param.rs
+++ b/lib/tests/secure-pathbuf-param.rs
@@ -1,0 +1,29 @@
+#![feature(plugin)]
+#![plugin(rocket_codegen)]
+
+extern crate rocket;
+
+use std::path::PathBuf;
+
+#[get("/<path..>")]
+fn none(path: PathBuf) -> String {
+    path.to_string_lossy().into()
+}
+
+#[cfg(feature = "testing")]
+mod tests {
+    use super::*;
+    use rocket::testing::MockRequest;
+    use rocket::http::Method::*;
+
+    #[test]
+    fn secure_segments() {
+        let rocket = rocket::ignite()
+            .mount("/", routes![none]);
+
+        let mut req = MockRequest::new(Get, "hello%2f..%2f..%2f..%2fetc%2fpasswd");
+        let mut response = req.dispatch_with(&rocket);
+        let body_str = response.body().and_then(|b| b.into_string());
+        assert_eq!(body_str, Some("etc/passwd".into()));
+    }
+}


### PR DESCRIPTION
## Problem
In the example [static_file](https://github.com/SergioBenitez/Rocket/tree/master/examples/static_files), there exist a [LFI](https://www.owasp.org/index.php/Testing_for_Local_File_Inclusion) vulnerability. An attacker can read any file from the server.

For example,
```
$ curl 'http://localhost:8000/hidden%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2fetc%2fpasswd'
```
Invoking the `curl` command may show you the content of `/etc/passwd` that must not be disclosed.

It seems that Rocket is already filtering `..` for PathBuf in [params.rs](https://github.com/SergioBenitez/Rocket/blob/41aecc3e7ff1a14f4519bb22b71a82f4ec2ef286/lib/src/request/param.rs#L293). But, URI decode is invoked after segmenting, so the filtering can be bypassed.

## Fix

I fixed it by creating another segments for each URI decoded segment. Since I'm new to Rust and Rocket, I'm not sure if it is the best solution or not. I think we can call URI decode before segmenting, but it concerns me to make a big change.

Feel free to give me any feedback. 