### PR TITLE
updated json example with managed state

### DIFF
--- a/examples/json/Cargo.toml
+++ b/examples/json/Cargo.toml
@@ -9,7 +9,6 @@ rocket_codegen = { path = "../../codegen" }
 serde = "0.9"
 serde_json = "0.9"
 serde_derive = "0.9"
-lazy_static = "*"
 
 [dependencies.rocket_contrib]
 path = "../../contrib"

--- a/examples/json/src/main.rs
+++ b/examples/json/src/main.rs
@@ -70,10 +70,13 @@ fn not_found() -> JSON<Value> {
     }))
 }
 
-fn main() {
+fn rocket() -> rocket::Rocket {
     rocket::ignite()
         .mount("/message", routes![new, update, get])
         .catch(errors![not_found])
         .manage(Mutex::new(HashMap::<ID, String>::new()))
-        .launch();
+}
+
+fn main() {
+    rocket().launch();
 }

--- a/examples/json/src/main.rs
+++ b/examples/json/src/main.rs
@@ -3,13 +3,13 @@
 
 extern crate rocket;
 extern crate serde_json;
-#[macro_use] extern crate lazy_static;
 #[macro_use] extern crate rocket_contrib;
 #[macro_use] extern crate serde_derive;
 
 #[cfg(test)] mod tests;
 
 use rocket_contrib::{JSON, Value};
+use rocket::State;
 use std::collections::HashMap;
 use std::sync::Mutex;
 
@@ -17,9 +17,7 @@ use std::sync::Mutex;
 type ID = usize;
 
 // We're going to store all of the messages here. No need for a DB.
-lazy_static! {
-    static ref MAP: Mutex<HashMap<ID, String>> = Mutex::new(HashMap::new());
-}
+type MessageMap = Mutex<HashMap<ID, String>>;
 
 #[derive(Serialize, Deserialize)]
 struct Message {
@@ -29,8 +27,8 @@ struct Message {
 
 // TODO: This example can be improved by using `route` with muliple HTTP verbs.
 #[post("/<id>", format = "application/json", data = "<message>")]
-fn new(id: ID, message: JSON<Message>) -> JSON<Value> {
-    let mut hashmap = MAP.lock().expect("map lock.");
+fn new(id: ID, message: JSON<Message>, map: State<MessageMap>) -> JSON<Value> {
+    let mut hashmap = map.lock().expect("map lock.");
     if hashmap.contains_key(&id) {
         JSON(json!({
             "status": "error",
@@ -43,8 +41,8 @@ fn new(id: ID, message: JSON<Message>) -> JSON<Value> {
 }
 
 #[put("/<id>", format = "application/json", data = "<message>")]
-fn update(id: ID, message: JSON<Message>) -> Option<JSON<Value>> {
-    let mut hashmap = MAP.lock().unwrap();
+fn update(id: ID, message: JSON<Message>, map: State<MessageMap>) -> Option<JSON<Value>> {
+    let mut hashmap = map.lock().unwrap();
     if hashmap.contains_key(&id) {
         hashmap.insert(id, message.0.contents);
         Some(JSON(json!({ "status": "ok" })))
@@ -54,8 +52,8 @@ fn update(id: ID, message: JSON<Message>) -> Option<JSON<Value>> {
 }
 
 #[get("/<id>", format = "application/json")]
-fn get(id: ID) -> Option<JSON<Message>> {
-    let hashmap = MAP.lock().unwrap();
+fn get(id: ID, map: State<MessageMap>) -> Option<JSON<Message>> {
+    let hashmap = map.lock().unwrap();
     hashmap.get(&id).map(|contents| {
         JSON(Message {
             id: Some(id),
@@ -76,5 +74,6 @@ fn main() {
     rocket::ignite()
         .mount("/message", routes![new, update, get])
         .catch(errors![not_found])
+        .manage(Mutex::new(HashMap::<ID, String>::new()))
         .launch();
 }

--- a/examples/json/src/tests.rs
+++ b/examples/json/src/tests.rs
@@ -4,19 +4,23 @@ use rocket::http::Method::*;
 use rocket::http::{Status, ContentType};
 use rocket::Response;
 
-macro_rules! run_test {
-    ($req:expr, $test_fn:expr) => ({
-        let rocket = rocket::ignite()
-            .mount("/message", routes![super::new, super::update, super::get])
-            .catch(errors![super::not_found]);
+use std::collections::HashMap;
+use std::sync::Mutex;
 
+macro_rules! run_test {
+    ($req:expr, $test_fn:expr, $rocket:expr) => ({
         let mut req = $req;
-        $test_fn(req.dispatch_with(&rocket));
+        $test_fn(req.dispatch_with($rocket));
     })
 }
 
 #[test]
 fn bad_get_put() {
+    let rocket = rocket::ignite()
+        .mount("/message", routes![super::new, super::update, super::get])
+        .manage(Mutex::new(HashMap::<super::ID, String>::new()))
+        .catch(errors![super::not_found]);
+
     // Try to get a message with an ID that doesn't exist.
     let req = MockRequest::new(Get, "/message/99").header(ContentType::JSON);
     run_test!(req, |mut response: Response| {
@@ -25,7 +29,7 @@ fn bad_get_put() {
         let body = response.body().unwrap().into_string().unwrap();
         assert!(body.contains("error"));
         assert!(body.contains("Resource was not found."));
-    });
+    }, &rocket);
 
     // Try to get a message with an invalid ID.
     let req = MockRequest::new(Get, "/message/hi").header(ContentType::JSON);
@@ -33,13 +37,13 @@ fn bad_get_put() {
         assert_eq!(response.status(), Status::NotFound);
         let body = response.body().unwrap().into_string().unwrap();
         assert!(body.contains("error"));
-    });
+    }, &rocket);
 
     // Try to put a message without a proper body.
     let req = MockRequest::new(Put, "/message/80").header(ContentType::JSON);
     run_test!(req, |response: Response| {
         assert_eq!(response.status(), Status::BadRequest);
-    });
+    }, &rocket);
 
     // Try to put a message for an ID that doesn't exist.
     let req = MockRequest::new(Put, "/message/80")
@@ -48,16 +52,20 @@ fn bad_get_put() {
 
     run_test!(req, |response: Response| {
         assert_eq!(response.status(), Status::NotFound);
-    });
+    }, &rocket);
 }
 
 #[test]
 fn post_get_put_get() {
+    let rocket = rocket::ignite()
+        .mount("/message", routes![super::new, super::update, super::get])
+        .manage(Mutex::new(HashMap::<super::ID, String>::new()))
+        .catch(errors![super::not_found]);
     // Check that a message with ID 1 doesn't exist.
     let req = MockRequest::new(Get, "/message/1").header(ContentType::JSON);
     run_test!(req, |response: Response| {
         assert_eq!(response.status(), Status::NotFound);
-    });
+    }, &rocket);
 
     // Add a new message with ID 1.
     let req = MockRequest::new(Post, "/message/1")
@@ -66,7 +74,7 @@ fn post_get_put_get() {
 
     run_test!(req, |response: Response| {
         assert_eq!(response.status(), Status::Ok);
-    });
+    }, &rocket);
 
     // Check that the message exists with the correct contents.
     let req = MockRequest::new(Get, "/message/1") .header(ContentType::JSON);
@@ -74,7 +82,7 @@ fn post_get_put_get() {
         assert_eq!(response.status(), Status::Ok);
         let body = response.body().unwrap().into_string().unwrap();
         assert!(body.contains("Hello, world!"));
-    });
+    }, &rocket);
 
     // Change the message contents.
     let req = MockRequest::new(Put, "/message/1")
@@ -83,7 +91,7 @@ fn post_get_put_get() {
 
     run_test!(req, |response: Response| {
         assert_eq!(response.status(), Status::Ok);
-    });
+    }, &rocket);
 
     // Check that the message exists with the updated contents.
     let req = MockRequest::new(Get, "/message/1") .header(ContentType::JSON);
@@ -92,5 +100,5 @@ fn post_get_put_get() {
         let body = response.body().unwrap().into_string().unwrap();
         assert!(!body.contains("Hello, world!"));
         assert!(body.contains("Bye bye, world!"));
-    });
+    }, &rocket);
 }

--- a/examples/json/src/tests.rs
+++ b/examples/json/src/tests.rs
@@ -5,7 +5,7 @@ use rocket::http::{Status, ContentType};
 use rocket::Response;
 
 macro_rules! run_test {
-    ($req:expr, $test_fn:expr, $rocket:expr) => ({
+    ($rocket: expr, $req:expr, $test_fn:expr) => ({
         let mut req = $req;
         $test_fn(req.dispatch_with($rocket));
     })
@@ -17,36 +17,36 @@ fn bad_get_put() {
 
     // Try to get a message with an ID that doesn't exist.
     let req = MockRequest::new(Get, "/message/99").header(ContentType::JSON);
-    run_test!(req, |mut response: Response| {
+    run_test!(&rocket, req, |mut response: Response| {
         assert_eq!(response.status(), Status::NotFound);
 
         let body = response.body().unwrap().into_string().unwrap();
         assert!(body.contains("error"));
         assert!(body.contains("Resource was not found."));
-    }, &rocket);
+    });
 
     // Try to get a message with an invalid ID.
     let req = MockRequest::new(Get, "/message/hi").header(ContentType::JSON);
-    run_test!(req, |mut response: Response| {
+    run_test!(&rocket, req, |mut response: Response| {
         assert_eq!(response.status(), Status::NotFound);
         let body = response.body().unwrap().into_string().unwrap();
         assert!(body.contains("error"));
-    }, &rocket);
+    });
 
     // Try to put a message without a proper body.
     let req = MockRequest::new(Put, "/message/80").header(ContentType::JSON);
-    run_test!(req, |response: Response| {
+    run_test!(&rocket, req, |response: Response| {
         assert_eq!(response.status(), Status::BadRequest);
-    }, &rocket);
+    });
 
     // Try to put a message for an ID that doesn't exist.
     let req = MockRequest::new(Put, "/message/80")
         .header(ContentType::JSON)
         .body(r#"{ "contents": "Bye bye, world!" }"#);
 
-    run_test!(req, |response: Response| {
+    run_test!(&rocket, req, |response: Response| {
         assert_eq!(response.status(), Status::NotFound);
-    }, &rocket);
+    });
 }
 
 #[test]
@@ -54,42 +54,42 @@ fn post_get_put_get() {
     let rocket = rocket();
     // Check that a message with ID 1 doesn't exist.
     let req = MockRequest::new(Get, "/message/1").header(ContentType::JSON);
-    run_test!(req, |response: Response| {
+    run_test!(&rocket, req, |response: Response| {
         assert_eq!(response.status(), Status::NotFound);
-    }, &rocket);
+    });
 
     // Add a new message with ID 1.
     let req = MockRequest::new(Post, "/message/1")
         .header(ContentType::JSON)
         .body(r#"{ "contents": "Hello, world!" }"#);
 
-    run_test!(req, |response: Response| {
+    run_test!(&rocket, req, |response: Response| {
         assert_eq!(response.status(), Status::Ok);
-    }, &rocket);
+    });
 
     // Check that the message exists with the correct contents.
     let req = MockRequest::new(Get, "/message/1") .header(ContentType::JSON);
-    run_test!(req, |mut response: Response| {
+    run_test!(&rocket, req, |mut response: Response| {
         assert_eq!(response.status(), Status::Ok);
         let body = response.body().unwrap().into_string().unwrap();
         assert!(body.contains("Hello, world!"));
-    }, &rocket);
+    });
 
     // Change the message contents.
     let req = MockRequest::new(Put, "/message/1")
         .header(ContentType::JSON)
         .body(r#"{ "contents": "Bye bye, world!" }"#);
 
-    run_test!(req, |response: Response| {
+    run_test!(&rocket, req, |response: Response| {
         assert_eq!(response.status(), Status::Ok);
-    }, &rocket);
+    });
 
     // Check that the message exists with the updated contents.
     let req = MockRequest::new(Get, "/message/1") .header(ContentType::JSON);
-    run_test!(req, |mut response: Response| {
+    run_test!(&rocket, req, |mut response: Response| {
         assert_eq!(response.status(), Status::Ok);
         let body = response.body().unwrap().into_string().unwrap();
         assert!(!body.contains("Hello, world!"));
         assert!(body.contains("Bye bye, world!"));
-    }, &rocket);
+    });
 }

--- a/examples/json/src/tests.rs
+++ b/examples/json/src/tests.rs
@@ -4,9 +4,6 @@ use rocket::http::Method::*;
 use rocket::http::{Status, ContentType};
 use rocket::Response;
 
-use std::collections::HashMap;
-use std::sync::Mutex;
-
 macro_rules! run_test {
     ($req:expr, $test_fn:expr, $rocket:expr) => ({
         let mut req = $req;
@@ -16,10 +13,7 @@ macro_rules! run_test {
 
 #[test]
 fn bad_get_put() {
-    let rocket = rocket::ignite()
-        .mount("/message", routes![super::new, super::update, super::get])
-        .manage(Mutex::new(HashMap::<super::ID, String>::new()))
-        .catch(errors![super::not_found]);
+    let rocket = rocket();
 
     // Try to get a message with an ID that doesn't exist.
     let req = MockRequest::new(Get, "/message/99").header(ContentType::JSON);
@@ -57,10 +51,7 @@ fn bad_get_put() {
 
 #[test]
 fn post_get_put_get() {
-    let rocket = rocket::ignite()
-        .mount("/message", routes![super::new, super::update, super::get])
-        .manage(Mutex::new(HashMap::<super::ID, String>::new()))
-        .catch(errors![super::not_found]);
+    let rocket = rocket();
     // Check that a message with ID 1 doesn't exist.
     let req = MockRequest::new(Get, "/message/1").header(ContentType::JSON);
     run_test!(req, |response: Response| {


### PR DESCRIPTION
Reading the docs and trying out examples, I've noticed that JSON example uses `lazy_static` way to handle state. Which I've changed to managed state as this seems to be the preferred way to handle state in Rocket.

I've also had to update tests since `run_test!` macro was not properly isolating objects that were created inside: `lazy_static`-initialized objects were leaking outside the test runs.