### PR TITLE
Make query string parsing non-strict by default

### DIFF
--- a/codegen/src/decorators/route.rs
+++ b/codegen/src/decorators/route.rs
@@ -68,7 +68,7 @@ impl RouteParams {
             #[allow(non_snake_case)]
             let $name: $ty = {
                 let mut items = ::rocket::request::FormItems::from($form_string);
-                let form = ::rocket::request::FromForm::from_form(items.by_ref(), true);
+                let form = ::rocket::request::FromForm::from_form(items.by_ref(), false);
                 #[allow(unreachable_patterns)]
                 let obj = match form {
                     Ok(v) => v,

--- a/examples/query_params/src/tests.rs
+++ b/examples/query_params/src/tests.rs
@@ -52,6 +52,6 @@ fn non_existent_params() {
     });
 
     run_test!("?age=10&name=john&complete=true", |response: Response| {
-        assert_eq!(response.status(), Status::NotFound);
+        assert_eq!(response.status(), Status::Ok);
     });
 }


### PR DESCRIPTION
I'd like to suggest this change which makes query string parsing non-strict by default. Query strings often contain garbage data and having erroneous parameters we don't care about in it should not factor in on whether the route matches or not.

For example, if you are implementing a GET webhook, the webhook developer might add a new parameter to the payload, which they can do without notice since it isn't a breaking change to the API, and this would break our application because the route would no longer match, even though we can still parse the data just fine.

Or, a Facebook share button might attach a `share=facebook_newsfeed` parameter to the URL to indicate where the user came from. In the current default behavior, they would get a 404 if the route took query parameters.

Finally, no other web framework to my knowledge rejects a request for having a super set of the expected query parameters. This behavior is very confusing for developers coming over from Rails or Node, etc. If someone has a good use case for making query parameters strict on the route, we should provide the option to do so, but the default should be non-strict to match more in-line with what web developers expect.