### PR TITLE
Provide a template registration callback

### DIFF
--- a/contrib/src/templates/engine.rs
+++ b/contrib/src/templates/engine.rs
@@ -15,9 +15,9 @@ pub trait Engine: Send + Sync + 'static {
 
 pub struct Engines {
     #[cfg(feature = "tera_templates")]
-    tera: Tera,
+    pub tera: Tera,
     #[cfg(feature = "handlebars_templates")]
-    handlebars: Handlebars,
+    pub handlebars: Handlebars,
 }
 
 impl Engines {


### PR DESCRIPTION
This makes it possible to register helper functions with Handlebars and Tera, resolving #64.

I'm using this locally to update Crates.io to use server-side rendering: https://github.com/rust-lang/crates.io/pull/1173.

That branch is out of date currently; here's how I'm using this feature:

```rust
// src/lib.rs

pub fn route(app: App) {
    rocket::ignite()
        .mount("/", routes![html::index])
        .attach(Template::fairing_with(|context| {
            html::register_helpers(&mut context.engines.handlebars);
        }))
        .launch();
}
```
```rust
// src/html/mod.rs

#[get("/")]
pub fn index() -> Template {
    let mut json = json!({});
    json["current_user"] = json!({"id": 1, "name": "Sean Linsley"});

    Template::render("index", &json)
}

pub fn register_helpers(handlebars: &mut Handlebars) {
    handlebars.register_helper("format_num", Box::new(format_num));
    handlebars.register_helper("embed_svg", Box::new(embed_svg));
}
```

There have been two previous PRs to try adding this feature: #60 and #364. @SergioBenitez has wanted the ability to register the same helper functions on both rendering engines simultaneously, but I'm not sure that's possible because of the library-specific code inside of the helper functions themselves.

Instead I opted to make the underlying template objects accessible via a callback passed to `Template::fairing_with`. Is there a better name for this function?

Once we're happy with this change, I'll update the documentation and write a test.