### PR TITLE
unprovided "?" query should act like empty query

### DIFF
--- a/codegen/src/decorators/route.rs
+++ b/codegen/src/decorators/route.rs
@@ -114,12 +114,7 @@ impl RouteParams {
 
     fn generate_query_statement(&self, ecx: &ExtCtxt) -> Option<Stmt> {
         let param = self.query_param.as_ref();
-        let expr = quote_expr!(ecx,
-           match __req.uri().query() {
-               Some(query) => query,
-               None => return ::rocket::Outcome::Forward(__data)
-           }
-        );
+        let expr = quote_expr!(ecx, __req.uri().query());
 
         self.gen_form(ecx, param, expr)
     }

--- a/lib/src/http/uri/uri.rs
+++ b/lib/src/http/uri/uri.rs
@@ -156,8 +156,7 @@ impl<'a> Uri<'a> {
         &self.uri[i..j]
     }
 
-    /// Returns the query part of this URI without the question mark, if there is
-    /// any.
+    /// Returns the query part of this URI without the question mark.
     ///
     /// ### Examples
     ///
@@ -167,7 +166,7 @@ impl<'a> Uri<'a> {
     /// use rocket::http::uri::Uri;
     ///
     /// let uri = Uri::new("/a/b/c?alphabet=true");
-    /// assert_eq!(uri.query(), Some("alphabet=true"));
+    /// assert_eq!(uri.query(), "alphabet=true");
     /// ```
     ///
     /// A URI without the query part:
@@ -176,11 +175,37 @@ impl<'a> Uri<'a> {
     /// use rocket::http::uri::Uri;
     ///
     /// let uri = Uri::new("/a/b/c");
-    /// assert_eq!(uri.query(), None);
+    /// assert_eq!(uri.query(), "");
     /// ```
     #[inline(always)]
-    pub fn query(&self) -> Option<&str> {
-        self.query.map(|(i, j)| &self.uri[i..j])
+    pub fn query(&self) -> &str {
+        self.query.map(|(i, j)| &self.uri[i..j]).unwrap_or("")
+    }
+
+    /// Returns whether the query part of this URI was explicitly specified.
+    ///
+    /// ### Examples
+    ///
+    /// A URI with a query part:
+    ///
+    /// ```rust
+    /// use rocket::http::uri::Uri;
+    ///
+    /// let uri = Uri::new("/a/b/c?alphabet=true");
+    /// assert!(uri.query_explicit());
+    /// ```
+    ///
+    /// A URI without the query part:
+    ///
+    /// ```rust
+    /// use rocket::http::uri::Uri;
+    ///
+    /// let uri = Uri::new("/a/b/c");
+    /// assert!(!uri.query_explicit());
+    /// ```
+    #[inline(always)]
+    pub fn query_explicit(&self) -> bool {
+        self.query.is_some()
     }
 
     /// Returns the fargment part of this URI without the hash mark, if there is
@@ -337,7 +362,8 @@ impl<'a> fmt::Display for Uri<'a> {
             }
         }
 
-        if let Some(query_str) = self.query() {
+        let query_str = self.query();
+        if !query_str.is_empty() {
             write!(f, "?{}", query_str)?;
         }
 
@@ -533,7 +559,11 @@ mod tests {
 
     fn test_query(uri: &str, query: Option<&str>) {
         let uri = Uri::new(uri);
-        assert_eq!(uri.query(), query);
+        assert_eq!(uri.query_explicit(), query.is_some());
+        match query {
+            Some(q) => assert_eq!(uri.query(), q),
+            None => assert!(uri.query().is_empty()),
+        };
     }
 
     fn test_fragment(uri: &str, fragment: Option<&str>) {

--- a/lib/src/router/collider.rs
+++ b/lib/src/router/collider.rs
@@ -108,14 +108,11 @@ impl Collider for Route {
 // intended for this Route. Format collisions works like this:
 //   * If route specifies format, it only gets requests for that format.
 //   * If route doesn't specify format, it gets requests for any format.
-// Query collisions work like this:
-//   * If route specifies a query, it only gets request that have queries.
-//   * If route doesn't specify query, requests with & without queries collide.
+// Queries are irrelevant to collision with a route.
 impl<'r> Collider<Request<'r>> for Route {
     fn collides_with(&self, req: &Request<'r>) -> bool {
         self.method == req.method()
             && self.uri.collides_with(req.uri())
-            && self.uri.query().map_or(true, |_| req.uri().query().is_some())
             && match self.format {
                 Some(ref mt_a) => match req.format() {
                     Some(ref mt_b) => mt_a.collides_with(mt_b),
@@ -444,10 +441,10 @@ mod tests {
 
         assert!(req_route_path_collide("/a/b?a=b", "/a/b"));
         assert!(req_route_path_collide("/a/b", "/a/b"));
+        assert!(req_route_path_collide("/a/b", "/a/b?<c>"));
         assert!(req_route_path_collide("/a/b/c/d?", "/a/b/c/d"));
         assert!(req_route_path_collide("/a/b/c/d?v=1&v=2", "/a/b/c/d"));
 
-        assert!(!req_route_path_collide("/a/b", "/a/b?<c>"));
         assert!(!req_route_path_collide("/a/b/c", "/a/b?<c>"));
         assert!(!req_route_path_collide("/a?b=c", "/a/b?<c>"));
         assert!(!req_route_path_collide("/?b=c", "/a/b?<c>"));

--- a/lib/src/router/mod.rs
+++ b/lib/src/router/mod.rs
@@ -198,6 +198,12 @@ mod test {
         assert!(route(&router, Get, "/i/a").is_some());
         assert!(route(&router, Get, "/jdlk/asdij").is_some());
 
+        let router = router_with_routes(&["/a?<b>"]);
+        assert!(route(&router, Get, "/a?hi").is_some());
+        assert!(route(&router, Get, "/a?").is_some());
+        assert!(route(&router, Get, "/a#").is_some());
+        assert!(route(&router, Get, "/a").is_some());
+
         let mut router = Router::new();
         router.add(Route::new(Put, "/hello".to_string(), dummy_handler));
         router.add(Route::new(Post, "/hello".to_string(), dummy_handler));
@@ -259,9 +265,14 @@ mod test {
         assert_ranked_routes!(&["/<a>/<b>", "/hi/a"], "/hi/c", "/<a>/<b>");
         assert_ranked_routes!(&["/hi/a", "/hi/<c>"], "/hi/c", "/hi/<c>");
         assert_ranked_routes!(&["/a", "/a?<b>"], "/a?b=c", "/a?<b>");
-        assert_ranked_routes!(&["/a", "/a?<b>"], "/a", "/a");
-        assert_ranked_routes!(&["/a", "/<a>", "/a?<b>", "/<a>?<b>"], "/a", "/a");
-        assert_ranked_routes!(&["/a", "/<a>", "/a?<b>", "/<a>?<b>"], "/b", "/<a>");
+        assert_ranked_routes!(&["/a", "/a?<b>"], "/a", "/a?<b>");
+        assert_ranked_routes!(&["/a", "/a?<b>"], "/a?", "/a?<b>");
+        assert_ranked_routes!(&["/a", "/<a>?<b>"], "/a", "/a");
+        assert_ranked_routes!(&["/a", "/<a>?<b>"], "/a?", "/a");
+        assert_ranked_routes!(&["/<a>", "/a?<b>"], "/a", "/a?<b>");
+        assert_ranked_routes!(&["/<a>", "/a?<b>"], "/a?", "/a?<b>");
+        assert_ranked_routes!(&["/a", "/<a>", "/a?<b>", "/<a>?<b>"], "/a", "/a?<b>");
+        assert_ranked_routes!(&["/a", "/<a>", "/a?<b>", "/<a>?<b>"], "/b", "/<a>?<b>");
         assert_ranked_routes!(&["/a", "/<a>", "/a?<b>", "/<a>?<b>"],
                               "/b?v=1", "/<a>?<b>");
         assert_ranked_routes!(&["/a", "/<a>", "/a?<b>", "/<a>?<b>"],
@@ -397,7 +408,7 @@ mod test {
         assert_default_ranked_routing!(
             to: "a/b",
             with: ["a/<b>", "a/b", "a/b?<v>", "a/<b>?<v>"],
-            expect: "a/b", "a/<b>"
+            expect: "a/b?<v>", "a/b", "a/<b>?<v>", "a/<b>"
         );
     }
 

--- a/lib/src/router/route.rs
+++ b/lib/src/router/route.rs
@@ -31,7 +31,7 @@ pub struct Route {
 fn default_rank(uri: &Uri) -> isize {
     // static path, query = -4; static path, no query = -3
     // dynamic path, query = -2; dynamic path, no query = -1
-    match (!uri.path().contains('<'),  uri.query().is_some()) {
+    match (!uri.path().contains('<'),  uri.query_explicit()) {
         (true, true) => -4,
         (true, false) => -3,
         (false, true) => -2,


### PR DESCRIPTION
Resolves #376.
Doesn't change the default ranking system.

API change:
- method `URI::query` now returns `&str` instead of `Option<&str>`
- added method `URI::query_explicit` returning a `bool` of whether a query was explicitly specified.

Impact:
- Routes for `/a` and `/a?<foo>` can _both_ match the request `/a`, unless the empty string fails to parse into the type indicated for the `foo` param. Previously, a path would necessarily start with `/a?` to match the latter route (and again, the match would fail if the empty string fails to parse into `foo`'s type). **Queries are irrelevant for collision with a route.** Rank and failed form parsing should be relied on instead.

Tests have been added and modified to reflect these changes.