### PR TITLE
Fix: tera_templates using old catchers expressions

### DIFF
--- a/examples/tera_templates/Cargo.toml
+++ b/examples/tera_templates/Cargo.toml
@@ -6,9 +6,9 @@ workspace = "../../"
 [dependencies]
 rocket = { path = "../../lib" }
 rocket_codegen = { path = "../../codegen" }
-serde = "1.0"
-serde_derive = "1.0"
-serde_json = "1.0"
+serde = "1.0.27"
+serde_derive = "1.0.27"
+serde_json = "1.0.9"
 
 [dependencies.rocket_contrib]
 path = "../../contrib"

--- a/examples/tera_templates/src/main.rs
+++ b/examples/tera_templates/src/main.rs
@@ -31,7 +31,7 @@ fn get(name: String) -> Template {
     Template::render("index", &context)
 }
 
-#[catch(404)]
+#[error(404)]
 fn not_found(req: &Request) -> Template {
     let mut map = HashMap::new();
     map.insert("path", req.uri().as_str());
@@ -42,7 +42,7 @@ fn rocket() -> rocket::Rocket {
     rocket::ignite()
         .mount("/", routes![index, get])
         .attach(Template::fairing())
-        .catch(catchers![not_found])
+        .catch(errors![not_found])
 }
 
 fn main() {


### PR DESCRIPTION
`examples/tera_templates` example uses the old `catchers` syntax and produces the following error when run

```bash
error: cannot find macro `catchers!` in this scope
  --> src/main.rs:45:16
   |
45 |         .catch(catchers![not_found])
   |                ^^^^^^^^

error: aborting due to previous error
```

Based on the documentation for [rocket/struct.Catcher](https://api.rocket.rs/rocket/struct.Catcher.html#code-generation) I've resolved the issue. 

One of the side effects of doing this meant I also updated the `serde` dependencies to the latest release and confirmed example still functioned appropriately.

