### PR TITLE
Fix language type of code block

### DIFF
--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -42,7 +42,7 @@
 //! Rocket matures. To use Rocket with the code generation plugin in your
 //! Cargo-based project, add the following to `Cargo.toml`:
 //!
-//! ```rust,ignore
+//! ```toml
 //! [dependencies]
 //! rocket = "*"
 //! rocket_codegen = "*"


### PR DESCRIPTION
Changes langauge type of the toml snippet to remove unnecessary "it's not tested" warning in the documentation.