### PR TITLE
fix: Make form items parsing less strict

### DIFF
--- a/lib/tests/limits.rs
+++ b/lib/tests/limits.rs
@@ -7,7 +7,7 @@ use rocket::request::Form;
 
 #[derive(FromForm)]
 struct Simple {
-    value: String
+    value: String,
 }
 
 #[post("/", data = "<form>")]
@@ -32,7 +32,8 @@ mod limits_tests {
     #[test]
     fn large_enough() {
         let client = Client::new(rocket_with_forms_limit(128)).unwrap();
-        let mut response = client.post("/")
+        let mut response = client
+            .post("/")
             .body("value=Hello+world")
             .header(ContentType::Form)
             .dispatch();
@@ -43,7 +44,8 @@ mod limits_tests {
     #[test]
     fn just_large_enough() {
         let client = Client::new(rocket_with_forms_limit(17)).unwrap();
-        let mut response = client.post("/")
+        let mut response = client
+            .post("/")
             .body("value=Hello+world")
             .header(ContentType::Form)
             .dispatch();
@@ -54,18 +56,20 @@ mod limits_tests {
     #[test]
     fn much_too_small() {
         let client = Client::new(rocket_with_forms_limit(4)).unwrap();
-        let response = client.post("/")
+        let response = client
+            .post("/")
             .body("value=Hello+world")
             .header(ContentType::Form)
             .dispatch();
 
-        assert_eq!(response.status(), Status::BadRequest);
+        assert_eq!(response.status(), Status::UnprocessableEntity);
     }
 
     #[test]
     fn contracted() {
         let client = Client::new(rocket_with_forms_limit(10)).unwrap();
-        let mut response = client.post("/")
+        let mut response = client
+            .post("/")
             .body("value=Hello+world")
             .header(ContentType::Form)
             .dispatch();


### PR DESCRIPTION
Currently Rocket is pretty strict on form items parsing, which affects how parameters without a value in query strings are handled, for example for `?flag` or `?f&foo=bar`. The [RFC 3986](https://tools.ietf.org/html/rfc3986#page-23) do not impose any constraints to the usage of empty query parameters and it seems like the way most framewors and servers handle this is by assigning an empty value to the parameter ([ref](https://stackoverflow.com/questions/4557387/is-a-url-query-parameter-valid-if-it-has-no-value)).

This change modifies the `FormItems` iterator to handle empty or unvalued parameters.

This affects the limits handling as well, since a `POST` request with a form content type and a body `valu`, as it results from limiting `value=Hello+world` to 4 bytes, will produce a valid form items collection like `&[("valu", "")]`. Then when trying to parse it agains a given type without a `valu` field this will result in a `422 Unprocessable Entity` error instead of a `400 Bad Request`. See the change to the `limits_tests::much_too_small` test.

Sorry for the whitespace changes, it's all `rustfmt` work.