### PR TITLE
Add a default catcher for Gateway Timeout.

### DIFF
--- a/lib/src/catcher.rs
+++ b/lib/src/catcher.rs
@@ -239,9 +239,8 @@ pub mod defaults {
                 method, or it lacks the ability to fulfill the request.", handle_501,
             503, "Service Unavailable", "The server is currently unavailable.",
                 handle_503,
-            504, "Gateway Timeout", "The server didn't receive a timely response
-                from another server.",
-                handle_504,
+            504, "Gateway Timeout", "The server did not receive a timely
+                response from an upstream server.", handle_504,
             510, "Not Extended", "Further extensions to the request are required for
                 the server to fulfill it.", handle_510
         }

--- a/lib/src/catcher.rs
+++ b/lib/src/catcher.rs
@@ -239,6 +239,9 @@ pub mod defaults {
                 method, or it lacks the ability to fulfill the request.", handle_501,
             503, "Service Unavailable", "The server is currently unavailable.",
                 handle_503,
+            504, "Gateway Timeout", "The server didn't receive a timely response
+                from another server.",
+                handle_504,
             510, "Not Extended", "Further extensions to the request are required for
                 the server to fulfill it.", handle_510
         }


### PR DESCRIPTION
Gateway Timeout is an useful response, when the server fails to receive a timely response from a backend server (for example, an LDAP server for user authentication). At the moment Rocket doesn't provide a default catcher for it, although it could.