### PR TITLE
Add UrlDecoder trait for str.

### DIFF
--- a/lib/src/http/uri.rs
+++ b/lib/src/http/uri.rs
@@ -314,6 +314,20 @@ impl<'a> fmt::Display for URI<'a> {
 
 unsafe impl<'a> Sync for URI<'a> { /* It's safe! */ }
 
+pub trait UrlDecoder<'a> {
+    fn url_decode(&'a self) -> Result<String, &'a str>;
+}
+
+impl<'a> UrlDecoder<'a> for &'a str {
+    fn url_decode(&'a self) -> Result<String, &'a str> {
+        let replaced = self.replace("+", " ");
+        match URI::percent_decode(replaced.as_bytes()) {
+            Err(_) => Err(self),
+            Ok(string) => Ok(string.into_owned())
+        }
+    }
+}
+
 /// Iterator over the segments of an absolute URI path. Skips empty segments.
 ///
 /// ### Examples

--- a/lib/src/request/form/from_form_value.rs
+++ b/lib/src/request/form/from_form_value.rs
@@ -2,7 +2,7 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6, SocketAdd
 use std::str::FromStr;
 
 use error::Error;
-use http::uri::URI;
+use http::uri::UrlDecoder;
 
 /// Trait to create instance of some type from a form value; expected from field
 /// types in structs deriving `FromForm`.
@@ -167,10 +167,9 @@ impl<'v> FromFormValue<'v> for String {
 
     // This actually parses the value according to the standard.
     fn from_form_value(v: &'v str) -> Result<Self, Self::Error> {
-        let replaced = v.replace("+", " ");
-        match URI::percent_decode(replaced.as_bytes()) {
+        match v.url_decode() {
             Err(_) => Err(v),
-            Ok(string) => Ok(string.into_owned())
+            Ok(string) => Ok(string)
         }
     }
 }

--- a/lib/src/request/param.rs
+++ b/lib/src/request/param.rs
@@ -3,7 +3,7 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6, SocketAdd
 use std::path::PathBuf;
 use std::fmt::Debug;
 
-use http::uri::{URI, Segments, SegmentError};
+use http::uri::{URI, Segments, SegmentError, UrlDecoder};
 
 /// Trait to convert a dynamic path segment string to a concrete value.
 ///
@@ -211,7 +211,10 @@ impl<'a> FromParam<'a> for &'a str {
 impl<'a> FromParam<'a> for String {
     type Error = &'a str;
     fn from_param(p: &'a str) -> Result<String, Self::Error> {
-        URI::percent_decode(p.as_bytes()).map_err(|_| p).map(|s| s.into_owned())
+        match p.url_decode() {
+            Err(_) => Err(p),
+            Ok(string) => Ok(string)
+        }
     }
 }
 


### PR DESCRIPTION
This PR try to resolve #43 .

The original proposal is trying to add a new type called ```RawStr``` that act exactly as str type but add a new additional method ```url_decode```.

After playing for a while, I think adding a new trait might be a good idea.

I have added a new trait called ```UrlDecoder``` which currently implement to the ```str``` type.

The following code snippets shows how the user can use this trait and the difference between two return value.
```rust
use rocket::http::uri::UrlDecoder;

#[derive(FromForm)]
pub struct FormData<'a> {
    form_data: &'a str,
}

#[post("/reproduce_bug", data = "<form>")]
fn reproduce_bug<'a>(form: Form<'a, FormData<'a>>) -> &'static str {
    assert_eq!("A+value+with+spaces", form.get().form_data);
    assert_eq!("A value with spaces", form.get().form_data.url_decode().unwrap());
    "Everything is fine"
}
```

Any advices and recommendations are helpful. Thanks.