### PR TITLE
Fix errors![...] macro

### DIFF
--- a/codegen/src/macros/mod.rs
+++ b/codegen/src/macros/mod.rs
@@ -56,6 +56,6 @@ pub fn routes(ecx: &mut ExtCtxt, sp: Span, args: &[TokenTree])
 pub fn errors(ecx: &mut ExtCtxt, sp: Span, args: &[TokenTree])
         -> Box<MacResult + 'static> {
     prefixing_vec_macro(CATCH_STRUCT_PREFIX, |ecx, path| {
-        quote_expr!(ecx, rocket::Catcher::from(&$path))
+        quote_expr!(ecx, ::rocket::Catcher::from(&$path))
     }, ecx, sp, args)
 }


### PR DESCRIPTION
In most applications, Rocket "lives" in the parent module. But sometimes, it
might be useful to encapsulate all Rocket code in a distict module like
`my_crate::http`.

In that case, rocket needs to be addressed with a absolute path instead of a
relative path. While the routes![...] macro does this correct, the errors![...]
macro did not.

This commit fixes the errors![...] macro.