### PR TITLE
router: avoid sorting routes on add

### DIFF
--- a/lib/src/router/mod.rs
+++ b/lib/src/router/mod.rs
@@ -25,10 +25,8 @@ impl Router {
     pub fn add(&mut self, route: Route) {
         let selector = route.method;
         let entries = self.routes.entry(selector).or_insert_with(|| vec![]);
-        // TODO: We really just want an insertion at the correct spot here,
-        // instead of pushing to the end and _then_ sorting.
-        entries.push(route);
-        entries.sort_by(|a, b| a.rank.cmp(&b.rank));
+        let insert_index = entries.binary_search_by_key(&route.rank, |r| r.rank).unwrap_or_else(|x| x);
+        entries.insert(insert_index, route);
     }
 
     pub fn route<'b>(&'b self, req: &Request) -> Vec<&'b Route> {


### PR DESCRIPTION
Resolves the TODO in the comment :)

It would probably be nicer to do the whole thing with a data structure suited for a priority queue like a BinaryHeap, which should improve insertion efficiency as well; I've started doing this in 7424729dddbaa8bda0551530e239cb82a1f050c1 but the tests aren't passing and I have yet to work out why. It also requires a fair bit of extra code.