### PR TITLE
Add support for setting a custom Content-Length

### DIFF
--- a/lib/src/rocket.rs
+++ b/lib/src/rocket.rs
@@ -132,6 +132,10 @@ impl Rocket {
             hyp_res.headers_mut().append_raw(name, value);
         }
 
+        if let Some(_) = response.headers().get_one("Content-Length") {
+            return hyp_res.start()?.end();
+        }
+
         if response.body().is_none() {
             hyp_res.headers_mut().set(header::ContentLength(0));
             return hyp_res.start()?.end();


### PR DESCRIPTION
Currently it is not possible to set a custom Content-Length header. This can be needed when conforming to a spec for example. The default behavior is definitely recommended for 95% of use-cases.

Thanks for a great project, I'm really enjoying working with Rocket.