### PR TITLE
Remove incorrect section of RawStr docs

### DIFF
--- a/lib/src/http/raw_str.rs
+++ b/lib/src/http/raw_str.rs
@@ -105,10 +105,6 @@ impl RawStr {
     /// percent-encoded byte sequences will be replaced � U+FFFD, the
     /// replacement character.
     ///
-    /// # Errors
-    ///
-    /// Returns an `Err` if the percent encoded values are not valid UTF-8.
-    ///
     /// # Example
     ///
     /// With a valid string:


### PR DESCRIPTION
This was probably a copy&pasta bug from `percent_decode()`.