### PR TITLE
Implement Responder with 'r instead of 'static

### DIFF
--- a/lib/src/response/responder.rs
+++ b/lib/src/response/responder.rs
@@ -193,8 +193,8 @@ impl<'r> Responder<'r> for &'r str {
 
 /// Returns a response with Content-Type `text/plain` and a fixed-size body
 /// containing the string `self`. Always returns `Ok`.
-impl Responder<'static> for String {
-    fn respond_to(self, _: &Request) -> Result<Response<'static>, Status> {
+impl<'r> Responder<'r> for String {
+    fn respond_to(self, _: &Request) -> Result<Response<'r>, Status> {
         Response::build()
             .header(ContentType::Plain)
             .sized_body(Cursor::new(self))
@@ -203,15 +203,15 @@ impl Responder<'static> for String {
 }
 
 /// Returns a response with a sized body for the file. Always returns `Ok`.
-impl Responder<'static> for File {
-    fn respond_to(self, _: &Request) -> Result<Response<'static>, Status> {
+impl<'r> Responder<'r> for File {
+    fn respond_to(self, _: &Request) -> Result<Response<'r>, Status> {
         Response::build().streamed_body(self).ok()
     }
 }
 
 /// Returns an empty, default `Response`. Always returns `Ok`.
-impl Responder<'static> for () {
-    fn respond_to(self, _: &Request) -> Result<Response<'static>, Status> {
+impl<'r> Responder<'r> for () {
+    fn respond_to(self, _: &Request) -> Result<Response<'r>, Status> {
         Ok(Response::new())
     }
 }


### PR DESCRIPTION
For String, File, and ()

Consider the following minimal example:

```rust
#![feature(plugin, custom_derive)]
#![plugin(rocket_codegen)]
extern crate rocket;

use std::marker::PhantomData;

use rocket::State;
use rocket::response;

struct SomeState {}

pub struct Responder<'r, R> {
    responder: R,
    state: &'r SomeState,
    marker: PhantomData<response::Responder<'r>>,
}

impl<'r, R: response::Responder<'r>> Responder<'r, R> {
    fn new(responder: R, state: &'r SomeState) -> Self {
        Self {
            responder,
            state,
            marker: PhantomData,
        }
    }
}

impl<'r, R: response::Responder<'r>> response::Responder<'r> for Responder<'r, R> {
    fn respond_to(
        self,
        request: &rocket::Request,
    ) -> Result<response::Response<'r>, rocket::http::Status> {
        self.responder.respond_to(request)
    }
}

#[get("/string_state")]
fn string_state(state: State<SomeState>) -> Responder<String> {
    Responder::new("Testing".to_string(), state.inner())
}

#[get("/string")]
fn string() -> String {
    "Testing".to_string()
}

#[get("/str_route")]
fn str_route(state: State<SomeState>) -> Responder<&str> {
    Responder::new("Testing", state.inner())
}

#[get("/unit_state")]
fn unit_state(state: State<SomeState>) -> Responder<()> {
    Responder::new((), state.inner())
}

#[get("/unit")]
fn unit() -> () {
    ()
}

fn main() {
    rocket::Rocket::ignite()
        .manage(SomeState {})
        .mount(
            "/",
            routes![string_state, string, str_route, string, unit_state, unit],
        )
        .launch();
}
```
This results in a bunch of [lifetime errors](https://gist.github.com/lawliet89/7a6bfeff39918f3d32149393cf3627b0).

Looking at the following [snippet](https://gist.github.com/lawliet89/988d8367aaf4988f1263fb5d9ea6df5b#file-expand-rs-L43-L57) of `cargo expand`'s [full output](https://gist.github.com/lawliet89/988d8367aaf4988f1263fb5d9ea6df5b):

```rust
#[allow(unreachable_code)]
fn rocket_route_fn_string_state<'_b>(
    __req: &'_b ::rocket::Request,
    __data: ::rocket::Data,
) -> ::rocket::handler::Outcome<'_b> {
    #[allow(non_snake_case)]
    let rocket_param_state: State<SomeState> =
        match ::rocket::request::FromRequest::from_request(__req) {
            ::rocket::Outcome::Success(v) => v,
            ::rocket::Outcome::Forward(_) => return ::rocket::Outcome::Forward(__data),
            ::rocket::Outcome::Failure((code, _)) => return ::rocket::Outcome::Failure(code),
        };
    let responder = string_state(rocket_param_state);
    ::rocket::handler::Outcome::from(__req, responder)
}
```
I think this is because the compiler is trying to constraint the `'_b` in `__req: &'_b ::rocket::Request` to `'static` which won't work. If you notice, the route `str_route` did not produce any errors because the `Responder` impl for `&'a str` is for some generic `'a` and not `'static'.

Please let me know if I am mistaken and this could be fixed via other means.