### PR TITLE
[WIP] Replace log with slog

### DIFF
--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -16,7 +16,6 @@ plugin = true
 
 [dependencies]
 rocket = { version = "0.2.0", path = "../lib/" }
-log = "^0.3"
 
 [dev-dependencies]
 compiletest_rs = "^0.2"

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -121,7 +121,7 @@ extern crate syntax;
 extern crate syntax_ext;
 extern crate syntax_pos;
 extern crate rustc_plugin;
-extern crate rocket;
+#[macro_use] extern crate rocket;
 
 #[macro_use] mod utils;
 mod parser;

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -175,7 +175,7 @@ macro_rules! register_lints {
 pub fn plugin_registrar(reg: &mut Registry) {
     // Enable logging early if the DEBUG_ENV_VAR is set.
     if env::var(DEBUG_ENV_VAR).is_ok() {
-        ::rocket::logger::init(::rocket::LoggingLevel::Debug);
+        ::rocket::logger::init(&::rocket::logger::default_for(::rocket::LoggingLevel::Debug));
     }
 
     reg.register_macro("routes", macros::routes);

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -116,7 +116,6 @@
 #![allow(unused_attributes)]
 #![allow(deprecated)]
 
-#[macro_use] extern crate log;
 #[macro_use] extern crate rustc;
 extern crate syntax;
 extern crate syntax_ext;

--- a/contrib/Cargo.toml
+++ b/contrib/Cargo.toml
@@ -22,7 +22,6 @@ lazy_static_macro = ["lazy_static"]
 
 [dependencies]
 rocket = { version = "0.2.0", path = "../lib/" }
-log = "^0.3"
 
 # UUID dependencies.
 uuid = { version = "^0.4", optional = true }

--- a/contrib/src/json/mod.rs
+++ b/contrib/src/json/mod.rs
@@ -79,7 +79,7 @@ impl<T: Deserialize> FromData for JSON<T> {
 
     fn from_data(request: &Request, data: Data) -> data::Outcome<Self, SerdeError> {
         if !request.content_type().is_json() {
-            error_!("Content-Type is not JSON.");
+            error!("Content-Type is not JSON.");
             return Outcome::Forward(data);
         }
 
@@ -87,7 +87,7 @@ impl<T: Deserialize> FromData for JSON<T> {
         match serde_json::from_reader(reader).map(|val| JSON(val)) {
             Ok(value) => Outcome::Success(value),
             Err(e) => {
-                error_!("Couldn't parse JSON body: {:?}", e);
+                error!("Couldn't parse JSON body: {:?}", e);
                 Outcome::Failure((Status::BadRequest, e))
             }
         }
@@ -102,7 +102,7 @@ impl<T: Serialize> Responder<'static> for JSON<T> {
         serde_json::to_string(&self.0).map(|string| {
             content::JSON(string).respond().unwrap()
         }).map_err(|e| {
-            error_!("JSON failed to serialize: {:?}", e);
+            error!("JSON failed to serialize: {:?}", e);
             Status::InternalServerError
         })
     }

--- a/contrib/src/lib.rs
+++ b/contrib/src/lib.rs
@@ -33,7 +33,6 @@
 //! This crate is expected to grow with time, bringing in outside crates to be
 //! officially supported by Rocket.
 
-#[macro_use] extern crate log;
 #[macro_use] extern crate rocket;
 
 #[cfg_attr(feature = "lazy_static_macro", macro_use)]

--- a/contrib/src/templates/handlebars_templates.rs
+++ b/contrib/src/templates/handlebars_templates.rs
@@ -13,7 +13,7 @@ pub const EXT: &'static str = "hbs";
 // hold here and in `render`.
 pub unsafe fn register(templates: &[(&str, &TemplateInfo)]) -> bool {
     if HANDLEBARS.is_some() {
-        error_!("Internal error: reregistering handlebars!");
+        error!("Internal error: reregistering handlebars!");
         return false;
     }
 
@@ -22,7 +22,7 @@ pub unsafe fn register(templates: &[(&str, &TemplateInfo)]) -> bool {
     for &(name, info) in templates {
         let path = &info.full_path;
         if let Err(e) = hb.register_template_file(name, path) {
-            error_!("Handlebars template '{}' failed registry: {:?}", name, e);
+            error!("Handlebars template '{}' failed registry: {:?}", name, e);
             success = false;
         }
     }
@@ -37,20 +37,20 @@ pub fn render<T>(name: &str, _info: &TemplateInfo, context: &T) -> Option<String
     let hb = match unsafe { HANDLEBARS.as_ref() } {
         Some(hb) => hb,
         None => {
-            error_!("Internal error: `render` called before handlebars init.");
+            error!("Internal error: `render` called before handlebars init.");
             return None;
         }
     };
 
     if hb.get_template(name).is_none() {
-        error_!("Handlebars template '{}' does not exist.", name);
+        error!("Handlebars template '{}' does not exist.", name);
         return None;
     }
 
     match hb.render(name, context) {
         Ok(string) => Some(string),
         Err(e) => {
-            error_!("Error rendering Handlebars template '{}': {}", name, e);
+            error!("Error rendering Handlebars template '{}': {}", name, e);
             None
         }
     }

--- a/contrib/src/templates/mod.rs
+++ b/contrib/src/templates/mod.rs
@@ -108,8 +108,8 @@ lazy_static! {
         let default_dir_path = config::active().ok_or(ConfigError::NotFound)
             .map(|config| config.root().join(DEFAULT_TEMPLATE_DIR))
             .map_err(|_| {
-                warn_!("No configuration is active!");
-                warn_!("Using default template directory: {:?}", DEFAULT_TEMPLATE_DIR);
+                warn!("No configuration is active!");
+                warn!("Using default template directory: {:?}", DEFAULT_TEMPLATE_DIR);
             })
             .unwrap_or(PathBuf::from(DEFAULT_TEMPLATE_DIR));
 
@@ -119,7 +119,7 @@ lazy_static! {
             .map_err(|e| {
                 if !e.is_not_found() {
                     e.pretty_print();
-                    warn_!("Using default directory '{:?}'", default_dir_path);
+                    warn!("Using default directory '{:?}'", default_dir_path);
                 }
             })
             .unwrap_or(default_dir_path)
@@ -150,9 +150,9 @@ impl Template {
         let template = TEMPLATES.get(name);
         if template.is_none() {
             let names: Vec<_> = TEMPLATES.keys().map(|s| s.as_str()).collect();
-            error_!("Template '{}' does not exist.", name);
-            info_!("Known templates: {}", names.join(","));
-            info_!("Searched in '{:?}'.", *TEMPLATE_DIR);
+            error!("Template '{}' does not exist.", name);
+            info!("Known templates: {}", names.join(","));
+            info!("Searched in '{:?}'.", *TEMPLATE_DIR);
             return Template(None, None);
         }
 
@@ -245,10 +245,10 @@ fn discover_templates() -> HashMap<String, TemplateInfo> {
         for path in glob(glob_path.to_str().unwrap()).unwrap().filter_map(Result::ok) {
             let (rel_path, name, data_type) = split_path(&path);
             if let Some(info) = templates.get(&*name) {
-                warn_!("Template name '{}' does not have a unique path.", name);
-                info_!("Existing path: {:?}", info.full_path);
-                info_!("Additional path: {:?}", path);
-                warn_!("Using existing path for template '{}'.", name);
+                warn!("Template name '{}' does not have a unique path.", name);
+                info!("Existing path: {:?}", info.full_path);
+                info!("Additional path: {:?}", path);
+                warn!("Using existing path for template '{}'.", name);
                 continue;
             }
 

--- a/contrib/src/templates/tera_templates.rs
+++ b/contrib/src/templates/tera_templates.rs
@@ -13,7 +13,7 @@ pub const EXT: &'static str = "tera";
 // hold here and in `render`.
 pub unsafe fn register(templates: &[(&str, &TemplateInfo)]) -> bool {
     if TERA.is_some() {
-        error_!("Internal error: reregistering Tera!");
+        error!("Internal error: reregistering Tera!");
         return false;
     }
 
@@ -29,7 +29,7 @@ pub unsafe fn register(templates: &[(&str, &TemplateInfo)]) -> bool {
     // Finally try to tell Tera about all of the templates.
     let mut success = true;
     if let Err(e) = tera.add_template_files(tera_templates) {
-        error_!("Failed to initialize Tera templates: {:?}", e);
+        error!("Failed to initialize Tera templates: {:?}", e);
         success = false;
     }
 
@@ -43,20 +43,20 @@ pub fn render<T>(name: &str, _: &TemplateInfo, context: &T) -> Option<String>
     let tera = match unsafe { TERA.as_ref() } {
         Some(tera) => tera,
         None => {
-            error_!("Internal error: `render` called before Tera init.");
+            error!("Internal error: `render` called before Tera init.");
             return None;
         }
     };
 
     if tera.get_template(name).is_err() {
-        error_!("Tera template '{}' does not exist.", name);
+        error!("Tera template '{}' does not exist.", name);
         return None;
     };
 
     match tera.value_render(name, context) {
         Ok(string) => Some(string),
         Err(e) => {
-            error_!("Error rendering Tera template '{}': {}", name, e);
+            error!("Error rendering Tera template '{}': {}", name, e);
             None
         }
     }

--- a/contrib/tests/templates.rs
+++ b/contrib/tests/templates.rs
@@ -10,7 +10,7 @@ fn init() {
     let tests_dir = cwd.join("tests");
 
     let config = Config::build(Development).root(tests_dir).unwrap();
-    rocket::custom(config, true);
+    rocket::custom(config);
 }
 
 // FIXME: Do something about overlapping configs.

--- a/examples/config/tests/common/mod.rs
+++ b/examples/config/tests/common/mod.rs
@@ -19,7 +19,6 @@ pub fn test_config(environment: Environment) {
             assert_eq!(config.address, "localhost".to_string());
             assert_eq!(config.port, 8000);
             assert_eq!(config.workers, 1);
-            assert_eq!(config.log_level, LoggingLevel::Normal);
             assert_eq!(config.environment, config::Environment::Development);
             assert_eq!(config.extras().count(), 2);
             assert_eq!(config.get_str("hi"), Ok("Hello!"));
@@ -29,7 +28,6 @@ pub fn test_config(environment: Environment) {
             assert_eq!(config.address, "0.0.0.0".to_string());
             assert_eq!(config.port, 80);
             assert_eq!(config.workers, 8);
-            assert_eq!(config.log_level, LoggingLevel::Normal);
             assert_eq!(config.environment, config::Environment::Staging);
             assert_eq!(config.extras().count(), 0);
         }
@@ -37,7 +35,6 @@ pub fn test_config(environment: Environment) {
             assert_eq!(config.address, "0.0.0.0".to_string());
             assert_eq!(config.port, 80);
             assert_eq!(config.workers, 12);
-            assert_eq!(config.log_level, LoggingLevel::Critical);
             assert_eq!(config.environment, config::Environment::Production);
             assert_eq!(config.extras().count(), 0);
         }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -16,13 +16,15 @@ build = "build.rs"
 
 [dependencies]
 term-painter = "^0.2"
-log = "^0.3"
 url = "^1"
 hyper = { version = "0.10", default-features = false }
 toml = { version = "^0.2", default-features = false }
 num_cpus = "1"
 state = "^0.2"
 time = "^0.1"
+slog = "1.2"
+slog-term = "1.4.0"
+slog-scope = "0.2.2"
 
 [dependencies.cookie]
 version = "^0.6"

--- a/lib/src/config/builder.rs
+++ b/lib/src/config/builder.rs
@@ -17,7 +17,7 @@ pub struct ConfigBuilder {
     /// The number of workers to run in parallel.
     pub workers: u16,
     /// Logger to use to log information.
-    pub log: Logger,
+    pub log: Option<Logger>,
     /// The session key.
     pub session_key: Option<String>,
     /// Any extra parameters that aren't part of Rocket's config.
@@ -141,8 +141,8 @@ impl ConfigBuilder {
     ///     .unwrap();
     /// ```
     #[inline]
-    pub fn log(mut self, log: Logger) -> Self {
-        self.log = log;
+    pub fn log<T>(mut self, log: T) -> Self where T: Into<Option<Logger>> {
+        self.log = log.into();
         self
     }
 
@@ -260,9 +260,9 @@ impl ConfigBuilder {
         config.set_address(self.address)?;
         config.set_port(self.port);
         config.set_workers(self.workers);
-        config.set_log(self.log);
         config.set_extras(self.extras);
         config.set_root(self.root);
+        config.set_log(self.log);
 
         if let Some(key) = self.session_key {
             config.set_session_key(key)?;

--- a/lib/src/config/config.rs
+++ b/lib/src/config/config.rs
@@ -38,7 +38,7 @@ pub struct Config {
     /// The number of workers to run concurrently.
     pub workers: u16,
     /// Logger to use to log information.
-    pub log: Logger,
+    pub log: Option<Logger>,
     /// Extra parameters that aren't part of Rocket's core config.
     pub extras: HashMap<String, Value>,
     /// The path to the configuration file this config belongs to.
@@ -133,7 +133,7 @@ impl Config {
                     address: "localhost".to_string(),
                     port: 8000,
                     workers: default_workers,
-                    log: logger::default_for(LoggingLevel::Normal),
+                    log: Some(logger::default_for(LoggingLevel::Normal)),
                     session_key: RwLock::new(None),
                     extras: HashMap::new(),
                     config_path: config_path,
@@ -145,7 +145,7 @@ impl Config {
                     address: "0.0.0.0".to_string(),
                     port: 80,
                     workers: default_workers,
-                    log: logger::default_for(LoggingLevel::Normal),
+                    log: Some(logger::default_for(LoggingLevel::Normal)),
                     session_key: RwLock::new(None),
                     extras: HashMap::new(),
                     config_path: config_path,
@@ -157,7 +157,7 @@ impl Config {
                     address: "0.0.0.0".to_string(),
                     port: 80,
                     workers: default_workers,
-                    log: logger::default_for(LoggingLevel::Critical),
+                    log: Some(logger::default_for(LoggingLevel::Critical)),
                     session_key: RwLock::new(None),
                     extras: HashMap::new(),
                     config_path: config_path,
@@ -373,8 +373,8 @@ impl Config {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn set_log(&mut self, log: Logger) {
-        self.log = log;
+    pub fn set_log<T>(&mut self, log: T) where T: Into<Option<Logger>> {
+        self.log = log.into();
     }
 
     /// Sets the extras for `self` to be the key/value pairs in `extras`.

--- a/lib/src/config/error.rs
+++ b/lib/src/config/error.rs
@@ -65,22 +65,22 @@ impl ConfigError {
             IOError => error!("failed reading the config file: IO error"),
             BadFilePath(ref path, reason) => {
                 error!("configuration file path '{:?}' is invalid", path);
-                info_!("{}", reason);
+                info!("{}", reason);
             }
             BadEntry(ref name, ref filename) => {
                 let valid_entries = format!("{}, and global", valid_envs);
                 error!("[{}] is not a known configuration environment", name);
-                info_!("in {:?}", White.paint(filename));
-                info_!("valid environments are: {}", White.paint(valid_entries));
+                info!("in {:?}", White.paint(filename));
+                info!("valid environments are: {}", White.paint(valid_entries));
             }
             BadEnv(ref name) => {
                 error!("'{}' is not a valid ROCKET_ENV value", name);
-                info_!("valid environments are: {}", White.paint(valid_envs));
+                info!("valid environments are: {}", White.paint(valid_envs));
             }
             BadType(ref name, expected, actual, ref filename) => {
                 error!("'{}' key could not be parsed", name);
-                info_!("in {:?}", White.paint(filename));
-                info_!("expected value to be {}, but found {}",
+                info!("in {:?}", White.paint(filename));
+                info!("expected value to be {}, but found {}",
                        White.paint(expected), White.paint(actual));
             }
             ParseError(ref source, ref filename, ref errors) => {
@@ -90,14 +90,14 @@ impl ConfigError {
                     let error_source = &source[lo..hi];
 
                     error!("config file could not be parsed as TOML");
-                    info_!("at {:?}:{}:{}", White.paint(filename), line + 1, col + 1);
-                    trace_!("'{}' - {}", error_source, White.paint(&error.desc));
+                    info!("at {:?}:{}:{}", White.paint(filename), line + 1, col + 1);
+                    trace!("'{}' - {}", error_source, White.paint(&error.desc));
                 }
             }
             BadEnvVal(ref key, ref value, ref expected) => {
                 error!("environment variable '{}={}' could not be parsed",
                        White.paint(key), White.paint(value));
-                info_!("value for {:?} must be {}",
+                info!("value for {:?} must be {}",
                        White.paint(key), White.paint(expected))
             }
         }

--- a/lib/src/config/mod.rs
+++ b/lib/src/config/mod.rs
@@ -957,13 +957,12 @@ mod test {
         let _env_lock = ENV_LOCK.lock().unwrap();
 
         let pairs = [
-            ("log", "critical"), ("LOG", "debug"), ("PORT", "8110"),
+            ("PORT", "8110"),
             ("address", "1.2.3.4"), ("EXTRA_EXTRA", "true"), ("workers", "3")
         ];
 
         let check_value = |key: &str, val: &str, config: &Config| {
             match key {
-                "log" => assert_eq!(config.log_level, val.parse().unwrap()),
                 "port" => assert_eq!(config.port, val.parse().unwrap()),
                 "address" => assert_eq!(config.address, val),
                 "extra_extra" => assert_eq!(config.get_bool(key).unwrap(), true),

--- a/lib/src/config/mod.rs
+++ b/lib/src/config/mod.rs
@@ -447,7 +447,7 @@ pub(crate) fn custom_init(config: Config) -> (&'static Config, bool) {
 
 unsafe fn private_init() {
     let bail = |e: ConfigError| -> ! {
-        logger::init(LoggingLevel::Debug);
+        logger::init(&logger::default_for(LoggingLevel::Debug));
         e.pretty_print();
         process::exit(1)
     };

--- a/lib/src/config/mod.rs
+++ b/lib/src/config/mod.rs
@@ -492,7 +492,7 @@ mod test {
     use super::Environment::*;
     use super::Result;
 
-    use ::logger::LoggingLevel;
+    use ::logger::{self, LoggingLevel};
 
     const TEST_CONFIG_FILENAME: &'static str = "/tmp/testing/Rocket.toml";
 
@@ -597,7 +597,7 @@ mod test {
             .address("1.2.3.4")
             .port(7810)
             .workers(21)
-            .log_level(LoggingLevel::Critical)
+            .log(logger::default_for(LoggingLevel::Critical))
             .session_key("01234567890123456789012345678901")
             .extra("template_dir", "mine")
             .extra("json", true)
@@ -798,35 +798,6 @@ mod test {
             [staging]
             workers = 105836
         "#.to_string(), TEST_CONFIG_FILENAME).is_err());
-    }
-
-    #[test]
-    fn test_good_log_levels() {
-        // Take the lock so changing the environment doesn't cause races.
-        let _env_lock = ENV_LOCK.lock().unwrap();
-        env::set_var(CONFIG_ENV, "stage");
-
-        check_config!(RocketConfig::parse(r#"
-                          [stage]
-                          log = "normal"
-                      "#.to_string(), TEST_CONFIG_FILENAME), {
-                          default_config(Staging).log_level(LoggingLevel::Normal)
-                      });
-
-
-        check_config!(RocketConfig::parse(r#"
-                          [stage]
-                          log = "debug"
-                      "#.to_string(), TEST_CONFIG_FILENAME), {
-                          default_config(Staging).log_level(LoggingLevel::Debug)
-                      });
-
-        check_config!(RocketConfig::parse(r#"
-                          [stage]
-                          log = "critical"
-                      "#.to_string(), TEST_CONFIG_FILENAME), {
-                          default_config(Staging).log_level(LoggingLevel::Critical)
-                      });
     }
 
     #[test]

--- a/lib/src/data/data.rs
+++ b/lib/src/data/data.rs
@@ -160,7 +160,7 @@ impl Data {
         // Make sure the buffer is large enough for the bytes we want to peek.
         const PEEK_BYTES: usize = 4096;
         if buf.len() < PEEK_BYTES {
-            trace_!("Resizing peek buffer from {} to {}.", buf.len(), PEEK_BYTES);
+            trace!("Resizing peek buffer from {} to {}.", buf.len(), PEEK_BYTES);
             buf.resize(PEEK_BYTES, 0);
         }
 
@@ -170,17 +170,17 @@ impl Data {
         trace!("Init buffer cap: {}", cap);
         let eof = match stream.read_max(&mut buf[cap..]) {
             Ok(n) => {
-                trace_!("Filled peek buf with {} bytes.", n);
+                trace!("Filled peek buf with {} bytes.", n);
                 cap += n;
                 cap < buf.len()
             }
             Err(e) => {
-                error_!("Failed to read into peek buffer: {:?}.", e);
+                error!("Failed to read into peek buffer: {:?}.", e);
                 false
             },
         };
 
-        trace_!("Peek buffer size: {}, remaining: {}", buf.len(), buf.len() - cap);
+        trace!("Peek buffer size: {}, remaining: {}", buf.len(), buf.len() - cap);
         Data {
             buffer: buf,
             stream: stream,

--- a/lib/src/data/data_stream.rs
+++ b/lib/src/data/data_stream.rs
@@ -48,9 +48,9 @@ pub fn kill_stream<S: Read, N: NetworkStream>(stream: &mut S, network: &mut N) {
     let mut buf = [0];
     if let Ok(n) = stream.read(&mut buf) {
         if n > 0 {
-            warn_!("Data left unread. Force closing network stream.");
+            warn!("Data left unread. Force closing network stream.");
             if let Err(e) = network.close(Shutdown::Both) {
-                error_!("Failed to close network stream: {:?}", e);
+                error!("Failed to close network stream: {:?}", e);
             }
         }
     }

--- a/lib/src/http/uri.rs
+++ b/lib/src/http/uri.rs
@@ -394,11 +394,11 @@ mod tests {
     fn seg_count(path: &str, expected: usize) -> bool {
         let actual = URI::new(path).segment_count();
         if actual != expected {
-            trace_!("Count mismatch: expected {}, got {}.", expected, actual);
-            trace_!("{}", if actual != expected { "lifetime" } else { "buf" });
-            trace_!("Segments (for {}):", path);
+            trace!("Count mismatch: expected {}, got {}.", expected, actual);
+            trace!("{}", if actual != expected { "lifetime" } else { "buf" });
+            trace!("Segments (for {}):", path);
             for (i, segment) in URI::new(path).segments().enumerate() {
-                trace_!("{}: {}", i, segment);
+                trace!("{}: {}", i, segment);
             }
         }
 

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -101,8 +101,8 @@ extern crate slog;
 
 extern crate slog_term;
 
-#[macro_reexport(trace, info, warn, debug, crit, error)]
 #[macro_use]
+#[macro_reexport(trace, info, warn, debug, crit, error)]
 extern crate slog_scope;
 
 extern crate term_painter;

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -159,6 +159,6 @@ pub fn ignite() -> Rocket {
 
 /// Alias to [Rocket::custom()](/rocket/struct.Rocket.html#method.custom).
 /// Creates a new instance of `Rocket` with a custom configuration.
-pub fn custom(config: config::Config, log: bool) -> Rocket {
-    Rocket::custom(config, log)
+pub fn custom(config: config::Config) -> Rocket {
+    Rocket::custom(config)
 }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -94,10 +94,6 @@
 //! the [testing module](/rocket/testing) documentation.
 //!
 
-// #[macro_use] extern crate log;
-
-
-// TODO: Should we re-export logger macros?
 #[allow(unused_imports)]
 #[macro_use(o, slog_o, slog_log, slog_trace, slog_info, slog_warn, slog_debug, slog_crit, slog_error)]
 #[macro_reexport(slog_o, slog_log, slog_trace, slog_info, slog_warn, slog_debug, slog_crit, slog_error)]
@@ -105,7 +101,6 @@ extern crate slog;
 
 extern crate slog_term;
 
-// TODO: Should we re-export logger macros?
 #[macro_reexport(trace, info, warn, debug, crit, error)]
 #[macro_use]
 extern crate slog_scope;

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -4,6 +4,7 @@
 #![feature(associated_consts)]
 #![feature(const_fn)]
 #![feature(type_ascription)]
+#![feature(macro_reexport)]
 
 //! # Rocket - Core API Documentation
 //!
@@ -90,7 +91,21 @@
 //! [testing module](testing) documentation.
 //!
 
-#[macro_use] extern crate log;
+// #[macro_use] extern crate log;
+
+
+// TODO: Should we re-export logger macros?
+#[macro_use(slog_o, slog_log, slog_trace, slog_info, slog_warn, slog_debug, slog_crit, slog_error)]
+#[macro_reexport(slog_o, slog_log, slog_trace, slog_info, slog_warn, slog_debug, slog_crit, slog_error)]
+extern crate slog;
+
+extern crate slog_term;
+
+// TODO: Should we re-export logger macros?
+#[macro_reexport(trace, info, warn, debug, crit, error)]
+#[macro_use]
+extern crate slog_scope;
+
 extern crate term_painter;
 extern crate hyper;
 extern crate url;

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -98,7 +98,8 @@
 
 
 // TODO: Should we re-export logger macros?
-#[macro_use(slog_o, slog_log, slog_trace, slog_info, slog_warn, slog_debug, slog_crit, slog_error)]
+#[allow(unused_imports)]
+#[macro_use(o, slog_o, slog_log, slog_trace, slog_info, slog_warn, slog_debug, slog_crit, slog_error)]
 #[macro_reexport(slog_o, slog_log, slog_trace, slog_info, slog_warn, slog_debug, slog_crit, slog_error)]
 extern crate slog;
 

--- a/lib/src/logger.rs
+++ b/lib/src/logger.rs
@@ -7,6 +7,15 @@ use slog_term;
 use slog::{self, DrainExt};
 use slog_scope;
 
+pub use slog::Logger;
+
+pub fn default_for(level: LoggingLevel) -> slog::Logger {
+    let drain = slog_term::streamer().stderr().compact().build();
+    let drain = slog::LevelFilter::new(drain, level.max_log_level()).fuse();
+
+    slog::Logger::root(drain, slog_o!())
+}
+
 /// Defines the different levels for log messages.
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]
 pub enum LoggingLevel {
@@ -56,11 +65,6 @@ impl fmt::Display for LoggingLevel {
 }
 
 #[doc(hidden)]
-pub fn init(level: LoggingLevel) {
-    // TODO: Configure drain in a far more complex fashion
-    let drain = slog_term::streamer().stderr().compact().build();
-    let drain = slog::LevelFilter::new(drain, level.max_log_level()).fuse();
-
-    // Set _global_ scope of log/info/etc. macros
-    slog_scope::set_global_logger(slog::Logger::root(drain, slog_o!()));
+pub fn init(log: &Logger) {
+    slog_scope::set_global_logger(log.clone());
 }

--- a/lib/src/logger.rs
+++ b/lib/src/logger.rs
@@ -3,15 +3,9 @@
 use std::str::FromStr;
 use std::fmt;
 
-// use log::{self, Log, LogLevel, LogRecord, LogMetadata};
 use slog_term;
 use slog::{self, DrainExt};
 use slog_scope;
-
-use term_painter::Color::*;
-use term_painter::ToStyle;
-
-struct RocketLogger(LoggingLevel);
 
 /// Defines the different levels for log messages.
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]
@@ -25,14 +19,14 @@ pub enum LoggingLevel {
 }
 
 impl LoggingLevel {
-    // #[inline(always)]
-    // fn max_log_level(&self) -> LogLevel {
-    //     match *self {
-    //         LoggingLevel::Critical => LogLevel::Warn,
-    //         LoggingLevel::Normal => LogLevel::Info,
-    //         LoggingLevel::Debug => LogLevel::Trace,
-    //     }
-    // }
+    #[inline(always)]
+    fn max_log_level(&self) -> slog::Level {
+        match *self {
+            LoggingLevel::Critical => slog::Level::Warning,
+            LoggingLevel::Normal => slog::Level::Info,
+            LoggingLevel::Debug => slog::Level::Trace,
+        }
+    }
 }
 
 impl FromStr for LoggingLevel {
@@ -64,9 +58,9 @@ impl fmt::Display for LoggingLevel {
 #[doc(hidden)]
 pub fn init(level: LoggingLevel) {
     // TODO: Configure drain in a far more complex fashion
-    let drain = slog_term::streamer().stderr().full().build().fuse();
-    let root_log = slog::Logger::root(drain, slog_o!());
+    let drain = slog_term::streamer().stderr().compact().build();
+    let drain = slog::LevelFilter::new(drain, level.max_log_level()).fuse();
 
     // Set _global_ scope of log/info/etc. macros
-    slog_scope::set_global_logger(root_log);
+    slog_scope::set_global_logger(slog::Logger::root(drain, slog_o!()));
 }

--- a/lib/src/request/form/mod.rs
+++ b/lib/src/request/form/mod.rs
@@ -235,20 +235,20 @@ impl<'f, T: FromForm<'f>> FromData for Form<'f, T> where T::Error: Debug {
 
     fn from_data(request: &Request, data: Data) -> data::Outcome<Self, Self::Error> {
         if !request.content_type().is_form() {
-            warn_!("Form data does not have form content type.");
+            warn!("Form data does not have form content type.");
             return Forward(data);
         }
 
         let mut form_string = String::with_capacity(4096);
         let mut stream = data.open().take(32768);
         if let Err(e) = stream.read_to_string(&mut form_string) {
-            error_!("IO Error: {:?}", e);
+            error!("IO Error: {:?}", e);
             Failure((Status::InternalServerError, None))
         } else {
             match Form::new(form_string) {
                 Ok(form) => Success(form),
                 Err((form_string, e)) => {
-                    error_!("Failed to parse value from form: {:?}", e);
+                    error!("Failed to parse value from form: {:?}", e);
                     Failure((Status::BadRequest, Some(form_string)))
                 }
             }

--- a/lib/src/request/state.rs
+++ b/lib/src/request/state.rs
@@ -28,13 +28,13 @@ impl<'a, 'r, T: Send + Sync + 'static> FromRequest<'a, 'r> for State<'r, T> {
             match state.try_get::<T>() {
                 Some(state) => Outcome::Success(State(state)),
                 None => {
-                    error_!("Attempted to retrieve unmanaged state!");
+                    error!("Attempted to retrieve unmanaged state!");
                     Outcome::Failure((Status::InternalServerError, ()))
                 }
             }
         } else {
-            error_!("Internal Rocket error: managed state is unset!");
-            error_!("Please report this error in the Rocket GitHub issue tracker.");
+            error!("Internal Rocket error: managed state is unset!");
+            error!("Please report this error in the Rocket GitHub issue tracker.");
             Outcome::Failure((Status::InternalServerError, ()))
         }
     }

--- a/lib/src/response/flash.rs
+++ b/lib/src/response/flash.rs
@@ -177,7 +177,7 @@ impl<'r, R: Responder<'r>> Flash<R> {
 /// the response is the `Outcome` of the wrapped `Responder`.
 impl<'r, R: Responder<'r>> Responder<'r> for Flash<R> {
     fn respond(self) -> Result<Response<'r>, Status> {
-        trace_!("Flash: setting message: {}:{}", self.name, self.message);
+        trace!("Flash: setting message: {}:{}", self.name, self.message);
         let cookie = self.cookie();
         Response::build_from(self.responder.respond()?)
             .header_adjoin(cookie)
@@ -215,10 +215,10 @@ impl<'a, 'r> FromRequest<'a, 'r> for Flash<()> {
     type Error = ();
 
     fn from_request(request: &'a Request<'r>) -> request::Outcome<Self, Self::Error> {
-        trace_!("Flash: attemping to retrieve message.");
+        trace!("Flash: attemping to retrieve message.");
         let r = request.cookies().find(FLASH_COOKIE_NAME).ok_or(()).and_then(|cookie| {
             // Clear the flash message.
-            trace_!("Flash: retrieving message: {:?}", cookie);
+            trace!("Flash: retrieving message: {:?}", cookie);
             request.cookies().remove(FLASH_COOKIE_NAME);
 
             // Parse the flash.

--- a/lib/src/response/responder.rs
+++ b/lib/src/response/responder.rs
@@ -218,7 +218,7 @@ impl Responder<'static> for () {
 impl<'r, R: Responder<'r>> Responder<'r> for Option<R> {
     fn respond(self) -> Result<Response<'r>, Status> {
         self.map_or_else(|| {
-            warn_!("Response was `None`.");
+            warn!("Response was `None`.");
             Err(Status::NotFound)
         }, |r| r.respond())
     }
@@ -230,7 +230,7 @@ impl<'r, R: Responder<'r>> Responder<'r> for Option<R> {
 impl<'r, R: Responder<'r>, E: fmt::Debug> Responder<'r> for Result<R, E> {
     default fn respond(self) -> Result<Response<'r>, Status> {
         self.map(|r| r.respond()).unwrap_or_else(|e| {
-            error_!("Response was `Err`: {:?}.", e);
+            error!("Response was `Err`: {:?}.", e);
             Err(Status::InternalServerError)
         })
     }

--- a/lib/src/response/response.rs
+++ b/lib/src/response/response.rs
@@ -63,7 +63,7 @@ impl<T: io::Read> Body<T> {
         };
 
         if let Err(e) = body.read_to_string(&mut string) {
-            error_!("Error reading body: {:?}", e);
+            error!("Error reading body: {:?}", e);
             return None;
         }
 

--- a/lib/src/rocket.rs
+++ b/lib/src/rocket.rs
@@ -341,7 +341,7 @@ impl Rocket {
 
     fn configured(config: &'static Config, log: bool) -> Rocket {
         if log {
-            logger::init(config.log_level);
+            logger::init(&config.log);
         }
 
         let clog = slog_scope::logger().new(slog_o!(
@@ -350,7 +350,6 @@ impl Rocket {
 
         slog_info!(clog, "address: {}", White.paint(&config.address));
         slog_info!(clog, "port: {}", White.paint(&config.port));
-        slog_info!(clog, "log: {}", White.paint(config.log_level));
         slog_info!(clog, "workers: {}", White.paint(config.workers));
 
         let session_key = config.take_session_key();

--- a/lib/src/rocket.rs
+++ b/lib/src/rocket.rs
@@ -330,7 +330,7 @@ impl Rocket {
     ///     .finalize()?;
     ///
     /// # #[allow(unused_variables)]
-    /// let app = rocket::custom(config, false);
+    /// let app = rocket::custom(config);
     /// # Ok(())
     /// # }
     /// ```

--- a/lib/src/rocket.rs
+++ b/lib/src/rocket.rs
@@ -334,14 +334,16 @@ impl Rocket {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn custom(config: Config, log: bool) -> Rocket {
+    pub fn custom(config: Config) -> Rocket {
         let (config, initted) = config::custom_init(config);
-        Rocket::configured(config, log && initted)
+        Rocket::configured(config, initted)
     }
 
-    fn configured(config: &'static Config, log: bool) -> Rocket {
-        if log {
-            logger::init(&config.log);
+    fn configured(config: &'static Config, initial: bool) -> Rocket {
+        if let Some(ref log) = config.log {
+            if initial {
+                logger::init(&log);
+            }
         }
 
         let clog = slog_scope::logger().new(slog_o!(

--- a/lib/src/router/mod.rs
+++ b/lib/src/router/mod.rs
@@ -34,7 +34,7 @@ impl Router {
     // FIXME: Figure out a way to get more than one route, i.e., to correctly
     // handle ranking.
     pub fn route<'b>(&'b self, req: &Request) -> Vec<&'b Route> {
-        trace_!("Trying to route: {}", req);
+        trace!("Trying to route: {}", req);
         // let num_segments = req.uri.segment_count();
         // self.routes.get(&(req.method, num_segments)).map_or(vec![], |routes| {
         self.routes.get(&req.method()).map_or(vec![], |routes| {
@@ -44,7 +44,7 @@ impl Router {
 
             // FIXME: Presort vector to avoid a sort on each route.
             matches.sort_by(|a, b| a.rank.cmp(&b.rank));
-            trace_!("All matches: {:?}", matches);
+            trace!("All matches: {:?}", matches);
             matches
         })
     }


### PR DESCRIPTION
This is a _spike_ to get Rocket compiling with slog instead of log. It's nowhere near complete. I'll be working on it for the next week at least.

```
Jan 30 10:52:23.674 INFO 🔧  Configured for development.
Jan 30 10:52:23.674 INFO address: localhost
Jan 30 10:52:23.675 INFO port: 8000
Jan 30 10:52:23.675 INFO log: normal
Jan 30 10:52:23.675 INFO workers: 8
Jan 30 10:52:23.675 INFO session key: present
Jan 30 10:52:23.675 WARN Signing and encryption of cookies is currently disabled.
Jan 30 10:52:23.675 WARN See https://github.com/SergioBenitez/Rocket/issues/20 for info.
Jan 30 10:52:23.675 INFO 🛰  Mounting '/':
Jan 30 10:52:23.676 INFO GET /
Jan 30 10:52:23.676 INFO 🚀  Rocket has launched from http://localhost:8000...
Jan 30 10:52:25.804 INFO GET /:
Jan 30 10:52:25.806 INFO Matched: GET /
Jan 30 10:52:25.806 INFO Hi Everyone!, Stuff: Things
Jan 30 10:52:25.806 INFO Outcome: Success
Jan 30 10:52:25.806 INFO Response succeeded.
Jan 30 10:52:26.944 INFO GET /:
Jan 30 10:52:26.944 INFO Matched: GET /
Jan 30 10:52:26.944 INFO Hi Everyone!, Stuff: Things
Jan 30 10:52:26.945 INFO Outcome: Success
Jan 30 10:52:26.945 INFO Response succeeded.
```
 - [x] Re-structure log invocations to forward arguments in the way that slog expects

 - [x] Re-structure start-up logs to be more friendly with slog. Here's an example of how they could look from some experimenting (outside of the code-base):

```
🔧 Configure: Development
  Jan 30 10:28:32.005 DEBG Address: localhost
  Jan 30 10:28:32.006 DEBG Port: 8080
  Jan 30 10:28:32.006 DEBG Workers: 8
🛰  Mount: /
  Jan 30 10:28:32.006 DEBG GET /
Jan 30 10:28:32.006 INFO 🚀 Rocket has launched from http://localhost:8000...
```

 - [x] ~Add _versions_ to the startup logs: Rust, Rocket, and _Project_~

 - [x] Determine ideal method to allow a configurable drain. My initial thought is a method on the Rocket struct that would accept a function that returns a configured drain. My second thought is to utilize `Rocket.toml` and forward a `log` table to https://github.com/slog-rs/config . I'm leaning towards the latter right now (as its more ergonomic).

 - [x] Do research to determine the ideal format for request logs.

    What I think a request log should contain:
      - Timestamp [info]
      - Path / "Matched" [info]
      - Parameters (could include request guards) [debug]
      - Response "Status Code" [info]
      - Request IP (in production) [info]

---

@SergioBenitez After I get things to a point where I like them. I'll be going through your requirements to make sure we satisfy as many as possible.