### PR TITLE
Provide template registration callback for native template engine features

### DIFF
--- a/contrib/src/lib.rs
+++ b/contrib/src/lib.rs
@@ -48,6 +48,12 @@ extern crate serde;
 #[cfg_attr(feature = "json", macro_reexport(json_internal))]
 extern crate serde_json;
 
+#[cfg(feature = "handlebars_templates")]
+pub extern crate handlebars;
+
+#[cfg(feature = "tera_templates")]
+pub extern crate tera;
+
 #[cfg(feature = "json")]
 #[cfg_attr(feature = "json", macro_use)]
 #[doc(hidden)]
@@ -74,9 +80,3 @@ mod uuid;
 
 #[cfg(feature = "uuid")]
 pub use uuid::{UUID, UuidParseError};
-
-#[cfg(feature = "handlebars_templates")]
-pub extern crate handlebars;
-
-#[cfg(feature = "tera_templates")]
-pub extern crate tera;

--- a/contrib/src/lib.rs
+++ b/contrib/src/lib.rs
@@ -74,3 +74,9 @@ mod uuid;
 
 #[cfg(feature = "uuid")]
 pub use uuid::{UUID, UuidParseError};
+
+#[cfg(feature = "handlebars_templates")]
+pub extern crate handlebars;
+
+#[cfg(feature = "tera_templates")]
+pub extern crate tera;

--- a/contrib/src/templates/context.rs
+++ b/contrib/src/templates/context.rs
@@ -49,10 +49,6 @@ impl Context {
             Context { root, templates, engines }
         })
     }
-
-    pub fn engines_mut(&mut self) -> &mut Engines {
-        &mut self.engines
-    }
 }
 
 /// Removes the file path's extension or does nothing if there is none.

--- a/contrib/src/templates/context.rs
+++ b/contrib/src/templates/context.rs
@@ -49,6 +49,10 @@ impl Context {
             Context { root, templates, engines }
         })
     }
+
+    pub fn engines_mut(&mut self) -> &mut Engines {
+        &mut self.engines
+    }
 }
 
 /// Removes the file path's extension or does nothing if there is none.

--- a/contrib/src/templates/engine.rs
+++ b/contrib/src/templates/engine.rs
@@ -15,9 +15,9 @@ pub trait Engine: Send + Sync + 'static {
 
 pub struct Engines {
     #[cfg(feature = "tera_templates")]
-    tera: Tera,
+    pub tera: Tera,
     #[cfg(feature = "handlebars_templates")]
-    handlebars: Handlebars,
+    pub handlebars: Handlebars,
 }
 
 impl Engines {
@@ -68,15 +68,5 @@ impl Engines {
         }
 
         None
-    }
-
-    #[cfg(feature = "handlebars_templates")]
-    pub fn handlebars(&mut self) -> &mut Handlebars {
-        &mut self.handlebars
-    }
-
-    #[cfg(feature = "tera_templates")]
-    pub fn tera(&mut self) -> &mut Tera {
-        &mut self.tera
     }
 }

--- a/contrib/src/templates/engine.rs
+++ b/contrib/src/templates/engine.rs
@@ -69,4 +69,14 @@ impl Engines {
 
         None
     }
+
+    #[cfg(feature = "handlebars_templates")]
+    pub fn handlebars(&mut self) -> &mut Handlebars {
+        &mut self.handlebars
+    }
+
+    #[cfg(feature = "tera_templates")]
+    pub fn tera(&mut self) -> &mut Tera {
+        &mut self.tera
+    }
 }

