### PR TITLE
update uuid to ^0.5

### DIFF
--- a/contrib/Cargo.toml
+++ b/contrib/Cargo.toml
@@ -26,7 +26,7 @@ rocket = { version = "0.2.6", path = "../lib/" }
 log = "^0.3"
 
 # UUID dependencies.
-uuid = { version = "^0.4", optional = true }
+uuid = { version = "^0.5", optional = true }
 
 # Serialization and templating dependencies.
 serde = { version = "1.0", optional = true }

--- a/examples/uuid/Cargo.toml
+++ b/examples/uuid/Cargo.toml
@@ -6,7 +6,7 @@ workspace = "../../"
 [dependencies]
 rocket = { path = "../../lib" }
 rocket_codegen = { path = "../../codegen" }
-uuid = "^0.4"
+uuid = "^0.5"
 lazy_static = "^0.2"
 
 [dependencies.rocket_contrib]


### PR DESCRIPTION
uuid was updated for serde, but the 1.0 serde update in Rocket didn't include it.