### PR TITLE
Reference the Birthday problem (ID collision in Pastebin example)

### DIFF
--- a/site/guide/pastebin.md
+++ b/site/guide/pastebin.md
@@ -144,10 +144,9 @@ pub struct PasteID<'a>(Cow<'a, str>);
 
 impl<'a> PasteID<'a> {
     /// Generate a _probably_ unique ID with `size` characters. For readability,
-    /// the characters used are from the sets [0-9], [A-Z], [a-z]. The
-    /// probability of a collision depends on the value of `size` and
-    /// the amount of IDs generated. If you want to learn more, this is known as
-    /// the birthday problem: https://en.wikipedia.org/wiki/Birthday_problem
+    /// the characters used are from the sets [0-9], [A-Z], [a-z].
+    /// The probability of a collision depends on the value of `size` and
+    /// the number of IDs generated thus far.
     pub fn new(size: usize) -> PasteID<'static> {
         let mut id = String::with_capacity(size);
         let mut rng = rand::thread_rng();

--- a/site/guide/pastebin.md
+++ b/site/guide/pastebin.md
@@ -145,8 +145,9 @@ pub struct PasteID<'a>(Cow<'a, str>);
 impl<'a> PasteID<'a> {
     /// Generate a _probably_ unique ID with `size` characters. For readability,
     /// the characters used are from the sets [0-9], [A-Z], [a-z]. The
-    /// probability of a collision depends on the value of `size`. In
-    /// particular, the probability of a collision is 1/62^(size).
+    /// probability of a collision depends on the value of `size` and
+    /// the amount of IDs generated. If you want to learn more, this is known as
+    /// the birthday problem: https://en.wikipedia.org/wiki/Birthday_problem
     pub fn new(size: usize) -> PasteID<'static> {
         let mut id = String::with_capacity(size);
         let mut rng = rand::thread_rng();


### PR DESCRIPTION
I think that the probability of some collision is more important than the chance of two particular IDs colliding. However the birthday paradox is too complicated to explain in a short comment, so I referred to Wikipedia instead.

I don't believe that it is necessary to refer to the birthday problem at all, only if you believe that talking about the probability of collision is important.