### PR TITLE
Port auto config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
   "examples/errors",
   "examples/extended_validation",
   "examples/forms",
+  "examples/hello_auto_port",
   "examples/hello_person",
   "examples/query_params",
   "examples/hello_world",

--- a/examples/hello_auto_port/Cargo.toml
+++ b/examples/hello_auto_port/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "hello_auto_port"
+version = "0.0.1"
+workspace = "../../"
+
+[dependencies]
+rocket = { path = "../../lib" }
+rocket_codegen = { path = "../../codegen" }
+
+[dev-dependencies]
+rocket = { path = "../../lib", features = ["testing"] }

--- a/examples/hello_auto_port/src/main.rs
+++ b/examples/hello_auto_port/src/main.rs
@@ -1,0 +1,34 @@
+#![feature(plugin)]
+#![plugin(rocket_codegen)]
+
+extern crate rocket;
+
+use rocket::config::{Config, Environment};
+use rocket::config::ConfigError;
+use rocket::logger::LoggingLevel;
+
+#[get("/")]
+fn index() -> &'static str {
+    "Hello, world!"
+}
+
+fn main() {
+    try_config().unwrap()
+}
+
+#[allow(dead_code)]
+fn try_config() -> Result<(), ConfigError> {
+    let config = Config::build(Environment::Development)
+        .address("127.0.0.1")
+        .port(0) // 0 will request that the OS assigns a port.
+        .log_level(LoggingLevel::Debug)
+        .finalize()?;
+    let logging = true;
+    let on_success = |addr| {
+            println!("Resulting address: {}", addr);
+    };
+    rocket::custom(config, logging)
+        .mount("/", routes![index])
+        .launch(on_success);
+    Ok(())
+}

--- a/examples/hello_auto_port/src/main.rs
+++ b/examples/hello_auto_port/src/main.rs
@@ -24,11 +24,12 @@ fn try_config() -> Result<(), ConfigError> {
         .log_level(LoggingLevel::Debug)
         .finalize()?;
     let logging = true;
-    let on_success = |addr| {
+    let callback = Box::new(|addr| {
             println!("Resulting address: {}", addr);
-    };
+    });
     rocket::custom(config, logging)
         .mount("/", routes![index])
-        .launch(on_success);
+        .on_success(callback)
+        .launch();
     Ok(())
 }

--- a/examples/hello_auto_port/src/tests.rs
+++ b/examples/hello_auto_port/src/tests.rs
@@ -1,0 +1,13 @@
+use super::rocket;
+use rocket::testing::MockRequest;
+use rocket::http::Method::*;
+
+#[test]
+fn hello_world() {
+    let rocket = rocket::ignite().mount("/", routes![super::hello]);
+    let mut req = MockRequest::new(Get, "/");
+    let mut response = req.dispatch_with(&rocket);
+
+    let body_str = response.body().and_then(|body| body.into_string());
+    assert_eq!(body_str, Some("Hello, world!".to_string()));
+}

--- a/examples/hello_world/src/main.rs
+++ b/examples/hello_world/src/main.rs
@@ -11,5 +11,5 @@ fn hello() -> &'static str {
 }
 
 fn main() {
-    rocket::ignite().mount("/", routes![hello]).launch();
+    rocket::ignite().mount("/", routes![hello]).launch(|addr| { println!("{}", addr) });
 }

--- a/examples/hello_world/src/main.rs
+++ b/examples/hello_world/src/main.rs
@@ -11,5 +11,5 @@ fn hello() -> &'static str {
 }
 
 fn main() {
-    rocket::ignite().mount("/", routes![hello]).launch(|addr| { println!("{}", addr) });
+    rocket::ignite().mount("/", routes![hello]).launch();
 }

--- a/lib/src/rocket.rs
+++ b/lib/src/rocket.rs
@@ -24,6 +24,8 @@ use http::{Method, Status, Header};
 use http::hyper::{self, header};
 use http::uri::URI;
 
+type SuccessCallback = Box<FnMut(SocketAddr) + Send + Sync>;
+
 /// The main `Rocket` type: used to mount routes and catchers and launch the
 /// application.
 pub struct Rocket {
@@ -32,6 +34,7 @@ pub struct Rocket {
     default_catchers: HashMap<u16, Catcher>,
     catchers: HashMap<u16, Catcher>,
     state: Container,
+    on_success: Option<SuccessCallback>
 }
 
 #[doc(hidden)]
@@ -359,7 +362,8 @@ impl Rocket {
             router: Router::new(),
             default_catchers: catcher::defaults::get(),
             catchers: catcher::defaults::get(),
-            state: Container::new()
+            state: Container::new(),
+            on_success: None
         }
     }
 
@@ -527,6 +531,11 @@ impl Rocket {
         self
     }
 
+    pub fn on_success(mut self, f:SuccessCallback) -> Self {
+        self.on_success = Some(f);
+        self
+    }
+
     /// Starts the application server and begins listening for and dispatching
     /// requests to mounted routes and catchers.
     ///
@@ -542,8 +551,7 @@ impl Rocket {
     /// rocket::ignite().launch()
     /// # }
     /// ```
-    pub fn launch<F>(self, on_success: F) 
-        where F: Fn(SocketAddr)
+    pub fn launch(mut self) 
     {
         if self.router.has_collisions() {
             warn!("Route collisions detected!");
@@ -555,11 +563,11 @@ impl Rocket {
             Ok(l)  => l,
             Err(e) => {
                 error!("Failed to start server.");
-                panic!("{}", e)
+                panic!("{}", e)                        // TODO: Return error (?)
             }
         };
         use hyper::net::NetworkListener;
-        let result_addr = lis.local_addr().unwrap();
+        let result_addr = lis.local_addr().unwrap();   // TODO: Return error (?)
         let server = hyper::Server::new(lis);
 
         info!("🚀  {} {}{}...",
@@ -567,9 +575,12 @@ impl Rocket {
               White.bold().paint("http://"),
               White.bold().paint(result_addr));
 
-        on_success(result_addr);
+        if let Some(f) = self.on_success.take().as_mut() {
+            f(result_addr);
+        }
+
         let threads = self.config.workers as usize;
-        server.handle_threads(self, threads).unwrap();
+        server.handle_threads(self, threads).unwrap(); // TODO: Return error (?)
     }
 }
 


### PR DESCRIPTION
Hi,

This PR is not ready to merge yet, I just wanted to throw the code up on github to get some initial feedback before putting more work into this. 

Overview:
- [ ] Find consensus and approval
- [x] Write a new example hello_auto_port.
- [ ] Write a test for hello_auto_port example.
- [X] Do not break the public API (existing examples and tests work without modification)
- [ ] Write documentation
- [ ] Use rustfmt

This is just a rough initial attempt at providing auto configuration of the port. My motivation is that this is a feature I need for a project where I want to use Rocket as backend for a desktop application with an embedded browser as GUI and I would like to let Rocket allocate an available port and then pass the resulting address on to the browser.

Please feel free to close if this is totally out of scope.