### PR TITLE
feat: add mime type for json-api

### DIFF
--- a/lib/src/http/known_media_types.rs
+++ b/lib/src/http/known_media_types.rs
@@ -22,7 +22,8 @@ macro_rules! known_media_types {
         TTF (is_ttf): "TTF", "application", "font-sfnt",
         OTF (is_otf): "OTF", "application", "font-sfnt",
         WOFF (is_woff): "WOFF", "application", "font-woff",
-        WOFF2 (is_woff2): "WOFF2", "font", "woff2"
+        WOFF2 (is_woff2): "WOFF2", "font", "woff2",
+        JsonApi (is_json_api): "JsonApi", "application", "vnd.api+json",
     })
 }
 

--- a/lib/src/http/known_media_types.rs
+++ b/lib/src/http/known_media_types.rs
@@ -23,7 +23,7 @@ macro_rules! known_media_types {
         OTF (is_otf): "OTF", "application", "font-sfnt",
         WOFF (is_woff): "WOFF", "application", "font-woff",
         WOFF2 (is_woff2): "WOFF2", "font", "woff2",
-        JsonApi (is_json_api): "JsonApi", "application", "vnd.api+json"
+        JsonApi (is_json_api): "JSON API", "application", "vnd.api+json"
     })
 }
 

--- a/lib/src/http/known_media_types.rs
+++ b/lib/src/http/known_media_types.rs
@@ -23,7 +23,7 @@ macro_rules! known_media_types {
         OTF (is_otf): "OTF", "application", "font-sfnt",
         WOFF (is_woff): "WOFF", "application", "font-woff",
         WOFF2 (is_woff2): "WOFF2", "font", "woff2",
-        JsonApi (is_json_api): "JsonApi", "application", "vnd.api+json",
+        JsonApi (is_json_api): "JsonApi", "application", "vnd.api+json"
     })
 }
 


### PR DESCRIPTION
Hey, awesome job on Rocket! 😃

This PR adds [application/vnd.api+json](http://www.iana.org/assignments/media-types/application/vnd.api+json) [(json-api)](http://jsonapi.org) as a known media type.