### PR TITLE
Fix Tera error reporting

### DIFF
--- a/contrib/src/templates/tera_templates.rs
+++ b/contrib/src/templates/tera_templates.rs
@@ -41,8 +41,8 @@ impl Engine for Tera {
             Ok(string) => Some(string),
             Err(e) => {
                 error_!("Error rendering Tera template '{}'.", name);
-                for error in e.iter().skip(1) {
-                    error_!("{}.", error);
+                for error in e.iter() {
+                    error_!("{}", error);
                 }
 
                 None


### PR DESCRIPTION
Don't skip over the first error line as returned by Tera.