### PR TITLE
Protect against paths with spaces in scripts.

### DIFF
--- a/examples/todo/bootstrap.sh
+++ b/examples/todo/bootstrap.sh
@@ -3,9 +3,9 @@
 SCRIPT_PATH=$(cd "$(dirname "$0")" ; pwd -P)
 DATABASE_URL="${SCRIPT_PATH}/db/db.sql"
 
-pushd "$SCRIPT_PATH" > /dev/null
+pushd "${SCRIPT_PATH}" > /dev/null
   # clear an existing database
-  rm -f "$DATABASE_URL"
+  rm -f "${DATABASE_URL}"
 
   # install the diesel CLI tools if they're not installed
   if ! command -v diesel >/dev/null 2>&1; then
@@ -13,7 +13,7 @@ pushd "$SCRIPT_PATH" > /dev/null
   fi
 
   # create db/db.sql
-  diesel migration --database-url="$DATABASE_URL" run > /dev/null
+  diesel migration --database-url="${DATABASE_URL}" run > /dev/null
 popd > /dev/null
 
 echo "export DATABASE_URL=\"${DATABASE_URL}\""

--- a/examples/todo/bootstrap.sh
+++ b/examples/todo/bootstrap.sh
@@ -1,11 +1,11 @@
 #! /usr/bin/env bash
 
 SCRIPT_PATH=$(cd "$(dirname "$0")" ; pwd -P)
-DATABASE_URL=${SCRIPT_PATH}/db/db.sql
+DATABASE_URL="${SCRIPT_PATH}/db/db.sql"
 
-pushd $SCRIPT_PATH > /dev/null
+pushd "$SCRIPT_PATH" > /dev/null
   # clear an existing database
-  rm -f $DATABASE_URL
+  rm -f "$DATABASE_URL"
 
   # install the diesel CLI tools if they're not installed
   if ! command -v diesel >/dev/null 2>&1; then
@@ -13,7 +13,7 @@ pushd $SCRIPT_PATH > /dev/null
   fi
 
   # create db/db.sql
-  diesel migration --database-url=$DATABASE_URL run > /dev/null
+  diesel migration --database-url="$DATABASE_URL" run > /dev/null
 popd > /dev/null
 
-echo "export DATABASE_URL=$DATABASE_URL"
+echo "export DATABASE_URL=\"${DATABASE_URL}\""

