### PR TITLE
[POC] Allow ignoring unused items in query string.

### DIFF
--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -182,7 +182,8 @@ pub fn plugin_registrar(reg: &mut Registry) {
     reg.register_macro("errors", macros::errors);
 
     register_derives!(reg,
-        "derive_FromForm" => from_form_derive
+        "derive_FromForm" => from_form_derive,
+        "derive_FromFormIgnorable" => from_form_ignorable_derive
     );
 
     register_decorators!(reg,

--- a/codegen/tests/run-pass/derive_form.rs
+++ b/codegen/tests/run-pass/derive_form.rs
@@ -12,6 +12,12 @@ struct TodoTask {
     completed: bool
 }
 
+#[derive(Debug, PartialEq, FromFormIgnorable)]
+struct TodoTaskIgnorable {
+    description: String,
+    completed: bool
+}
+
 // TODO: Make deriving `FromForm` for this enum possible.
 #[derive(Debug, PartialEq)]
 enum FormOption {
@@ -90,6 +96,27 @@ fn main() {
     // Ensure _method isn't required.
     let task: Option<TodoTask> = parse("_method=patch&description=Hello&completed=off");
     assert_eq!(task, Some(TodoTask {
+        description: "Hello".to_string(),
+        completed: false
+    }));
+
+    // Same number of arguments: simple case.
+    let task: Option<TodoTaskIgnorable> = parse("description=Hello&completed=on");
+    assert_eq!(task, Some(TodoTaskIgnorable {
+        description: "Hello".to_string(),
+        completed: true
+    }));
+
+    // Argument in string but not in form.
+    let task: Option<TodoTaskIgnorable> = parse("other=a&description=Hello&completed=on");
+    assert_eq!(task, Some(TodoTaskIgnorable {
+        description: "Hello".to_string(),
+        completed: true
+    }));
+
+    // Ensure _method isn't required.
+    let task: Option<TodoTaskIgnorable> = parse("_method=patch&description=Hello&completed=off");
+    assert_eq!(task, Some(TodoTaskIgnorable {
         description: "Hello".to_string(),
         completed: false
     }));


### PR DESCRIPTION
Hi, i'd like something like this to resolve #242, so that the actual struct that implements FromForm trait doesn't have to include everything the request might have. It also works together with #246 to ensure that something without a key doesn't fail the whole request.

The current actual names and identitiers used in this patch is awful. Just put it here to hear what you think.