### PR TITLE
Update cookie dependency revision

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -38,7 +38,7 @@ isatty = "0.1"
 
 [dependencies.cookie]
 git = "https://github.com/alexcrichton/cookie-rs"
-rev = "a15b37a"
+rev = "8579b4b7ca0fb4d698e0f4452d3fb55e9e72c50d"
 features = ["percent-encode", "secure"]
 
 [dev-dependencies]


### PR DESCRIPTION
Swapping to a different revision of `cookie` pulls in an updated version of `ring` which works around an issue in recent versions of nightly.  This allows Rocket to build successfully on the latest version of nightly.  