### PR TITLE
Improve Debug impl for Config by using `debug_struct()`

### DIFF
--- a/lib/src/config/config.rs
+++ b/lib/src/config/config.rs
@@ -791,15 +791,18 @@ impl Config {
 
 impl fmt::Debug for Config {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Config[{}] {{ address: {}, port: {}, workers: {}, log: {:?}",
-               self.environment, self.address, self.port, self.workers,
-               self.log_level)?;
+        let mut s = f.debug_struct("Config");
+        s.field("environment", &self.environment);
+        s.field("address", &self.address);
+        s.field("port", &self.port);
+        s.field("workers", &self.workers);
+        s.field("log_level", &self.log_level);
 
         for (key, value) in self.extras() {
-            write!(f, ", {}: {}", key, value)?;
+            s.field(key, &value);
         }
 
-        write!(f, " }}")
+        s.finish()
     }
 }
 


### PR DESCRIPTION
Hi there :crab: 

This makes it possible to debug-output `Config` with `"{:#?}"`. Please see the commit message for a full explanation.

While looking through all manual `Debug` impls in Rocket, I've found something questionable in the impl for `Outcome`: it doesn't output the values at all -- it only outputs the variant name. Is there a reason for that? If not, a `#[derive(Debug)]` should be fine. I could change this, too, if you want.