--- a/scripts/mk-docs.sh
+++ b/scripts/mk-docs.sh
@@ -7,12 +7,12 @@ set -e
 
 # Brings in: ROOT_DIR, EXAMPLES_DIR, LIB_DIR, CODEGEN_DIR, CONTRIB_DIR, DOC_DIR
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source $SCRIPT_DIR/config.sh
+source "$SCRIPT_DIR/config.sh"
 
 function mk_doc() {
   local dir=$1
   local flag=$2
-  pushd $dir > /dev/null 2>&1
+  pushd "$dir" > /dev/null 2>&1
     echo ":: Documenting '${dir}'..."
     cargo doc --no-deps --all-features
   popd > /dev/null 2>&1
@@ -21,9 +21,9 @@ function mk_doc() {
 # We need to clean-up beforehand so we don't get all of the dependencies.
 cargo clean
 
-mk_doc $LIB_DIR
-mk_doc $CODEGEN_DIR
-mk_doc $CONTRIB_DIR
+mk_doc "$LIB_DIR"
+mk_doc "$CODEGEN_DIR"
+mk_doc "$CONTRIB_DIR"
 
 # Blank index, for redirection.
-touch ${DOC_DIR}/index.html
+touch "${DOC_DIR}/index.html"

--- a/scripts/mk-docs.sh
+++ b/scripts/mk-docs.sh
@@ -7,12 +7,12 @@ set -e
 
 # Brings in: ROOT_DIR, EXAMPLES_DIR, LIB_DIR, CODEGEN_DIR, CONTRIB_DIR, DOC_DIR
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source "$SCRIPT_DIR/config.sh"
+source "${SCRIPT_DIR}/config.sh"
 
 function mk_doc() {
   local dir=$1
   local flag=$2
-  pushd "$dir" > /dev/null 2>&1
+  pushd "${dir}" > /dev/null 2>&1
     echo ":: Documenting '${dir}'..."
     cargo doc --no-deps --all-features
   popd > /dev/null 2>&1
@@ -21,9 +21,9 @@ function mk_doc() {
 # We need to clean-up beforehand so we don't get all of the dependencies.
 cargo clean
 
-mk_doc "$LIB_DIR"
-mk_doc "$CODEGEN_DIR"
-mk_doc "$CONTRIB_DIR"
+mk_doc "${LIB_DIR}"
+mk_doc "${CODEGEN_DIR}"
+mk_doc "${CONTRIB_DIR}"
 
 # Blank index, for redirection.
 touch "${DOC_DIR}/index.html"

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -7,24 +7,24 @@ set -e
 
 # Brings in: ROOT_DIR, EXAMPLES_DIR, LIB_DIR, CODEGEN_DIR, CONTRIB_DIR, DOC_DIR
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source $SCRIPT_DIR/config.sh
+source "$SCRIPT_DIR/config.sh"
 
-if ! [ -z "$(git status --porcelain)" ]; then
-  echo "There are uncommited changes! Aborting."
-  exit 1
-fi
+#if ! [ -z "$(git status --porcelain)" ]; then
+#  echo "There are uncommited changes! Aborting."
+#  exit 1
+#fi
 
 # Ensure everything passes before trying to publish.
 echo ":::: Running test suite..."
 cargo clean
-${SCRIPT_DIR}/test.sh
+bash "${SCRIPT_DIR}/test.sh"
 
 # Temporarily remove the dependency on codegen from core so crates.io verifies.
-sed -i.bak 's/rocket_codegen.*//' ${LIB_DIR}/Cargo.toml
+sed -i.bak 's/rocket_codegen.*//' "${LIB_DIR}/Cargo.toml"
 
 # Publish all the things.
 for dir in "${LIB_DIR}" "${CODEGEN_DIR}" "${CONTRIB_DIR}"; do
-  pushd ${dir}
+  pushd "${dir}"
   echo ":::: Publishing '${dir}..."
   # We already checked things ourselves. Don't spend time reverifying.
   cargo publish --no-verify --allow-dirty
@@ -32,4 +32,4 @@ for dir in "${LIB_DIR}" "${CODEGEN_DIR}" "${CONTRIB_DIR}"; do
 done
 
 # Restore the original core Cargo.toml.
-mv ${LIB_DIR}/Cargo.toml.bak ${LIB_DIR}/Cargo.toml
+mv "${LIB_DIR}/Cargo.toml.bak" "${LIB_DIR}/Cargo.toml"

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -7,12 +7,12 @@ set -e
 
 # Brings in: ROOT_DIR, EXAMPLES_DIR, LIB_DIR, CODEGEN_DIR, CONTRIB_DIR, DOC_DIR
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source "$SCRIPT_DIR/config.sh"
+source "${SCRIPT_DIR}/config.sh"
 
-#if ! [ -z "$(git status --porcelain)" ]; then
-#  echo "There are uncommited changes! Aborting."
-#  exit 1
-#fi
+if ! [ -z "$(git status --porcelain)" ]; then
+  echo "There are uncommited changes! Aborting."
+  exit 1
+fi
 
 # Ensure everything passes before trying to publish.
 echo ":::: Running test suite..."

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -3,7 +3,7 @@ set -e
 
 # Brings in: ROOT_DIR, EXAMPLES_DIR, LIB_DIR, CODEGEN_DIR, CONTRIB_DIR, DOC_DIR
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source $SCRIPT_DIR/config.sh
+source "$SCRIPT_DIR/config.sh"
 
 # Add Cargo to PATH.
 export PATH=${HOME}/.cargo/bin:${PATH}
@@ -11,14 +11,14 @@ export PATH=${HOME}/.cargo/bin:${PATH}
 # Checks that the versions for Cargo projects $@ all match
 function check_versions_match() {
   local last_version=""
-  for dir in $@; do
+  for dir in "$@"; do
     local cargo_toml="${dir}/Cargo.toml"
     if ! [ -f "${cargo_toml}" ]; then
       echo "Cargo configuration file '${cargo_toml}' does not exist."
       exit 1
     fi
 
-    local version=$(grep version ${cargo_toml} | head -n 1 | cut -d' ' -f3)
+    local version=$(grep version "${cargo_toml}" | head -n 1 | cut -d' ' -f3)
     if [ -z "${last_version}" ]; then
       last_version="${version}"
     elif ! [ "${version}" = "${last_version}" ]; then
@@ -31,7 +31,7 @@ function check_versions_match() {
 # Ensures there are no tabs in any file.
 function ensure_tab_free() {
   local tab=$(printf '\t')
-  local matches=$(grep -I -R "${tab}" $ROOT_DIR | egrep -v '/target|/.git|LICENSE')
+  local matches=$(grep -I -R "${tab}" "$ROOT_DIR" | egrep -v '/target|/.git|LICENSE')
   if ! [ -z "${matches}" ]; then
     echo "Tab characters were found in the following:"
     echo "${matches}"
@@ -41,7 +41,7 @@ function ensure_tab_free() {
 
 # Ensures there are no files with trailing whitespace.
 function ensure_trailing_whitespace_free() {
-  local matches=$(egrep -I -R " +$" $ROOT_DIR | egrep -v "/target|/.git")
+  local matches=$(egrep -I -R " +$" "$ROOT_DIR" | egrep -v "/target|/.git")
   if ! [ -z "${matches}" ]; then
     echo "Trailing whitespace was found in the following:"
     echo "${matches}"
@@ -50,23 +50,22 @@ function ensure_trailing_whitespace_free() {
 }
 
 function bootstrap_examples() {
-  for file in ${EXAMPLES_DIR}/*; do
-    if [ -d "${file}" ]; then
-      bootstrap_script="${file}/bootstrap.sh"
-      if [ -x "${bootstrap_script}" ]; then
-        echo "    Bootstrapping ${file}..."
+  while read -r file;
+  do
+    bootstrap_script="${file}/bootstrap.sh"
+    if [ -x "${bootstrap_script}" ]; then
+      echo "    Bootstrapping ${file}..."
 
-        env_vars=$(${bootstrap_script})
-        bootstrap_result=$?
-        if [ $bootstrap_result -ne 0 ]; then
-          echo "    Running bootstrap script (${bootstrap_script}) failed!"
-          exit 1
-        else
-          eval $env_vars
-        fi
+      env_vars=$(bash "${bootstrap_script}")
+      bootstrap_result=$?
+      if [ $bootstrap_result -ne 0 ]; then
+        echo "    Running bootstrap script (${bootstrap_script}) failed!"
+        exit 1
+      else
+        eval $env_vars
       fi
     fi
-  done
+  done < <(find "${EXAMPLES_DIR}" -maxdepth 1 -type d -name "*")
 }
 
 echo ":: Ensuring all crate versions match..."
@@ -81,7 +80,7 @@ ensure_trailing_whitespace_free
 echo ":: Updating dependencies..."
 cargo update
 
-echo ":: Boostrapping examples..."
+echo ":: Bootstrapping examples..."
 bootstrap_examples
 
 echo ":: Building and testing libraries..."

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -3,7 +3,7 @@ set -e
 
 # Brings in: ROOT_DIR, EXAMPLES_DIR, LIB_DIR, CODEGEN_DIR, CONTRIB_DIR, DOC_DIR
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source "$SCRIPT_DIR/config.sh"
+source "${SCRIPT_DIR}/config.sh"
 
 # Add Cargo to PATH.
 export PATH=${HOME}/.cargo/bin:${PATH}
@@ -11,7 +11,7 @@ export PATH=${HOME}/.cargo/bin:${PATH}
 # Checks that the versions for Cargo projects $@ all match
 function check_versions_match() {
   local last_version=""
-  for dir in "$@"; do
+  for dir in "${@}"; do
     local cargo_toml="${dir}/Cargo.toml"
     if ! [ -f "${cargo_toml}" ]; then
       echo "Cargo configuration file '${cargo_toml}' does not exist."
@@ -31,7 +31,7 @@ function check_versions_match() {
 # Ensures there are no tabs in any file.
 function ensure_tab_free() {
   local tab=$(printf '\t')
-  local matches=$(grep -I -R "${tab}" "$ROOT_DIR" | egrep -v '/target|/.git|LICENSE')
+  local matches=$(grep -I -R "${tab}" "${ROOT_DIR}" | egrep -v '/target|/.git|LICENSE')
   if ! [ -z "${matches}" ]; then
     echo "Tab characters were found in the following:"
     echo "${matches}"
@@ -41,7 +41,7 @@ function ensure_tab_free() {
 
 # Ensures there are no files with trailing whitespace.
 function ensure_trailing_whitespace_free() {
-  local matches=$(egrep -I -R " +$" "$ROOT_DIR" | egrep -v "/target|/.git")
+  local matches=$(egrep -I -R " +$" "${ROOT_DIR}" | egrep -v "/target|/.git")
   if ! [ -z "${matches}" ]; then
     echo "Trailing whitespace was found in the following:"
     echo "${matches}"
@@ -50,8 +50,7 @@ function ensure_trailing_whitespace_free() {
 }
 
 function bootstrap_examples() {
-  while read -r file;
-  do
+  while read -r file; do
     bootstrap_script="${file}/bootstrap.sh"
     if [ -x "${bootstrap_script}" ]; then
       echo "    Bootstrapping ${file}..."
@@ -65,7 +64,7 @@ function bootstrap_examples() {
         eval $env_vars
       fi
     fi
-  done < <(find "${EXAMPLES_DIR}" -maxdepth 1 -type d -name "*")
+  done < <(find "${EXAMPLES_DIR}" -maxdepth 1 -type d)
 }
 
 echo ":: Ensuring all crate versions match..."


### PR DESCRIPTION
These changes enable the scripts to handle paths that have spaces. The errors are mostly to do with missing double-quoting letting accidental word-splitting occur. You can see the errors before this patch with the following:
```
mkdir ~/dir\ with\ spaces && cd ~/dir\ with\ spaces
git clone https://github.com/SergioBenitez/Rocket
cd Rocket/scripts
./test.sh # errors out
./publish.sh # errors out
./mk-docs.sh # errors out
```

After merging these changes, the above should run successfully without error. The only weird change is inside the `bootstrap_examples()` Bash function in `test.sh`; it has a for loop written a strange way. This was needed so that the environment variables set by the call to `eval $env_vars` remain in scope for the call to `cargo test` later when they are needed. The alternative loops that can also handle paths with spaces require a pipe (`find "${EXAMPLES_DIR}" -maxdepth 1 -type d -name "*" | while read -r file do; .... done`) which causes a subshell, losing the exported environment variables in a different scope. The loop as implemented stores the `find ...` output in a file and just redirects it instead of piping.