### PR TITLE
update Fairing example to reflect doc's content

### DIFF
--- a/lib/src/fairing/mod.rs
+++ b/lib/src/fairing/mod.rs
@@ -283,7 +283,7 @@ pub trait Fairing: Send + Sync + 'static {
     ///     fn info(&self) -> Info {
     ///         Info {
     ///             name: "My Custom Fairing",
-    ///             kind: Kind::Attach | Kind::Launch | Kind::Response
+    ///             kind: Kind::Launch | Kind::Response
     ///         }
     ///     }
     /// }


### PR DESCRIPTION
Small tweak to align the example code with doc content that it "is both a launch and response fairing" on https://github.com/SergioBenitez/Rocket/blob/cdacda08964f25efb6b7c3d89eaa2cb08de68c24/lib/src/fairing/mod.rs#L275