### PR TITLE
Update error and error catcher docs.

### DIFF
--- a/docs/error_catchers.md
+++ b/docs/error_catchers.md
@@ -1,7 +1,11 @@
 # Error Catchers
 
-When Rocket wants to return an error page to the client, Rocket invokes the
-catcher for that error. A catcher is like a route, except it only handles
+When Rocket wants to return an error response type to the client,
+either because the request failed to pass any of the [request guards]
+(requests_request_guard.md) on the the handler's or because the matched 
+handler returned an `Err`, Rocket does this via error catchers.
+
+A catcher is like a route, except it only handles
 errors. Catchers are declared via the error attribute, which takes a single
 integer corresponding to the HTTP status code to catch. For instance, to
 declare a catcher for 404 errors, you’d write:

--- a/docs/error_catchers.md
+++ b/docs/error_catchers.md
@@ -1,0 +1,29 @@
+# Error Catchers
+
+When Rocket wants to return an error page to the client, Rocket invokes the
+catcher for that error. A catcher is like a route, except it only handles
+errors. Catchers are declared via the error attribute, which takes a single
+integer corresponding to the HTTP status code to catch. For instance, to
+declare a catcher for 404 errors, you’d write:
+
+```rust
+#[error(404)]
+fn not_found(req: &Request) -> String { }
+```
+
+As with routes, Rocket needs to know about a catcher before it is used to
+handle errors. The process is similar to mounting: call the `catch` method
+with a list of catchers via the `errors!` macro. The invocation to add the
+404 catcher declared above looks like this:
+
+```rust
+rocket::ignite().catch(errors![not_found])
+```
+
+Unlike request handlers, error handlers can only take 0, 1, or 2 parameters
+of types Request and/or Error. At present, the `Error` type is not
+particularly useful, and so it is often omitted. The error catcher example on
+ GitHub illustrates their use in full.
+
+Rocket has a default catcher for all of the standard HTTP error codes
+including 404, 500, and more.

--- a/docs/requests_errors.md
+++ b/docs/requests_errors.md
@@ -1,8 +1,13 @@
 ## Errors
 Responders need not always generate a response. Instead, they can return an
 Err with a given status code. When this happens, Rocket forwards the request
-to the error catcher for the given status code. If none exists, which can
-only happen when using custom status codes, Rocket uses the 500 error catcher.
+to the [error catcher](error_catcher.md) for the given status code. Just like a
+request handler, an error catcher will return a response by returning any type 
+that has the `Responder` trait implemented. A common example would be to render
+a page displaying **400 Bad Request** to a user who sent a request with a 
+malformed json body. If no error_catcher is configured to handle an specific 
+http error code, which can only happen when using custom status codes, Rocket
+uses's the 500 error catcher.
 
 ### Result
 `Result` is one of the most commonly used responders. Returning a `Result` means

--- a/docs/requests_errors.md
+++ b/docs/requests_errors.md
@@ -1,0 +1,29 @@
+## Errors
+Responders need not always generate a response. Instead, they can return an
+Err with a given status code. When this happens, Rocket forwards the request
+to the error catcher for the given status code. If none exists, which can
+only happen when using custom status codes, Rocket uses the 500 error catcher.
+
+### Result
+`Result` is one of the most commonly used responders. Returning a `Result` means
+one of two things. If the error type implements `Responder`, the `Ok` or `Err`
+value will be used, whichever the variant is. If the error type does not
+implement `Responder`, the error is printed to the console, and the request is
+forwarded to the 500 error catcher.
+
+### Option
+`Option` is another commonly used responder. If the `Option` is `Some`, the wrapped
+responder is used to respond to the client. Otherwise, the request is
+forwarded to the 404 error catcher.
+
+### Failure
+While not encouraged, you can also forward a request to a catcher manually by
+using the Failure type. For instance, to forward to the catcher for 406 Not
+Acceptable, you would write:
+
+```rust
+#[get("/")]
+fn just_fail() -> Failure {
+    Failure(Status::NotAcceptable)
+}
+```


### PR DESCRIPTION
From comment here: https://github.com/SergioBenitez/Rocket/issues/222#issuecomment-285824274

I did two commits since the file didn't previously exists so you could still have a diff view of before and after. The markdown is my best guess at what the actual source for the docs looks like.