### PR TITLE
Let toml use serde instead of rustc_serialize

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -18,7 +18,7 @@ build = "build.rs"
 term-painter = "^0.2"
 log = "^0.3"
 url = "^1"
-toml = { version = "^0.2", features = ["serde"], default-features = false }
+toml = { version = "^0.2", default-features = false }
 num_cpus = "1"
 # cookie = "^0.3"
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -18,7 +18,7 @@ build = "build.rs"
 term-painter = "^0.2"
 log = "^0.3"
 url = "^1"
-toml = "^0.2"
+toml = { version = "^0.2", features = ["serde"], default-features = false }
 num_cpus = "1"
 # cookie = "^0.3"
 


### PR DESCRIPTION
I was trying to compile a project of mine that was using both `serde` and `toml-rs` (with the `serde` flag enabled) but I occurred in this compilation error:

```
error[E0277]: the trait bound `config::Config: rustc_serialize::serialize::Decodable` is not satisfied
   --> src/config.rs:167:9
    |
167 |         toml::decode(config).unwrap()
    |         ^^^^^^^^^^^^ the trait `rustc_serialize::serialize::Decodable` is not implemented for `config::Config`
    |
    = note: required by `toml::decode`
```

I solved it by making this patch which removed the inconsistency in my code base forcing it to use only serde, that is the de-facto (de)serialization crate in Rust.

If you think that having `rustc_serialize` is important, we can add a flag for serde similar to the one that toml-rs has.