### PR TITLE
Proposal: Diesel documentation change in state.md

### DIFF
--- a/examples/todo/Cargo.toml
+++ b/examples/todo/Cargo.toml
@@ -9,10 +9,10 @@ rocket_codegen = { path = "../../codegen" }
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
-r2d2 = "0.7"
-diesel = { version = "0.16", features = ["sqlite"] }
-diesel_codegen = { version = "0.16", features = ["sqlite"] }
-r2d2-diesel = "0.16"
+r2d2 = "0.8"
+diesel = { version = "*", features = ["sqlite"] }
+diesel_derives = { version = "*", features = ["sqlite"] }
+r2d2-diesel = "*"
 dotenv = "0.10.*" # workaround for broken dependencies
 
 [dev-dependencies]

--- a/examples/todo/Cargo.toml
+++ b/examples/todo/Cargo.toml
@@ -10,9 +10,9 @@ serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
 r2d2 = "0.8"
-diesel = { version = "*", features = ["sqlite"] }
-diesel_derives = { version = "*", features = ["sqlite"] }
-r2d2-diesel = "*"
+diesel = { version = "1.0.0-rc1", features = ["sqlite"] }
+diesel_derives = { version = "1.0.0-rc1", features = ["sqlite"] }
+r2d2-diesel = "1.0.0-rc1"
 dotenv = "0.10.*" # workaround for broken dependencies
 
 [dev-dependencies]

--- a/examples/todo/migrations/20160720150332_create_tasks_table/up.sql
+++ b/examples/todo/migrations/20160720150332_create_tasks_table/up.sql
@@ -2,4 +2,7 @@ CREATE TABLE tasks (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     description VARCHAR NOT NULL,
     completed BOOLEAN NOT NULL DEFAULT 0
-)
+);
+
+INSERT INTO tasks (description) VALUES ("demo task");
+INSERT INTO tasks (description) VALUES ("demo task2");

--- a/examples/todo/src/db.rs
+++ b/examples/todo/src/db.rs
@@ -10,12 +10,11 @@ use rocket::{Request, State, Outcome};
 
 pub type Pool = r2d2::Pool<ConnectionManager<SqliteConnection>>;
 
-pub const DATABASE_FILE: &'static str = env!("DATABASE_URL");
+pub const DATABASE_URL: &'static str = env!("DATABASE_URL");
 
 pub fn init_pool() -> Pool {
-    let config = r2d2::Config::default();
-    let manager = ConnectionManager::<SqliteConnection>::new(DATABASE_FILE);
-    r2d2::Pool::new(config, manager).expect("db pool")
+    let manager = ConnectionManager::<SqliteConnection>::new(DATABASE_URL);
+    r2d2::Pool::new(manager).expect("db pool")
 }
 
 pub struct Conn(pub r2d2::PooledConnection<ConnectionManager<SqliteConnection>>);

--- a/examples/todo/src/main.rs
+++ b/examples/todo/src/main.rs
@@ -3,7 +3,7 @@
 
 extern crate rocket;
 #[macro_use] extern crate diesel;
-#[macro_use] extern crate diesel_codegen;
+#[macro_use] extern crate diesel_derives;
 #[macro_use] extern crate serde_derive;
 extern crate rocket_contrib;
 extern crate r2d2;

--- a/examples/todo/src/task.rs
+++ b/examples/todo/src/task.rs
@@ -2,14 +2,20 @@ use diesel;
 use diesel::prelude::*;
 use diesel::sqlite::SqliteConnection;
 
+mod schema {
+    table! {
+        tasks {
+            id -> Nullable<Integer>,
+            description -> Text,
+            completed -> Bool,
+        }
+    }
+}
+
 use self::schema::tasks;
 use self::schema::tasks::dsl::{tasks as all_tasks, completed as task_completed};
 
