### PR TITLE
Fix typo in documentation

### DIFF
--- a/lib/src/http/status.rs
+++ b/lib/src/http/status.rs
@@ -61,7 +61,7 @@ impl StatusClass {
 /// let ok = Status::Ok;
 /// ```
 ///
-/// A status of `400 Not Found` can be insantiated via the `NotFound` constant:
+/// A status of `404 Not Found` can be insantiated via the `NotFound` constant:
 ///
 /// ```rust
 /// use rocket::http::Status;


### PR DESCRIPTION
It's 404, not 400