### PR TITLE
Allow access to template containers

### DIFF
--- a/contrib/src/lib.rs
+++ b/contrib/src/lib.rs
@@ -67,7 +67,7 @@ pub use msgpack::{MsgPack, MsgPackError};
 mod templates;
 
 #[cfg(feature = "templates")]
-pub use templates::Template;
+pub use templates::{Template, Context as TemplateContext};
 
 #[cfg(feature = "uuid")]
 mod uuid;

--- a/contrib/src/lib.rs
+++ b/contrib/src/lib.rs
@@ -64,10 +64,10 @@ pub mod msgpack;
 pub use msgpack::{MsgPack, MsgPackError};
 
 #[cfg(feature = "templates")]
-mod templates;
+pub mod templates;
 
 #[cfg(feature = "templates")]
-pub use templates::{Template, Context as TemplateContext};
+pub use templates::Template;
 
 #[cfg(feature = "uuid")]
 mod uuid;

--- a/contrib/src/templates/engine.rs
+++ b/contrib/src/templates/engine.rs
@@ -15,9 +15,9 @@ pub trait Engine: Send + Sync + 'static {
 
 pub struct Engines {
     #[cfg(feature = "tera_templates")]
-    tera: Tera,
+    pub tera: Tera,
     #[cfg(feature = "handlebars_templates")]
-    handlebars: Handlebars,
+    pub handlebars: Handlebars,
 }
 
 impl Engines {

--- a/contrib/src/templates/handlebars_templates.rs
+++ b/contrib/src/templates/handlebars_templates.rs
@@ -1,4 +1,4 @@
-extern crate handlebars;
+pub extern crate handlebars;
 
 use super::serde::Serialize;
 use super::{Engine, TemplateInfo};

--- a/contrib/src/templates/mod.rs
+++ b/contrib/src/templates/mod.rs
@@ -166,6 +166,7 @@ impl Template {
         })
     }
 
+    /// Returns the path to the template root directory
     pub fn root(config: &Config) -> PathBuf {
         let mut template_root = config.root().join(DEFAULT_TEMPLATE_DIR);
         match config.get_str("template_dir") {

--- a/contrib/src/templates/mod.rs
+++ b/contrib/src/templates/mod.rs
@@ -4,7 +4,7 @@ extern crate glob;
 
 #[cfg(feature = "tera_templates")] mod tera_templates;
 
-#[cfg(feature = "tera_templates")] 
+#[cfg(feature = "tera_templates")]
 pub use self::tera_templates::{tera, Tera};
 
 #[cfg(feature = "handlebars_templates")] mod handlebars_templates;

--- a/contrib/src/templates/mod.rs
+++ b/contrib/src/templates/mod.rs
@@ -3,7 +3,16 @@ extern crate serde_json;
 extern crate glob;
 
 #[cfg(feature = "tera_templates")] mod tera_templates;
+
+#[cfg(feature = "tera_templates")] 
+pub use self::tera_templates::{tera, Tera};
+
 #[cfg(feature = "handlebars_templates")] mod handlebars_templates;
+
+#[cfg(feature = "handlebars_templates")]
+pub use self::handlebars_templates::{handlebars, Handlebars};
+
+
 mod engine;
 mod context;
 
@@ -22,6 +31,8 @@ use rocket::response::{self, Content, Responder};
 use rocket::http::{ContentType, Status};
 
 pub use self::context::Context;
+
+
 
 const DEFAULT_TEMPLATE_DIR: &'static str = "templates";
 

--- a/contrib/src/templates/tera_templates.rs
+++ b/contrib/src/templates/tera_templates.rs
@@ -1,4 +1,4 @@
-extern crate tera;
+pub extern crate tera;
 
 use super::serde::Serialize;
 use super::{Engine, TemplateInfo};


### PR DESCRIPTION
and make it possible to interact with them before adding them to managed state.

Also reexports `tera` and `handlebars`.

See #64.