### PR TITLE
Moving `toml` to a newer version

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -22,8 +22,10 @@ term-painter = "0.2"
 log = "0.3"
 url = "1"
 hyper = { version = "0.10.4", default-features = false }
-toml = { version = "0.2", default-features = false }
+toml = "^0.3"
 num_cpus = "1"
+serde = "^0.9.7"
+serde_derive = "^0.9.7"
 state = "0.2"
 time = "0.1"
 memchr = "1"

--- a/lib/src/config/config.rs
+++ b/lib/src/config/config.rs
@@ -564,11 +564,11 @@ impl Config {
     ///     .extra("numbers", vec![1, 2, 3])
     ///     .unwrap();
     ///
-    /// assert!(config.get_slice("numbers").is_ok());
+    /// assert!(config.get_array("numbers").is_ok());
     /// ```
-    pub fn get_slice(&self, name: &str) -> config::Result<&[Value]> {
+    pub fn get_array(&self, name: &str) -> config::Result<&config::Array> {
         let value = self.extras.get(name).ok_or_else(|| ConfigError::NotFound)?;
-        parse!(self, name, value, as_slice, "a slice")
+        parse!(self, name, value, as_array, "an array")
     }
 
     /// Attempts to retrieve the extra named `name` as a table.

--- a/lib/src/config/toml.rs
+++ b/lib/src/config/toml.rs
@@ -1,0 +1,22 @@
+use toml;
+
+use toml::Value;
+use serde::de::Deserialize;
+
+use config::ConfigError;
+use super::Result;
+
+pub fn parse(toml: &str) -> Result<Value> {
+    let first_error = match toml.parse() {
+        Ok(ret) => return Ok(ret),
+        Err(e) => e,
+    };
+
+    let mut second_parser = toml::de::Deserializer::new(toml);
+
+    if let Ok(ret) = Value::deserialize(&mut second_parser) {
+        return Ok(ret)
+    }
+
+    Err(ConfigError::from(first_error))
+}

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -100,6 +100,7 @@ extern crate hyper;
 extern crate url;
 extern crate toml;
 extern crate num_cpus;
+extern crate serde;
 extern crate state;
 extern crate cookie;
 extern crate time;


### PR DESCRIPTION
Right now everything works just like that, and I'm thinking about implementing it a `serde` way with `Deserialize` and everything else, to be more idiomatic and to drop such functions as `set`, because they look really ugly.

Note for @SergioBenitez : I want this PR to be merged before #204 , because I'm planning to change methods inside of `Config`