### PR TITLE
Added closure to configure template engines

### DIFF
--- a/contrib/src/lib.rs
+++ b/contrib/src/lib.rs
@@ -48,6 +48,12 @@ extern crate serde;
 #[cfg_attr(feature = "json", macro_reexport(json_internal))]
 extern crate serde_json;
 
+#[cfg(feature = "handlebars_templates")]
+pub extern crate handlebars;
+
+#[cfg(feature = "tera_templates")]
+pub extern crate tera;
+
 #[cfg(feature = "json")]
 #[cfg_attr(feature = "json", macro_use)]
 #[doc(hidden)]
@@ -74,9 +80,3 @@ mod uuid;
 
 #[cfg(feature = "uuid")]
 pub use uuid::{UUID, UuidParseError};
-
-#[cfg(feature = "handlebars_templates")]
-pub extern crate handlebars;
-
-#[cfg(feature = "tera_templates")]
-pub extern crate tera;

--- a/contrib/src/lib.rs
+++ b/contrib/src/lib.rs
@@ -74,3 +74,9 @@ mod uuid;
 
 #[cfg(feature = "uuid")]
 pub use uuid::{UUID, UuidParseError};
+
+#[cfg(feature = "handlebars_templates")]
+pub extern crate handlebars;
+
+#[cfg(feature = "tera_templates")]
+pub extern crate tera;

--- a/contrib/src/templates/context.rs
+++ b/contrib/src/templates/context.rs
@@ -49,10 +49,6 @@ impl Context {
             Context { root, templates, engines }
         })
     }
-
-    pub fn engines_mut(&mut self) -> &mut Engines {
-        &mut self.engines
-    }
 }
 
 /// Removes the file path's extension or does nothing if there is none.

--- a/contrib/src/templates/context.rs
+++ b/contrib/src/templates/context.rs
@@ -49,6 +49,10 @@ impl Context {
             Context { root, templates, engines }
         })
     }
+
+    pub fn engines_mut(&mut self) -> &mut Engines {
+        &mut self.engines
+    }
 }
 
 /// Removes the file path's extension or does nothing if there is none.

--- a/contrib/src/templates/engine.rs
+++ b/contrib/src/templates/engine.rs
@@ -15,9 +15,9 @@ pub trait Engine: Send + Sync + 'static {
 
 pub struct Engines {
     #[cfg(feature = "tera_templates")]
-    tera: Tera,
+    pub tera: Tera,
     #[cfg(feature = "handlebars_templates")]
-    handlebars: Handlebars,
+    pub handlebars: Handlebars,
 }
 
 impl Engines {
@@ -68,15 +68,5 @@ impl Engines {
         }
 
         None
-    }
-
-    #[cfg(feature = "handlebars_templates")]
-    pub fn handlebars(&mut self) -> &mut Handlebars {
-        &mut self.handlebars
-    }
-
-    #[cfg(feature = "tera_templates")]
-    pub fn tera(&mut self) -> &mut Tera {
-        &mut self.tera
     }
 }

--- a/contrib/src/templates/engine.rs
+++ b/contrib/src/templates/engine.rs
@@ -69,4 +69,14 @@ impl Engines {
 
         None
     }
+
+    #[cfg(feature = "handlebars_templates")]
+    pub fn handlebars(&mut self) -> &mut Handlebars {
+        &mut self.handlebars
+    }
+
+    #[cfg(feature = "tera_templates")]
+    pub fn tera(&mut self) -> &mut Tera {
+        &mut self.tera
+    }
 }

