### PR TITLE
indent comments to prevent being commonmark code blocks

### DIFF
--- a/lib/src/fairing/mod.rs
+++ b/lib/src/fairing/mod.rs
@@ -168,19 +168,19 @@ pub use self::info_kind::{Info, Kind};
 ///
 ///   1. Assign a name to the `Fairing`.
 ///
-///     This is the `name` field, which can be any arbitrary string. Name your
-///     fairing something illustrative. The name will be logged during the
-///     application's launch procedures.
+///      This is the `name` field, which can be any arbitrary string. Name your
+///      fairing something illustrative. The name will be logged during the
+///      application's launch procedures.
 ///
 ///   2. Determine which callbacks to actually issue on the `Fairing`.
 ///
-///     This is the `kind` field of type
-///     [`Kind`](/rocket/fairing/struct.Kind.html). This field is a bitset that
-///     represents the kinds of callbacks the fairing wishes to receive. Rocket
-///     will only invoke the callbacks that are flagged in this set. `Kind`
-///     structures can be `or`d together to represent any combination of kinds
-///     of callbacks. For instance, to request launch and response callbacks,
-///     return a `kind` field with the value `Kind::Launch | Kind::Response`.
+///      This is the `kind` field of type
+///      [`Kind`](/rocket/fairing/struct.Kind.html). This field is a bitset that
+///      represents the kinds of callbacks the fairing wishes to receive. Rocket
+///      will only invoke the callbacks that are flagged in this set. `Kind`
+///      structures can be `or`d together to represent any combination of kinds
+///      of callbacks. For instance, to request launch and response callbacks,
+///      return a `kind` field with the value `Kind::Launch | Kind::Response`.
 ///
 /// [`info`]: /rocket/fairing/trait.Fairing.html#tymethod.info
 ///

--- a/lib/src/local/mod.rs
+++ b/lib/src/local/mod.rs
@@ -13,40 +13,40 @@
 //!
 //!   1. Construct a `Rocket` instance that represents the application.
 //!
-//!     ```rust
-//!     let rocket = rocket::ignite();
-//!     # let _ = rocket;
-//!     ```
+//!      ```rust
+//!      let rocket = rocket::ignite();
+//!      # let _ = rocket;
+//!      ```
 //!
 //!   2. Construct a `Client` using the `Rocket` instance.
 //!
-//!     ```rust
-//!     # use rocket::local::Client;
-//!     # let rocket = rocket::ignite();
-//!     let client = Client::new(rocket).expect("valid rocket instance");
-//!     # let _ = client;
-//!     ```
+//!      ```rust
+//!      # use rocket::local::Client;
+//!      # let rocket = rocket::ignite();
+//!      let client = Client::new(rocket).expect("valid rocket instance");
+//!      # let _ = client;
+//!      ```
 //!
 //!   3. Construct requests using the `Client` instance.
 //!
-//!     ```rust
-//!     # use rocket::local::Client;
-//!     # let rocket = rocket::ignite();
-//!     # let client = Client::new(rocket).unwrap();
-//!     let req = client.get("/");
-//!     # let _ = req;
-//!     ```
+//!      ```rust
+//!      # use rocket::local::Client;
+//!      # let rocket = rocket::ignite();
+//!      # let client = Client::new(rocket).unwrap();
+//!      let req = client.get("/");
+//!      # let _ = req;
+//!      ```
 //!
 //!   3. Dispatch the request to retrieve the response.
 //!
-//!     ```rust
-//!     # use rocket::local::Client;
-//!     # let rocket = rocket::ignite();
-//!     # let client = Client::new(rocket).unwrap();
-//!     # let req = client.get("/");
-//!     let response = req.dispatch();
-//!     # let _ = response;
-//!     ```
+//!      ```rust
+//!      # use rocket::local::Client;
+//!      # let rocket = rocket::ignite();
+//!      # let client = Client::new(rocket).unwrap();
+//!      # let req = client.get("/");
+//!      let response = req.dispatch();
+//!      # let _ = response;
+//!      ```
 //!
 //! All together and in idiomatic fashion, this might look like:
 //!

--- a/lib/src/local/request.rs
+++ b/lib/src/local/request.rs
@@ -41,21 +41,21 @@ use http::{Header, Cookie};
 ///
 ///   1. [`dispatch`]
 ///
-///     This method should always be preferred. The `LocalRequest` is consumed
-///     and a response is returned.
+///      This method should always be preferred. The `LocalRequest` is consumed
+///      and a response is returned.
 ///
 ///   2. [`cloned_dispatch`]
 ///
-///     This method should be used when one `LocalRequest` will be dispatched
-///     many times. This method clones the request and dispatches the clone, so
-///     the request _is not_ consumed and can be reused.
+///      This method should be used when one `LocalRequest` will be dispatched
+///      many times. This method clones the request and dispatches the clone, so
+///      the request _is not_ consumed and can be reused.
 ///
 ///   3. [`mut_dispatch`]
 ///
-///     This method should _only_ be used when either it is known that the
-///     application will not modify the request, or it is desired to see
-///     modifications to the request. No cloning occurs, and the request is not
-///     consumed.
+///      This method should _only_ be used when either it is known that the
+///      application will not modify the request, or it is desired to see
+///      modifications to the request. No cloning occurs, and the request is not
+///      consumed.
 ///
 /// [`Client`]: /rocket/local/struct.Client.html
 /// [`header`]: #method.header


### PR DESCRIPTION
When running rustdoc with `--enable-commonmark`, it found a few paragraphs that were indented off-margin from the numbered list they were within, and treated them as code blocks instead. This PR shifts them all over by one space to align with the text in the list item, which turns them back into regular paragraphs.