### PR TITLE
Add Rocket version to Server header

### DIFF
--- a/lib/src/rocket.rs
+++ b/lib/src/rocket.rs
@@ -79,7 +79,7 @@ impl Rocket {
     fn issue_response(&self, mut response: Response, hyp_res: hyper::FreshResponse) {
         // Add the 'rocket' server header, and write out the response.
         // TODO: If removing Hyper, write out `Date` header too.
-        response.set_header(Header::new("Server", "rocket"));
+        response.set_header(Header::new("Server", "Rocket"));
 
         match self.write_response(response, hyp_res) {
             Ok(_) => info_!("{}", Green.paint("Response succeeded.")),


### PR DESCRIPTION
The information disclosure issue of exposing the Server header to the internet are known and this makes it a touch worse but I feel if a deployment cares about this they are already filtering out this header at a reverse proxy.

This changes increases the debugging value by letting us known which Rocket version is deployed.

---

I'd additionally like to print the Rust version as well but it [seems non-trivial](https://github.com/Kimundi/rustc-version-rs) so I didn't attempt to. 