--- a/contrib/src/templates/mod.rs
+++ b/contrib/src/templates/mod.rs
@@ -257,11 +257,13 @@ impl Template {
     /// # #[allow(unused_variables)]
     /// let template = Template::show("templates/", "index", context);
     #[inline]
-    pub fn show<P, S, C>(root: P, name: S, context: C) -> Option<String>
-        where P: AsRef<Path>, S: Into<Cow<'static, str>>, C: Serialize
+    pub fn show<P, S, C, F>(root: P, name: S, context: C, config_closure: F) -> Option<String>
+        where P: AsRef<Path>, S: Into<Cow<'static, str>>, C: Serialize,
+              F: Fn(&mut Engines) + Send + Sync + 'static
     {
         let root = root.as_ref().to_path_buf();
-        Context::initialize(root).and_then(|ctxt| {
+        Context::initialize(root).and_then(|mut ctxt| {
+            config_closure(&mut ctxt.engines);
             Template::render(name, context).finalize(&ctxt).ok().map(|v| v.0)
         })
     }

--- a/contrib/src/templates/mod.rs
+++ b/contrib/src/templates/mod.rs
@@ -158,9 +158,37 @@ impl Template {
     /// }
     /// ```
     pub fn fairing() -> impl Fairing {
-        AdHoc::on_attach(|rocket| {
-            let mut template_root = rocket.config()
-                .root_relative(DEFAULT_TEMPLATE_DIR);
+        Template::config_and_fairing(|_| {})
+    }
+
+    /// Returns a fairing that intializes and maintains templating state.
+    ///
+    /// This method allows you to configure the template context via the
+    /// closure.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// extern crate rocket;
+    /// extern crate rocket_contrib;
+    ///
+    /// use rocket_contrib::Template;
+    ///
+    /// fn main() {
+    ///     rocket::ignite()
+    ///         // ...
+    ///         .attach(Template::config_and_fairing(|ctxt| {
+    ///             // ctxt.engines_mut().handlebars().register_helper ...
+    ///         }))
+    ///         // ...
+    ///     # ;
+    /// }
+    /// ```
+    pub fn config_and_fairing<F>(f: F) -> impl Fairing
+        where F: Fn(&mut Context) + Send + Sync + 'static
+    {
+        AdHoc::on_attach(move |rocket| {
+            let mut template_root = rocket.config().root_relative(DEFAULT_TEMPLATE_DIR);
 
             match rocket.config().get_str("template_dir") {
                 Ok(dir) => template_root = rocket.config().root_relative(dir),

--- a/contrib/src/templates/mod.rs
+++ b/contrib/src/templates/mod.rs
@@ -241,6 +241,9 @@ impl Template {
     /// relative, in which case it is relative to the current working directory,
     /// or absolute.
     ///
+    /// This function accepts a closure for user to configure underlying template
+    /// engine, for example, adding your custom helper.
+    ///
     /// Returns `Some` if the template could be rendered. Otherwise, returns
     /// `None`. If rendering fails, error output is printed to the console.
     ///
@@ -255,7 +258,7 @@ impl Template {
     ///
     /// # context.insert("test", "test");
     /// # #[allow(unused_variables)]
-    /// let template = Template::show("templates/", "index", context);
+    /// let template = Template::show("templates/", "index", context, |_| {});
     #[inline]
     pub fn show<P, S, C, F>(root: P, name: S, context: C, config_closure: F) -> Option<String>
         where P: AsRef<Path>, S: Into<Cow<'static, str>>, C: Serialize,

--- a/contrib/tests/templates.rs
+++ b/contrib/tests/templates.rs
@@ -26,11 +26,11 @@ mod tera_tests {
         map.insert("content", "<script />");
 
         // Test with a txt file, which shouldn't escape.
-        let template = Template::show(template_root(), "tera/txt_test", &map);
+        let template = Template::show(template_root(), "tera/txt_test", &map, |_| {});
         assert_eq!(template, Some(UNESCAPED_EXPECTED.into()));
 
         // Now with an HTML file, which should.
-        let template = Template::show(template_root(), "tera/html_test", &map);
+        let template = Template::show(template_root(), "tera/html_test", &map, |_| {});
         assert_eq!(template, Some(ESCAPED_EXPECTED.into()));
     }
 }
@@ -51,8 +51,7 @@ mod handlebars_tests {
         map.insert("content", "<script /> hi");
 
         // Test with a txt file, which shouldn't escape.
-        let template = Template::show(template_root(), "hbs/test", &map);
+        let template = Template::show(template_root(), "hbs/test", &map, |_| {});
         assert_eq!(template, Some(EXPECTED.into()));
     }
 }
-

--- a/examples/cookies/src/tests.rs
+++ b/examples/cookies/src/tests.rs
@@ -39,11 +39,11 @@ fn test_body(optional_cookie: Option<Cookie<'static>>, expected_body: String) {
 fn test_index() {
     // Render the template with an empty context.
     let mut context: HashMap<&str, &str> = HashMap::new();
-    let template = Template::show(TEMPLATE_ROOT, "index", &context).unwrap();
+    let template = Template::show(TEMPLATE_ROOT, "index", &context, |_| {}).unwrap();
     test_body(None, template);
 
     // Render the template with a context that contains the message.
     context.insert("message", "Hello from Rocket!");
-    let template = Template::show(TEMPLATE_ROOT, "index", &context).unwrap();
+    let template = Template::show(TEMPLATE_ROOT, "index", &context, |_| {}).unwrap();
     test_body(Some(Cookie::new("message", "Hello from Rocket!")), template);
 }

--- a/examples/handlebars_templates/src/main.rs
+++ b/examples/handlebars_templates/src/main.rs
@@ -45,17 +45,17 @@ fn rocket() -> rocket::Rocket {
         .mount("/", routes![index, get])
         .attach(Template::custom(|engines| {
             engines.handlebars.register_helper(
-                "test", Box::new(|h: &Helper,
-                                 _: &Handlebars,
-                                 rc: &mut RenderContext| -> Result<(), RenderError> {
-                                     if let Some(p0) = h.param(0) {
-                                         rc.writer.write(p0.value()
-                                                         .render()
-                                                         .into_bytes()
-                                                         .as_ref())?;
-                                     }
-                                     Ok(())
-                                 }));
+                "echo", Box::new(|h: &Helper,
+                                  _: &Handlebars,
+                                  rc: &mut RenderContext| -> Result<(), RenderError> {
+                                      if let Some(p0) = h.param(0) {
+                                          rc.writer.write(p0.value()
+                                                          .render()
+                                                          .into_bytes()
+                                                          .as_ref())?;
+                                      }
+                                      Ok(())
+                                  }));
 
         }))
         .catch(errors![not_found])

--- a/examples/handlebars_templates/src/main.rs
+++ b/examples/handlebars_templates/src/main.rs
@@ -10,6 +10,7 @@ extern crate rocket;
 use rocket::Request;
 use rocket::response::Redirect;
 use rocket_contrib::Template;
+use rocket_contrib::handlebars::{Helper, Handlebars, RenderContext, RenderError};
 
 #[derive(Serialize)]
 struct TemplateContext {
@@ -43,6 +44,27 @@ fn rocket() -> rocket::Rocket {
     rocket::ignite()
         .mount("/", routes![index, get])
         .attach(Template::fairing())
+        .catch(errors![not_found])
+}
+
+// when you want to register handlebars helpers
+#[allow(dead_code)]
+fn rocket_with_hbs_helper() -> rocket::Rocket {
+    rocket::ignite()
+        .mount("/", routes![index, get])
+        .attach(Template::config_and_fairing(|ctxt| {
+            ctxt.engines_mut()
+                .handlebars()
+                .register_helper("test",
+                                 Box::new(|_: &Helper,
+                                           _: &Handlebars,
+                                           _: &mut RenderContext|
+                                           -> Result<(), RenderError> {
+                                              // do nothing
+                                              Ok(())
+                                          }));
+
+        }))
         .catch(errors![not_found])
 }
 

--- a/examples/handlebars_templates/templates/index.html.hbs
+++ b/examples/handlebars_templates/templates/index.html.hbs
@@ -14,6 +14,6 @@
     </ul>
 
     <p>Try going to <a href="/hello/YourName">/hello/YourName</a></p>
-    <p>You can define custom helper like <b>{{test "this"}}</b>.</p>
+    <p>You can define custom helper like <b>{{echo "this"}}</b>.</p>
   </body>
 </html>

--- a/examples/handlebars_templates/templates/index.html.hbs
+++ b/examples/handlebars_templates/templates/index.html.hbs
@@ -14,5 +14,6 @@
     </ul>
 
     <p>Try going to <a href="/hello/YourName">/hello/YourName</a></p>
+    <p>You can define custom helper like <b>{{test "this"}}</b>.</p>
   </body>
 </html>


### PR DESCRIPTION
Currently there is no way to access template engine, for example, adding custom helper to handlebars.

This patch added a closure to `Template::fairing` which allows a closure to configure those engines.