### PR TITLE
Fix typo in state guide

### DIFF
--- a/site/guide/state.md
+++ b/site/guide/state.md
@@ -72,7 +72,7 @@ fn state(hit_count: State<HitCount>, config: State<Config>) -> T { ... }
 ### Within Guards
 
 It can also be useful to retrieve managed state from a `FromRequest`
-implementation. To do so, simple invoke `State<T>` as a guard using the
+implementation. To do so, simply invoke `State<T>` as a guard using the
 [`Request::guard()`] method.
 
 ```rust


### PR DESCRIPTION
simple instead of adverb form simply.

Thanks for the amazing framework!