### PR TITLE
Add Font Content Types

### DIFF
--- a/lib/src/http/content_type.rs
+++ b/lib/src/http/content_type.rs
@@ -10,7 +10,7 @@ use http::ascii::{uncased_eq, UncasedAscii};
 ///
 /// # Usage
 ///
-/// ContentTypes should rarely be created directly. Instead, an associated
+/// `ContentTypes` should rarely be created directly. Instead, an associated
 /// constant should be used; one is declared for most commonly used content
 /// types.
 ///
@@ -114,8 +114,13 @@ impl ContentType {
         "GIF", GIF, is_gif => "image", "gif",
         "BMP", BMP, is_bmp => "image", "bmp",
         "JPEG", JPEG, is_jpeg => "image", "jpeg",
+        "WEBP", WEBP, is_webp => "image", "webp",
         "SVG", SVG, is_svg => "image", "svg+xml",
-        "PDF", PDF, is_pdf => "application", "pdf"
+        "PDF", PDF, is_pdf => "application", "pdf",
+        "TTF", TTF, is_ttf => "application", "font-sfnt",
+        "OTF", OTF, is_otf => "application", "font-sfnt",
+        "WOFF", WOFF, is_woff => "application", "font-woff",
+        "WOFF2", WOFF2, is_woff2 => "font", "woff2"
     }
 
     /// Returns the Content-Type associated with the extension `ext`. Not all
@@ -158,8 +163,13 @@ impl ContentType {
             x if uncased_eq(x, "bmp") => ContentType::BMP,
             x if uncased_eq(x, "jpeg") => ContentType::JPEG,
             x if uncased_eq(x, "jpg") => ContentType::JPEG,
+            x if uncased_eq(x, "webp") => ContentType::WEBP,
             x if uncased_eq(x, "svg") => ContentType::SVG,
             x if uncased_eq(x, "pdf") => ContentType::PDF,
+            x if uncased_eq(x, "ttf") => ContentType::TTF,
+            x if uncased_eq(x, "otf") => ContentType::OTF,
+            x if uncased_eq(x, "woff") => ContentType::WOFF,
+            x if uncased_eq(x, "woff2") => ContentType::WOFF2,
             _ => ContentType::Any
         }
     }
@@ -210,7 +220,7 @@ impl ContentType {
         ContentType {
             ttype: UncasedAscii::from(ttype),
             subtype: UncasedAscii::from(subtype),
-            params: params.map(|p| UncasedAscii::from(p))
+            params: params.map(UncasedAscii::from)
         }
     }
 
@@ -245,9 +255,9 @@ impl ContentType {
             None => ""
         };
 
-        params.split(";")
+        params.split(';')
             .filter_map(|param| {
-                let mut kv = param.split("=");
+                let mut kv = param.split('=');
                 match (kv.next(), kv.next()) {
                     (Some(key), Some(val)) => Some((key.trim(), val.trim())),
                     _ => None


### PR DESCRIPTION
Adds support for TTF, OTF, WOFF, and WOFF2 content types, in addition to fixing a few Clippy concerns in the file. Also added WEBP.