### PR TITLE
Default T in JSON to improve ergonomics of returning arbitrary JSON

### DIFF
--- a/contrib/src/json/mod.rs
+++ b/contrib/src/json/mod.rs
@@ -129,20 +129,23 @@ impl<T> DerefMut for JSON<T> {
 /// ```
 ///
 /// The return type of a macro invocation is
-/// [Value](/rocket_contrib/enum.Value.html). A value created with this macro
+/// [Value](/rocket_contrib/enum.Value.html), and is the default type parameter 
+/// of the JSON type. A value created with this macro
 /// can be returned from a handler as follows:
 ///
 /// ```rust,ignore
-/// use rocket_contrib::{JSON, Value};
+/// use rocket_contrib::JSON;
 ///
 /// #[get("/json")]
-/// fn get_json() -> JSON<Value> {
+/// fn get_json() -> JSON {
 ///     JSON(json!({
 ///         "key": "value",
 ///         "array": [1, 2, 3, 4]
 ///     }))
 /// }
 /// ```
+/// 
+/// 
 ///
 /// # Examples
 ///

--- a/contrib/src/json/mod.rs
+++ b/contrib/src/json/mod.rs
@@ -3,6 +3,7 @@ extern crate serde_json;
 
 use std::ops::{Deref, DerefMut};
 use std::io::Read;
+use std::collections::HashMap;
 
 use rocket::outcome::Outcome;
 use rocket::request::Request;
@@ -53,7 +54,7 @@ pub use self::serde_json::to_value;
 /// ```
 ///
 #[derive(Debug)]
-pub struct JSON<T>(pub T);
+pub struct JSON<T = HashMap<&'static str, Value>>(pub T);
 
 impl<T> JSON<T> {
     /// Consumes the JSON wrapper and returns the wrapped item.

--- a/contrib/src/json/mod.rs
+++ b/contrib/src/json/mod.rs
@@ -3,7 +3,6 @@ extern crate serde_json;
 
 use std::ops::{Deref, DerefMut};
 use std::io::Read;
-use std::collections::HashMap;
 
 use rocket::outcome::Outcome;
 use rocket::request::Request;
@@ -54,7 +53,7 @@ pub use self::serde_json::to_value;
 /// ```
 ///
 #[derive(Debug)]
-pub struct JSON<T = HashMap<&'static str, Value>>(pub T);
+pub struct JSON<T = Value>(pub T);
 
 impl<T> JSON<T> {
     /// Consumes the JSON wrapper and returns the wrapped item.

--- a/contrib/src/json/mod.rs
+++ b/contrib/src/json/mod.rs
@@ -129,9 +129,11 @@ impl<T> DerefMut for JSON<T> {
 /// ```
 ///
 /// The return type of a macro invocation is
-/// [Value](/rocket_contrib/enum.Value.html), and is the default type parameter 
-/// of the JSON type. A value created with this macro
-/// can be returned from a handler as follows:
+/// [Value](/rocket_contrib/enum.Value.html).
+/// This is the default value for the type parameter of 
+/// [JSON](/rocket_contrib/struct.JSON.html) and as such, you can return
+/// `JSON` without specifying the type.
+/// A value created with this macro can be returned from a handler as follows:
 ///
 /// ```rust,ignore
 /// use rocket_contrib::JSON;


### PR DESCRIPTION
This ...

```rust
use std::collections::HashMap;

use rocket_contrib::json::{JSON, Value};

type SimpleMap = HashMap<&'static str, Value>;

#[derive(Debug, Deserialize)]
struct UserForm {
    username: String,
    email: String,
    password: String,
}

#[post("/user", data = "<body>")]
fn post_user(body: JSON<UserForm>) -> JSON<SimpleMap> {
    println!("{:?}", body);

    JSON(map!(
        "status" => "ok",
    ))
}
```

Becomes ...

```rust
use rocket_contrib::json::JSON;

#[derive(Debug, Deserialize)]
struct UserForm {
    username: String,
    email: String,
    password: String,
}

#[post("/user", data = "<body>")]
fn post_user(body: JSON<UserForm>) -> JSON {
    println!("{:?}", body);

    JSON(map!(
        "status" => "ok",
    ))
}
```

Thoughts?