### PR TITLE
NamedFile using sized_body instead of streamed_body

### DIFF
--- a/lib/src/response/named_file.rs
+++ b/lib/src/response/named_file.rs
@@ -1,6 +1,6 @@
 use std::fs::File;
 use std::path::{Path, PathBuf};
-use std::io::{self, BufReader};
+use std::io;
 use std::ops::{Deref, DerefMut};
 
 use request::Request;
@@ -88,7 +88,7 @@ impl Responder<'static> for NamedFile {
             }
         }
 
-        response.set_streamed_body(BufReader::new(self.take_file()));
+        response.set_sized_body(self.take_file());
         Ok(response)
     }
 }


### PR DESCRIPTION
NamedFile responder sets sized_body instead to correctly handle Content-Length