### PR TITLE
Preserve header list using Hyper's raw headers interface

### DIFF
--- a/lib/src/request/mod.rs
+++ b/lib/src/request/mod.rs
@@ -15,3 +15,97 @@ pub use self::state::State;
 /// Type alias to retrieve [Flash](/rocket/response/struct.Flash.html) messages
 /// from a request.
 pub type FlashMessage = ::response::Flash<()>;
+
+#[cfg(test)]
+mod tests {
+    /// These tests are related to Issue#223
+    /// The way we were getting the headers from hyper
+    /// was causing a list to come back as a comma separated
+    /// list of entries.
+
+    use super::Request;
+    use super::super::http::hyper::header::Headers;
+    use hyper::method::Method;
+    use hyper::uri::RequestUri;
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+    use std::collections::HashMap;
+
+    fn check_headers(test_headers: HashMap<String, Vec<String>>) {
+        let h_method: Method = Method::Get;
+        let h_uri: RequestUri = RequestUri::AbsolutePath("/test".to_string());
+        let h_addr: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8000);
+        let mut h_headers: Headers = Headers::new();
+
+        for (key, values) in &test_headers {
+            let raw_bytes: Vec<Vec<u8>> = values
+                .iter()
+                .map(|v| v.clone().into_bytes())
+                .collect();
+            h_headers.set_raw(key.clone(), raw_bytes);
+        }
+
+        let req = Request::from_hyp(h_method, h_headers, h_uri, h_addr).unwrap();
+        let r_headers = req.headers();
+
+        for (key, values) in &test_headers {
+            for (v1, v2) in values.iter().zip(r_headers.get(&key)) {
+                assert_eq!(v1, v2)
+            }
+        }
+    }
+
+    #[test]
+    fn test_single_header_single_entry() {
+        let mut test_headers = HashMap::new();
+        test_headers.insert("friends".to_string(), vec![
+            "alice".to_string(),
+        ]);
+        check_headers(test_headers);
+    }
+
+    #[test]
+    fn test_single_header_multiple_entries() {
+        let mut test_headers = HashMap::new();
+        test_headers.insert("friends".to_string(), vec![
+            "alice".to_string(),
+            "bob".to_string()
+        ]);
+        check_headers(test_headers);
+    }
+
+    #[test]
+    fn test_single_header_comma_entry() {
+        let mut test_headers = HashMap::new();
+        test_headers.insert("friends".to_string(), vec![
+            "alice".to_string(),
+            "bob, carol".to_string()
+        ]);
+        check_headers(test_headers);
+    }
+
+    #[test]
+    fn test_multiple_headers_single_entry() {
+        let mut test_headers = HashMap::new();
+        test_headers.insert("friends".to_string(), vec![
+            "alice".to_string(),
+        ]);
+        test_headers.insert("enemies".to_string(), vec![
+            "victor".to_string(),
+        ]);
+        check_headers(test_headers);
+    }
+
+    #[test]
+    fn test_multiple_headers_multiple_entries() {
+        let mut test_headers = HashMap::new();
+        test_headers.insert("friends".to_string(), vec![
+            "alice".to_string(),
+            "bob".to_string(),
+        ]);
+        test_headers.insert("enemies".to_string(), vec![
+            "david".to_string(),
+            "emily".to_string(),
+        ]);
+        check_headers(test_headers);
+    }
+}

--- a/lib/src/request/mod.rs
+++ b/lib/src/request/mod.rs
@@ -44,7 +44,11 @@ mod tests {
             h_headers.set_raw(key.clone(), raw_bytes);
         }
 
-        let req = Request::from_hyp(h_method, h_headers, h_uri, h_addr).unwrap();
+        let req = match Request::from_hyp(h_method, h_headers, h_uri, h_addr) {
+            Ok(req) => req,
+            Err(e) => panic!("Building Request failed: {:?}", e),
+        };
+
         let r_headers = req.headers();
 
         for (key, values) in &test_headers {


### PR DESCRIPTION
### Changes
The hyper `value_string()` will take a list of headers and return a string which
is joined by commas. See Issue #223.

This change grabs the raw headers and loops over them, creating the proper
number of entries in the header map.

### Testing
* I tested this using a basic endpoint which prints out headers, and threw various combinations of headers at it with `curl`.
* I tried to pass in invalid utf8 to exercise the unhappy path, but it seemed like something at a lower level panic'd before this code even got run.
* `cargo test` passes.

### Thoughts
I also tried to fix this by implementing Hyper's [Header](https://hyper.rs/hyper/v0.10.5/hyper/header/trait.Header.html) and [Header Format](https://hyper.rs/hyper/v0.10.5/hyper/header/trait.HeaderFormat.html) traits on a simple struct wrapping a `Vec<String>` so that I could then make the direct call to `hyp.value()` which seemed recommended from the [docs](https://hyper.rs/hyper/v0.10.5/hyper/header/struct.HeaderView.html#method.value). This ended up being a lot more code, and I couldn't get it to work without introducing another allocation per header. I'm not well versed with Hyper and maybe someone more experienced than I can come up with a better solution.


