### PR TITLE
Make the info message 'Rocket has launched from http://localhost:8000…' clickable in shells.

### DIFF
--- a/lib/src/rocket.rs
+++ b/lib/src/rocket.rs
@@ -555,7 +555,7 @@ impl Rocket {
             }
         };
 
-        info!("🚀  {} {}{}...",
+        info!("🚀  {} {}{} ...",
               White.paint("Rocket has launched from"),
               White.bold().paint("http://"),
               White.bold().paint(&full_addr));


### PR DESCRIPTION
If there is no space after the URL, then the '…' character is treated as part of the URL, so that when you right click it or double click it to select/copy it, most terminal emulators become confused.