### PR TITLE
support dots in form fields

### DIFF
--- a/codegen/src/utils/mod.rs
+++ b/codegen/src/utils/mod.rs
@@ -112,14 +112,14 @@ pub fn strip_ty_lifetimes(ty: P<Ty>) -> P<Ty> {
 
 // Lifted from Rust's lexer, except this takes a `char`, not an `Option<char>`.
 fn ident_start(c: char) -> bool {
-    (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_' ||
+    (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_' || c == '.' ||
     (c > '\x7f' && c.is_xid_start())
 }
 
 // Lifted from Rust's lexer, except this takes a `char`, not an `Option<char>`.
 fn ident_continue(c: char) -> bool {
     (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') ||
-    c == '_' || (c > '\x7f' && c.is_xid_continue())
+    c == '_' || c == '.' || (c > '\x7f' && c.is_xid_continue())
 }
 
 pub fn is_valid_ident<S: AsRef<str>>(s: S) -> bool {

--- a/codegen/tests/run-pass/derive_form.rs
+++ b/codegen/tests/run-pass/derive_form.rs
@@ -70,6 +70,12 @@ struct FieldNamedV<'r> {
     v: &'r RawStr,
 }
 
+#[derive(Debug, PartialEq, FromForm)]
+struct FieldNamedVDotV<'r> {
+    #[form(field = "v.v")]
+    v_dot_v: &'r RawStr,
+}
+
 fn parse<'f, T: FromForm<'f>>(string: &'f str, strict: bool) -> Option<T> {
     let mut items = FormItems::from(string);
     let result = T::from_form(items.by_ref(), strict);
@@ -176,6 +182,9 @@ fn main() {
 
     let manual: Option<FieldNamedV> = lenient("c=abcddef&v=abc&a=123");
     assert_eq!(manual, Some(FieldNamedV { v: "abc".into() }));
+
+    let manual: Option<FieldNamedVDotV> = lenient("v.v=123");
+    assert_eq!(manual, Some(FieldNamedVDotV { v_dot_v: "123".into() }));
 
     // Check default values (bool) with lenient parsing.
     let manual: Option<UnpresentCheckboxTwo> = lenient("something=hello");


### PR DESCRIPTION
For OpenID I got fields like `openid.ns`.

I have no idea if it's OK to just add `c == '.' ||` but it seems to work.