### PR TITLE
Feature: add wasm content type support

### DIFF
--- a/lib/src/http/known_media_types.rs
+++ b/lib/src/http/known_media_types.rs
@@ -24,6 +24,7 @@ macro_rules! known_media_types {
         WOFF (is_woff): "WOFF", "application", "font-woff",
         WOFF2 (is_woff2): "WOFF2", "font", "woff2",
         JsonApi (is_json_api): "JSON API", "application", "vnd.api+json",
+        WASM (is_wasm): "WASM", "application", "wasm",
     })
 }
 
@@ -49,5 +50,6 @@ macro_rules! known_extensions {
         "otf" => OTF,
         "woff" => WOFF,
         "woff2" => WOFF2,
+        "wasm" => WASM,
     })
 }


### PR DESCRIPTION
I was including wasm on my rocket application, but there's a warning in the developer console: 

`client.js:197 wasm streaming compile failed: TypeError: Incorrect response MIME type. Expected 'application/wasm'.`

This pull request add wasm support to known media types.