### PR TITLE
Update the request guard and error catcher docs to link to each other.

### DIFF
--- a/site/guide/requests.md
+++ b/site/guide/requests.md
@@ -346,11 +346,15 @@ for a complete illustration.
 
 ## Error Catchers
 
-When Rocket wants to return an error page to the client, Rocket invokes the
-_catcher_ for that error. A catcher is like a route, except it only handles
-errors. Catchers are declared via the `error` attribute, which takes a single
-integer corresponding to the HTTP status code to catch. For instance, to declare
-a catcher for **404** errors, you'd write:
+When Rocket wants to return an error response type to the client,
+either because the request failed to pass any of the [request guards]
+(#request-guards) on the handlers or because the matched handler 
+returned an `Err`, Rocket does this using error catchers.
+
+A _catcher_ is like a route, except it only handles errors. Catchers are
+declared via the `error` attribute, which takes a single integer corresponding
+to the HTTP status code to catch. For instance, to declare a catcher for **404**
+errors, you'd write:
 
 ```rust
 #[error(404)]

--- a/site/guide/responses.md
+++ b/site/guide/responses.md
@@ -66,8 +66,13 @@ fn json() -> content::JSON<&'static str> {
 
 Responders need not _always_ generate a response. Instead, they can return an
 `Err` with a given status code. When this happens, Rocket forwards the request
-to the error catcher for the given status code. If none exists, which can only
-happen when using custom status codes, Rocket uses the **500** error catcher.
+to the [error catcher](/guide/requests/#error-catchers) for the given status
+code. Just like a request handler, an error catcher will return a response by
+returning any type that has the `Responder` trait implemented. A common example
+would be to render a page displaying **400 Bad Request** to a user who sent a
+request with a malformed json body. In the case that no error catcher is
+configured to handle a specific http error code, which can only happen when
+using custom status codes, Rocket will use the **500** error catcher.
 
 ### Result
 


### PR DESCRIPTION
For reference, the old PR https://github.com/SergioBenitez/Rocket/pull/229