### PR TITLE
Update v0.3 to Handlebars 0.28.

### DIFF
--- a/contrib/Cargo.toml
+++ b/contrib/Cargo.toml
@@ -33,7 +33,7 @@ serde_json = { version = "1.0", optional = true }
 rmp-serde = { version = "^0.13", optional = true }
 
 # Templating dependencies only.
-handlebars = { version = "^0.27", optional = true }
+handlebars = { version = "^0.28", optional = true }
 glob = { version = "^0.2", optional = true }
 tera = { version = "^0.10", optional = true }
 


### PR DESCRIPTION
Handlebars 0.28 contains a fix to a performance regression in 0.27, which caused gratuitous copying for large data structures in the template context:

https://github.com/sunng87/handlebars-rust/pull/167