### PR TITLE
remove reliance on lookup_host

### DIFF
--- a/lib/src/config/config.rs
+++ b/lib/src/config/config.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::net::{IpAddr, lookup_host};
+use std::net::ToSocketAddrs;
 use std::path::{Path, PathBuf};
 use std::convert::AsRef;
 use std::fmt;
@@ -344,7 +344,7 @@ impl Config {
     /// ```
     pub fn set_address<A: Into<String>>(&mut self, address: A) -> Result<()> {
         let address = address.into();
-        if address.parse::<IpAddr>().is_err() && lookup_host(&address).is_err() {
+        if (address.as_ref(), 0u16).to_socket_addrs().is_err() {
             return Err(self.bad_type("address", "string", "a valid hostname or IP"));
         }
 

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -2,7 +2,6 @@
 #![feature(conservative_impl_trait)]
 #![feature(drop_types_in_const)]
 #![feature(const_fn)]
-#![feature(lookup_host)]
 #![feature(plugin)]
 #![feature(never_type)]
 #![feature(try_trait)]


### PR DESCRIPTION
`lookup_host` doesn't look like being stabilised.  

`ToSocketAddrs` is kinda hokey - we have to provide a dummy port number to use it - but it's stable and does exactly the job that's wanted.