-mod schema {
-    infer_schema!("env:DATABASE_URL");
-}
-
-#[table_name = "tasks"]
+#[table_name="tasks"]
 #[derive(Serialize, Queryable, Insertable, Debug, Clone)]
 pub struct Task {
     pub id: Option<i32>,
@@ -29,7 +35,7 @@ impl Task {
 
     pub fn insert(todo: Todo, conn: &SqliteConnection) -> bool {
         let t = Task { id: None, description: todo.description, completed: false };
-        diesel::insert(&t).into(tasks::table).execute(conn).is_ok()
+        diesel::insert_into(tasks::table).values(&t).execute(conn).is_ok()
     }
 
     pub fn toggle_with_id(id: i32, conn: &SqliteConnection) -> bool {
@@ -47,4 +53,3 @@ impl Task {
         diesel::delete(all_tasks.find(id)).execute(conn).is_ok()
     }
 }
-

--- a/site/guide/state.md
+++ b/site/guide/state.md
@@ -178,9 +178,9 @@ use the following dependencies:
 ```
 [dependencies]
 rocket = "0.4.0-dev"
-diesel = { version = "1.0.0-rc1", features = ["sqlite"] }
+diesel = { version = "*", features = ["sqlite"] }
 r2d2-diesel = "*"
-r2d2 = "*"
+r2d2 = "0.8.*"
 ```
 
 Your `diesel` dependency information will differ. In particular, you should

--- a/site/guide/state.md
+++ b/site/guide/state.md
@@ -180,7 +180,7 @@ use the following dependencies:
 rocket = "0.4.0-dev"
 diesel = { version = "*", features = ["sqlite"] }
 r2d2-diesel = "*"
-r2d2 = "0.8.*"
+r2d2 = "0.8"
 ```
 
 Your `diesel` dependency information will differ. In particular, you should

--- a/site/guide/state.md
+++ b/site/guide/state.md
@@ -166,7 +166,7 @@ fn handler(conn: DbConn) { ... }
 ```
 
 [`diesel`]: http://diesel.rs/
-[`r2d2`]: https://docs.rs/r2d2/0.7.2/r2d2/
+[`r2d2`]: https://docs.rs/r2d2/
 
 ### Dependencies
 

--- a/site/guide/state.md
+++ b/site/guide/state.md
@@ -178,8 +178,7 @@ use the following dependencies:
 ```
 [dependencies]
 rocket = "0.4.0-dev"
-diesel = { version = "*", features = ["sqlite"] }
-diesel_codegen = { version = "*", features = ["sqlite"] }
+diesel = { version = "1.0.0-rc1", features = ["sqlite"] }
 r2d2-diesel = "*"
 r2d2 = "*"
 ```
@@ -191,7 +190,6 @@ crates are imported as well:
 ```rust
 extern crate rocket;
 #[macro_use] extern crate diesel;
-#[macro_use] extern crate diesel_codegen;
 extern crate r2d2_diesel;
 extern crate r2d2;
 ```
@@ -219,9 +217,8 @@ static DATABASE_URL: &'static str = env!("DATABASE_URL");
 
 /// Initializes a database pool.
 fn init_pool() -> Pool {
-    let config = r2d2::Config::default();
     let manager = ConnectionManager::<SqliteConnection>::new(DATABASE_URL);
-    r2d2::Pool::new(config, manager).expect("db pool")
+    r2d2::Pool::new(manager).expect("db pool")
 }
 ```
 

--- a/site/guide/state.md
+++ b/site/guide/state.md
@@ -178,13 +178,12 @@ use the following dependencies:
 ```
 [dependencies]
 rocket = "0.4.0-dev"
-diesel = { version = "*", features = ["sqlite"] }
-r2d2-diesel = "*"
+diesel = { version = "1.0.0-rc1", features = ["sqlite"] }
+r2d2-diesel = "1.0.0-rc1"
 r2d2 = "0.8"
 ```
 
-Your `diesel` dependency information will differ. In particular, you should
-specify the latest versions of these libraries as opposed to using a `*`. The
+Your `diesel` dependency information may differ. The
 crates are imported as well:
 
 ```rust

--- a/site/guide/state.md
+++ b/site/guide/state.md
@@ -183,8 +183,8 @@ r2d2-diesel = "1.0.0-rc1"
 r2d2 = "0.8"
 ```
 
-Your `diesel` dependency information may differ. The
-crates are imported as well:
+Your `diesel` dependency information may differ. The crates are imported as
+well:
 
 ```rust
 extern crate rocket;


### PR DESCRIPTION
When I was trying to integrate Rocket with Diesel I got a few errors with the tutorial code. I opened [#1441](https://github.com/diesel-rs/diesel/issues/1441) in the diesel repository and made the changes necessary to fix the error to the documentation. Apparently diesel_codegen is deprecated in the latest version of diesel.