--- a/contrib/src/templates/mod.rs
+++ b/contrib/src/templates/mod.rs
@@ -247,18 +247,17 @@ impl Template {
     /// # Example
     ///
     /// ```rust
+    /// # extern crate rocket;
+    /// # extern crate rocket_contrib;
+    ///
     /// use std::collections::HashMap;
     ///
-    /// extern crate rocket;
-    /// extern crate rocket_contrib;
-    ///
     /// use rocket_contrib::Template;
+    /// use rocket::local::Client;
     ///
     /// fn main() {
-    ///     let client =
-    ///         rocket::local::Client::new(rocket::ignite()
-    ///             .attach(Template::fairing())
-    ///         ).expect("valid rocket");
+    ///     let rocket = rocket::ignite().attach(Template::fairing());
+    ///     let client = Client::new(rocket).expect("valid rocket");
     ///
     ///     // Create a `context`. Here, just an empty `HashMap`.
     ///     let mut context = HashMap::new();
@@ -275,9 +274,9 @@ impl Template {
         let ctxt = match rocket.state::<Context>() {
             Some(ctxt) => ctxt,
             None => {
-                warn_!("Uninitialized template context: missing fairing.");
-                info_!("To use templates, you must attach `Template::fairing()`.");
-                info_!("See the `Template` documentation for more information.");
+                warn!("Uninitialized template context: missing fairing.");
+                info!("To use templates, you must attach `Template::fairing()`.");
+                info!("See the `Template` documentation for more information.");
                 return None;
             }
         };

--- a/contrib/src/templates/mod.rs
+++ b/contrib/src/templates/mod.rs
@@ -230,24 +230,23 @@ impl Template {
     }
 
     /// Render the template named `name` with the context `context` into a
-    /// `String`. This method should
-    /// **not** be used in any running Rocket application. This method should
-    /// only be used during testing to validate `Template` responses. For other
-    /// uses, use [`render`](#method.render) instead.
+    /// `String`. This method should **not** be used in any running Rocket
+    /// application. This method should only be used during testing to
+    /// validate `Template` responses. For other uses, use
+    /// [`render`](#method.render) instead.
     ///
     /// The `context` can be of any type that implements `Serialize`. This is
     /// typically a `HashMap` or a custom `struct`.
     ///
     /// Returns `Some` if the template could be rendered. Otherwise, returns
     /// `None`. If rendering fails, error output is printed to the console.
-    /// `None` is also returned if a Template fairing has not been attached.
+    /// `None` is also returned if a `Template` fairing has not been attached.
     ///
     /// # Example
     ///
     /// ```rust
     /// # extern crate rocket;
     /// # extern crate rocket_contrib;
-    ///
     /// use std::collections::HashMap;
     ///
     /// use rocket_contrib::Template;

--- a/contrib/src/templates/mod.rs
+++ b/contrib/src/templates/mod.rs
@@ -158,9 +158,37 @@ impl Template {
     /// }
     /// ```
     pub fn fairing() -> impl Fairing {
-        AdHoc::on_attach(|rocket| {
-            let mut template_root = rocket.config()
-                .root_relative(DEFAULT_TEMPLATE_DIR);
+        Template::config_and_fairing(|_| {})
+    }
+
+    /// Returns a fairing that intializes and maintains templating state.
+    ///
+    /// This method allows you to configure the template context via the
+    /// closure.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// extern crate rocket;
+    /// extern crate rocket_contrib;
+    ///
+    /// use rocket_contrib::Template;
+    ///
+    /// fn main() {
+    ///     rocket::ignite()
+    ///         // ...
+    ///         .attach(Template::config_and_fairing(|ctxt| {
+    ///             // ctxt.engines_mut().handlebars().register_helper ...
+    ///         }))
+    ///         // ...
+    ///     # ;
+    /// }
+    /// ```
+    pub fn config_and_fairing<F>(f: F) -> impl Fairing
+        where F: Fn(&mut Context) + Send + Sync + 'static
+    {
+        AdHoc::on_attach(move |rocket| {
+            let mut template_root = rocket.config().root_relative(DEFAULT_TEMPLATE_DIR);
 
             match rocket.config().get_str("template_dir") {
                 Ok(dir) => template_root = rocket.config().root_relative(dir),

--- a/contrib/src/templates/mod.rs
+++ b/contrib/src/templates/mod.rs
@@ -229,16 +229,14 @@ impl Template {
         Template { name: name.into(), value: to_value(context).ok() }
     }
 
-    /// Render the template named `name` located at the path `root` with the
-    /// context `context` into a `String`. This method is _very slow_ and should
+    /// Render the template named `name` with the context `context` into a
+    /// `String`. This method should
     /// **not** be used in any running Rocket application. This method should
     /// only be used during testing to validate `Template` responses. For other
     /// uses, use [`render`](#method.render) instead.
     ///
     /// The `context` can be of any type that implements `Serialize`. This is
-    /// typically a `HashMap` or a custom `struct`. The path `root` can be
-    /// relative, in which case it is relative to the current working directory,
-    /// or absolute.
+    /// typically a `HashMap` or a custom `struct`.
     ///
     /// Returns `Some` if the template could be rendered. Otherwise, returns
     /// `None`. If rendering fails, error output is printed to the console.

--- a/contrib/tests/templates.rs
+++ b/contrib/tests/templates.rs
@@ -1,17 +1,26 @@
+extern crate rocket;
 extern crate rocket_contrib;
 
 use std::env;
 use std::path::PathBuf;
+
+use rocket::Rocket;
+use rocket::config::{Config, Environment};
+use rocket_contrib::Template;
 
 fn template_root() -> PathBuf {
     let cwd = env::current_dir().expect("current working directory");
     cwd.join("tests").join("templates")
 }
 
+fn rocket() -> Rocket {
+    let config = Config::build(Environment::Development).extra("template_dir", template_root().to_str().unwrap()).unwrap();
+    rocket::custom(config, true).attach(Template::fairing())
+}
+
 #[cfg(feature = "tera_templates")]
 mod tera_tests {
     use super::*;
-    use rocket_contrib::Template;
     use std::collections::HashMap;
 
     const UNESCAPED_EXPECTED: &'static str
@@ -21,16 +30,17 @@ mod tera_tests {
 
     #[test]
     fn test_tera_templates() {
+        let rocket = rocket();
         let mut map = HashMap::new();
         map.insert("title", "_test_");
         map.insert("content", "<script />");
 
         // Test with a txt file, which shouldn't escape.
-        let template = Template::show(template_root(), "tera/txt_test", &map);
+        let template = Template::show(&rocket, "tera/txt_test", &map);
         assert_eq!(template, Some(UNESCAPED_EXPECTED.into()));
 
         // Now with an HTML file, which should.
-        let template = Template::show(template_root(), "tera/html_test", &map);
+        let template = Template::show(&rocket, "tera/html_test", &map);
         assert_eq!(template, Some(ESCAPED_EXPECTED.into()));
     }
 }
@@ -38,7 +48,6 @@ mod tera_tests {
 #[cfg(feature = "handlebars_templates")]
 mod handlebars_tests {
     use super::*;
-    use rocket_contrib::Template;
     use std::collections::HashMap;
 
     const EXPECTED: &'static str
@@ -46,12 +55,13 @@ mod handlebars_tests {
 
     #[test]
     fn test_handlebars_templates() {
+        let rocket = rocket();
         let mut map = HashMap::new();
         map.insert("title", "_test_");
         map.insert("content", "<script /> hi");
 
         // Test with a txt file, which shouldn't escape.
-        let template = Template::show(template_root(), "hbs/test", &map);
+        let template = Template::show(&rocket, "hbs/test", &map);
         assert_eq!(template, Some(EXPECTED.into()));
     }
 }

--- a/contrib/tests/templates.rs
+++ b/contrib/tests/templates.rs
@@ -17,6 +17,7 @@ fn rocket() -> Rocket {
     let config = Config::build(Environment::Development)
         .extra("template_dir", template_root().to_str().expect("template directory"))
         .expect("valid configuration");
+
     rocket::custom(config, true).attach(Template::fairing())
 }
 

--- a/contrib/tests/templates.rs
+++ b/contrib/tests/templates.rs
@@ -14,7 +14,9 @@ fn template_root() -> PathBuf {
 }
 
 fn rocket() -> Rocket {
-    let config = Config::build(Environment::Development).extra("template_dir", template_root().to_str().unwrap()).unwrap();
+    let config = Config::build(Environment::Development)
+        .extra("template_dir", template_root().to_str().expect("template directory"))
+        .expect("valid configuration");
     rocket::custom(config, true).attach(Template::fairing())
 }
 

--- a/examples/cookies/src/tests.rs
+++ b/examples/cookies/src/tests.rs
@@ -5,8 +5,6 @@ use rocket::local::Client;
 use rocket::http::*;
 use rocket_contrib::Template;
 
-const TEMPLATE_ROOT: &'static str = "templates/";
-
 #[test]
 fn test_submit() {
     let client = Client::new(rocket()).unwrap();
@@ -37,13 +35,15 @@ fn test_body(optional_cookie: Option<Cookie<'static>>, expected_body: String) {
 
 #[test]
 fn test_index() {
+    let client = Client::new(rocket()).unwrap();
+
     // Render the template with an empty context.
     let mut context: HashMap<&str, &str> = HashMap::new();
-    let template = Template::show(TEMPLATE_ROOT, "index", &context).unwrap();
+    let template = Template::show(client.rocket(), "index", &context).unwrap();
     test_body(None, template);
 
     // Render the template with a context that contains the message.
     context.insert("message", "Hello from Rocket!");
-    let template = Template::show(TEMPLATE_ROOT, "index", &context).unwrap();
+    let template = Template::show(client.rocket(), "index", &context).unwrap();
     test_body(Some(Cookie::new("message", "Hello from Rocket!")), template);
 }

--- a/examples/handlebars_templates/src/main.rs
+++ b/examples/handlebars_templates/src/main.rs
@@ -10,6 +10,7 @@ extern crate rocket;
 use rocket::Request;
 use rocket::response::Redirect;
 use rocket_contrib::Template;
+use rocket_contrib::handlebars::{Helper, Handlebars, RenderContext, RenderError};
 
 #[derive(Serialize)]
 struct TemplateContext {
@@ -43,6 +44,27 @@ fn rocket() -> rocket::Rocket {
     rocket::ignite()
         .mount("/", routes![index, get])
         .attach(Template::fairing())
+        .catch(catchers![not_found])
+}
+
+// when you want to register handlebars helpers
+#[allow(dead_code)]
+fn rocket_with_hbs_helper() -> rocket::Rocket {
+    rocket::ignite()
+        .mount("/", routes![index, get])
+        .attach(Template::config_and_fairing(|ctxt| {
+            ctxt.engines_mut()
+                .handlebars()
+                .register_helper("test",
+                                 Box::new(|_: &Helper,
+                                           _: &Handlebars,
+                                           _: &mut RenderContext|
+                                           -> Result<(), RenderError> {
+                                              // do nothing
+                                              Ok(())
+                                          }));
+
+        }))
         .catch(catchers![not_found])
 }
 

--- a/examples/handlebars_templates/src/main.rs
+++ b/examples/handlebars_templates/src/main.rs
@@ -45,17 +45,18 @@ fn rocket() -> rocket::Rocket {
         .mount("/", routes![index, get])
         .attach(Template::custom(|engines| {
             engines.handlebars.register_helper(
-                "test", Box::new(|h: &Helper,
-                                 _: &Handlebars,
-                                 rc: &mut RenderContext| -> Result<(), RenderError> {
-                                     if let Some(p0) = h.param(0) {
-                                         rc.writer.write(p0.value()
-                                                         .render()
-                                                         .into_bytes()
-                                                         .as_ref())?;
-                                     }
-                                     Ok(())
-                                 }));
+                "echo", Box::new(|h: &Helper,
+                                  _: &Handlebars,
+                                  rc: &mut RenderContext| -> Result<(), RenderError> {
+                                      if let Some(p0) = h.param(0) {
+                                          rc.writer.write(p0.value()
+                                                          .render()
+                                                          .into_bytes()
+                                                          .as_ref())?;
+                                      }
+                                      Ok(())
+                                  }));
+
         }))
         .catch(catchers![not_found])
 }

--- a/examples/handlebars_templates/src/main.rs
+++ b/examples/handlebars_templates/src/main.rs
@@ -10,7 +10,7 @@ extern crate rocket;
 use rocket::Request;
 use rocket::response::Redirect;
 use rocket_contrib::Template;
-use rocket_contrib::handlebars::{HelperDef, Helper, Handlebars, RenderContext, RenderError, JsonRender};
+use rocket_contrib::handlebars::{Helper, Handlebars, RenderContext, RenderError, JsonRender};
 
 #[derive(Serialize)]
 struct TemplateContext {
@@ -40,21 +40,18 @@ fn not_found(req: &Request) -> Template {
     Template::render("error/404", &map)
 }
 
-struct EchoHelper;
-impl HelperDef for EchoHelper {
-    fn call(&self, h: &Helper, _: &Handlebars, rc: &mut RenderContext) -> Result<(), RenderError> {
-        if let Some(p0) = h.param(0) {
-            rc.writer.write(p0.value().render().into_bytes().as_ref())?;
-        };
-        Ok(())
-    }
+fn echo_helper(h: &Helper, _: &Handlebars, rc: &mut RenderContext) -> Result<(), RenderError> {
+    if let Some(p0) = h.param(0) {
+        rc.writer.write(p0.value().render().into_bytes().as_ref())?;
+    };
+    Ok(())
 }
 
 fn rocket() -> rocket::Rocket {
     rocket::ignite()
         .mount("/", routes![index, get])
         .attach(Template::custom(|engines| {
-            engines.handlebars.register_helper("echo", Box::new(EchoHelper));
+            engines.handlebars.register_helper("echo", Box::new(echo_helper));
         }))
         .catch(catchers![not_found])
 }

--- a/examples/handlebars_templates/src/main.rs
+++ b/examples/handlebars_templates/src/main.rs
@@ -10,7 +10,7 @@ extern crate rocket;
 use rocket::Request;
 use rocket::response::Redirect;
 use rocket_contrib::Template;
-use rocket_contrib::handlebars::{Helper, Handlebars, RenderContext, RenderError, JsonRender};
+use rocket_contrib::handlebars::{HelperDef, Helper, Handlebars, RenderContext, RenderError, JsonRender};
 
 #[derive(Serialize)]
 struct TemplateContext {
@@ -40,23 +40,21 @@ fn not_found(req: &Request) -> Template {
     Template::render("error/404", &map)
 }
 
+struct EchoHelper;
+impl HelperDef for EchoHelper {
+    fn call(&self, h: &Helper, _: &Handlebars, rc: &mut RenderContext) -> Result<(), RenderError> {
+        if let Some(p0) = h.param(0) {
+            rc.writer.write(p0.value().render().into_bytes().as_ref())?;
+        };
+        Ok(())
+    }
+}
+
 fn rocket() -> rocket::Rocket {
     rocket::ignite()
         .mount("/", routes![index, get])
         .attach(Template::custom(|engines| {
-            engines.handlebars.register_helper(
-                "echo", Box::new(|h: &Helper,
-                                  _: &Handlebars,
-                                  rc: &mut RenderContext| -> Result<(), RenderError> {
-                                      if let Some(p0) = h.param(0) {
-                                          rc.writer.write(p0.value()
-                                                          .render()
-                                                          .into_bytes()
-                                                          .as_ref())?;
-                                      }
-                                      Ok(())
-                                  }));
-
+            engines.handlebars.register_helper("echo", Box::new(EchoHelper));
         }))
         .catch(catchers![not_found])
 }

--- a/examples/handlebars_templates/src/main.rs
+++ b/examples/handlebars_templates/src/main.rs
@@ -10,7 +10,7 @@ extern crate rocket;
 use rocket::Request;
 use rocket::response::Redirect;
 use rocket_contrib::Template;
-use rocket_contrib::handlebars::{Helper, Handlebars, RenderContext, RenderError};
+use rocket_contrib::handlebars::{Helper, Handlebars, RenderContext, RenderError, JsonRender};
 
 #[derive(Serialize)]
 struct TemplateContext {
@@ -43,27 +43,19 @@ fn not_found(req: &Request) -> Template {
 fn rocket() -> rocket::Rocket {
     rocket::ignite()
         .mount("/", routes![index, get])
-        .attach(Template::fairing())
-        .catch(catchers![not_found])
-}
-
-// when you want to register handlebars helpers
-#[allow(dead_code)]
-fn rocket_with_hbs_helper() -> rocket::Rocket {
-    rocket::ignite()
-        .mount("/", routes![index, get])
-        .attach(Template::config_and_fairing(|ctxt| {
-            ctxt.engines_mut()
-                .handlebars()
-                .register_helper("test",
-                                 Box::new(|_: &Helper,
-                                           _: &Handlebars,
-                                           _: &mut RenderContext|
-                                           -> Result<(), RenderError> {
-                                              // do nothing
-                                              Ok(())
-                                          }));
-
+        .attach(Template::custom(|engines| {
+            engines.handlebars.register_helper(
+                "test", Box::new(|h: &Helper,
+                                 _: &Handlebars,
+                                 rc: &mut RenderContext| -> Result<(), RenderError> {
+                                     if let Some(p0) = h.param(0) {
+                                         rc.writer.write(p0.value()
+                                                         .render()
+                                                         .into_bytes()
+                                                         .as_ref())?;
+                                     }
+                                     Ok(())
+                                 }));
         }))
         .catch(catchers![not_found])
 }

--- a/examples/handlebars_templates/src/tests.rs
+++ b/examples/handlebars_templates/src/tests.rs
@@ -15,7 +15,7 @@ macro_rules! dispatch {
 fn test_root() {
     // Check that the redirect works.
     for method in &[Get, Head] {
-        dispatch!(*method, "/", |_client: &Client, mut response: LocalResponse| {
+        dispatch!(*method, "/", |_: &Client, mut response: LocalResponse| {
             assert_eq!(response.status(), Status::SeeOther);
             assert!(response.body().is_none());
 

--- a/examples/handlebars_templates/src/tests.rs
+++ b/examples/handlebars_templates/src/tests.rs
@@ -4,12 +4,10 @@ use rocket::http::Method::*;
 use rocket::http::Status;
 use rocket_contrib::Template;
 
-const TEMPLATE_ROOT: &'static str = "templates/";
-
 macro_rules! dispatch {
     ($method:expr, $path:expr, $test_fn:expr) => ({
         let client = Client::new(rocket()).unwrap();
-        $test_fn(client.req($method, $path).dispatch());
+        $test_fn(&client, client.req($method, $path).dispatch());
     })
 }
 
@@ -17,7 +15,7 @@ macro_rules! dispatch {
 fn test_root() {
     // Check that the redirect works.
     for method in &[Get, Head] {
-        dispatch!(*method, "/", |mut response: LocalResponse| {
+        dispatch!(*method, "/", |_client: &Client, mut response: LocalResponse| {
             assert_eq!(response.status(), Status::SeeOther);
             assert!(response.body().is_none());
 
@@ -28,10 +26,10 @@ fn test_root() {
 
     // Check that other request methods are not accepted (and instead caught).
     for method in &[Post, Put, Delete, Options, Trace, Connect, Patch] {
-        dispatch!(*method, "/", |mut response: LocalResponse| {
+        dispatch!(*method, "/", |client: &Client, mut response: LocalResponse| {
             let mut map = ::std::collections::HashMap::new();
             map.insert("path", "/");
-            let expected = Template::show(TEMPLATE_ROOT, "error/404", &map).unwrap();
+            let expected = Template::show(client.rocket(), "error/404", &map).unwrap();
 
             assert_eq!(response.status(), Status::NotFound);
             assert_eq!(response.body_string(), Some(expected));
@@ -42,13 +40,13 @@ fn test_root() {
 #[test]
 fn test_name() {
     // Check that the /hello/<name> route works.
-    dispatch!(Get, "/hello/Jack", |mut response: LocalResponse| {
+    dispatch!(Get, "/hello/Jack", |client: &Client, mut response: LocalResponse| {
         let context = super::TemplateContext {
             name: "Jack".into(),
             items: vec!["One".into(), "Two".into(), "Three".into()]
         };
 
-        let expected = Template::show(TEMPLATE_ROOT, "index", &context).unwrap();
+        let expected = Template::show(client.rocket(), "index", &context).unwrap();
         assert_eq!(response.status(), Status::Ok);
         assert_eq!(response.body_string(), Some(expected));
     });
@@ -57,11 +55,11 @@ fn test_name() {
 #[test]
 fn test_404() {
     // Check that the error catcher works.
-    dispatch!(Get, "/hello/", |mut response: LocalResponse| {
+    dispatch!(Get, "/hello/", |client: &Client, mut response: LocalResponse| {
         let mut map = ::std::collections::HashMap::new();
         map.insert("path", "/hello/");
 
-        let expected = Template::show(TEMPLATE_ROOT, "error/404", &map).unwrap();
+        let expected = Template::show(client.rocket(), "error/404", &map).unwrap();
         assert_eq!(response.status(), Status::NotFound);
         assert_eq!(response.body_string(), Some(expected));
     });

--- a/examples/handlebars_templates/templates/index.html.hbs
+++ b/examples/handlebars_templates/templates/index.html.hbs
@@ -14,6 +14,6 @@
     </ul>
 
     <p>Try going to <a href="/hello/YourName">/hello/YourName</a></p>
-    <p>You can define custom helper like <b>{{test "this"}}</b>.</p>
+    <p>You can define custom helper like <b>{{echo "this"}}</b>.</p>
   </body>
 </html>

--- a/examples/handlebars_templates/templates/index.html.hbs
+++ b/examples/handlebars_templates/templates/index.html.hbs
@@ -14,5 +14,6 @@
     </ul>
 
     <p>Try going to <a href="/hello/YourName">/hello/YourName</a></p>
+    <p>You can define custom helper like <b>{{test "this"}}</b>.</p>
   </body>
 </html>

--- a/examples/tera_templates/src/tests.rs
+++ b/examples/tera_templates/src/tests.rs
@@ -15,7 +15,7 @@ macro_rules! dispatch {
 fn test_root() {
     // Check that the redirect works.
     for method in &[Get, Head] {
-        dispatch!(*method, "/", |_client: &Client, mut response: LocalResponse| {
+        dispatch!(*method, "/", |_: &Client, mut response: LocalResponse| {
             assert_eq!(response.status(), Status::SeeOther);
             assert!(response.body().is_none());
 

--- a/examples/tera_templates/src/tests.rs
+++ b/examples/tera_templates/src/tests.rs
@@ -4,12 +4,10 @@ use rocket::http::Method::*;
 use rocket::http::Status;
 use rocket_contrib::Template;
 
-const TEMPLATE_ROOT: &'static str = "templates/";
-
 macro_rules! dispatch {
     ($method:expr, $path:expr, $test_fn:expr) => ({
         let client = Client::new(rocket()).unwrap();
-        $test_fn(client.req($method, $path).dispatch());
+        $test_fn(&client, client.req($method, $path).dispatch());
     })
 }
 
@@ -17,7 +15,7 @@ macro_rules! dispatch {
 fn test_root() {
     // Check that the redirect works.
     for method in &[Get, Head] {
-        dispatch!(*method, "/", |mut response: LocalResponse| {
+        dispatch!(*method, "/", |_client: &Client, mut response: LocalResponse| {
             assert_eq!(response.status(), Status::SeeOther);
             assert!(response.body().is_none());
 
@@ -28,10 +26,10 @@ fn test_root() {
 
     // Check that other request methods are not accepted (and instead caught).
     for method in &[Post, Put, Delete, Options, Trace, Connect, Patch] {
-        dispatch!(*method, "/", |mut response: LocalResponse| {
+        dispatch!(*method, "/", |client: &Client, mut response: LocalResponse| {
             let mut map = ::std::collections::HashMap::new();
             map.insert("path", "/");
-            let expected = Template::show(TEMPLATE_ROOT, "error/404", &map).unwrap();
+            let expected = Template::show(client.rocket(), "error/404", &map).unwrap();
 
             assert_eq!(response.status(), Status::NotFound);
             assert_eq!(response.body_string(), Some(expected));
@@ -42,13 +40,13 @@ fn test_root() {
 #[test]
 fn test_name() {
     // Check that the /hello/<name> route works.
-    dispatch!(Get, "/hello/Jack", |mut response: LocalResponse| {
+    dispatch!(Get, "/hello/Jack", |client: &Client, mut response: LocalResponse| {
         let context = super::TemplateContext {
             name: "Jack".into(),
             items: vec!["One", "Two", "Three"]
         };
 
-        let expected = Template::show(TEMPLATE_ROOT, "index", &context).unwrap();
+        let expected = Template::show(client.rocket(), "index", &context).unwrap();
         assert_eq!(response.status(), Status::Ok);
         assert_eq!(response.body_string(), Some(expected));
     });
@@ -57,11 +55,11 @@ fn test_name() {
 #[test]
 fn test_404() {
     // Check that the error catcher works.
-    dispatch!(Get, "/hello/", |mut response: LocalResponse| {
+    dispatch!(Get, "/hello/", |client: &Client, mut response: LocalResponse| {
         let mut map = ::std::collections::HashMap::new();
         map.insert("path", "/hello/");
 
-        let expected = Template::show(TEMPLATE_ROOT, "error/404", &map).unwrap();
+        let expected = Template::show(client.rocket(), "error/404", &map).unwrap();
         assert_eq!(response.status(), Status::NotFound);
         assert_eq!(response.body_string(), Some(expected));
     });

--- a/lib/src/rocket.rs
+++ b/lib/src/rocket.rs
@@ -604,7 +604,8 @@ impl Rocket {
         self
     }
 
-    /// Get the managed state of type T, if it exists.
+    /// Returns `Some` of the managed state value for the type `T` if it is
+    /// being managed by this instance of Rocket. Otherwise, returns `None`.
     ///
     /// # Example
     ///

--- a/lib/src/rocket.rs
+++ b/lib/src/rocket.rs
@@ -609,8 +609,14 @@ impl Rocket {
     /// # Example
     ///
     /// ```rust
-    /// let rocket = rocket::ignite().manage("example");
-    /// assert_eq!(&"example", rocket.state::<&str>().unwrap());
+    /// #[derive(PartialEq, Debug)]
+    /// struct MyState(&'static str);
+    ///
+    /// let rocket = rocket::ignite().manage(MyState("hello!"));
+    /// assert_eq!(rocket.state::<MyState>(), Some(&MyState("hello!")));
+    ///
+    /// let client = rocket::local::Client::new(rocket).expect("valid rocket");
+    /// assert_eq!(client.rocket().state::<MyState>(), Some(&MyState("hello!")));
     /// ```
     #[inline(always)]
     pub fn state<T: Send + Sync + 'static>(&self) -> Option<&T> {

--- a/lib/src/rocket.rs
+++ b/lib/src/rocket.rs
@@ -604,6 +604,19 @@ impl Rocket {
         self
     }
 
+    /// Get the managed state of type T, if it exists.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// let rocket = rocket::ignite().manage("example");
+    /// assert_eq!(&"example", rocket.state::<&str>().unwrap());
+    /// ```
+    #[inline(always)]
+    pub fn state<T: Send + Sync + 'static>(&self) -> Option<&T> {
+        self.state.try_get()
+    }
+
     /// Attaches a fairing to this instance of Rocket.
     ///
     /// # Example


### PR DESCRIPTION
Closes #64. Supersedes #431, #500.

This includes most of the commits from #431 and is based on further feedback on #431 and #500, in particular changing the signature of `Template::show`. I considered including #500 instead and still can if that is desired, but #431 already added to the tests for handlebars