### PR TITLE
Make errors with binding more understandable

### DIFF
--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -33,6 +33,7 @@ pub enum Error {
 /// other kinds of launch errors.
 #[derive(Debug)]
 pub enum LaunchErrorKind {
+    Bind(hyper::Error),
     Io(io::Error),
     Collision(Vec<(Route, Route)>),
     FailedFairing,
@@ -158,6 +159,7 @@ impl fmt::Display for LaunchErrorKind {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
+            LaunchErrorKind::Bind(ref e) => write!(f, "failed to bind to given address: {}", e),
             LaunchErrorKind::Io(ref e) => write!(f, "I/O error: {}", e),
             LaunchErrorKind::Collision(_) => write!(f, "route collisions detected"),
             LaunchErrorKind::FailedFairing => write!(f, "a launch fairing failed"),
@@ -187,6 +189,7 @@ impl ::std::error::Error for LaunchError {
     fn description(&self) -> &str {
         self.mark_handled();
         match *self.kind() {
+            LaunchErrorKind::Bind(_) => "Failed to bind to given address",
             LaunchErrorKind::Io(_) => "an I/O error occured during launch",
             LaunchErrorKind::Collision(_) => "route collisions were detected",
             LaunchErrorKind::FailedFairing => "a launch fairing reported an error",
@@ -202,6 +205,10 @@ impl Drop for LaunchError {
         }
 
         match *self.kind() {
+            LaunchErrorKind::Bind(ref e) => {
+                error!("Rocket failed to launch due to binding issues.");
+                panic!("{}", e);
+            }
             LaunchErrorKind::Io(ref e) => {
                 error!("Rocket failed to launch due to an I/O error.");
                 panic!("{}", e);

--- a/lib/src/rocket.rs
+++ b/lib/src/rocket.rs
@@ -662,7 +662,7 @@ impl Rocket {
         serve!(self, &full_addr, |server, proto| {
             let mut server = match server {
                 Ok(server) => server,
-                Err(e) => return LaunchError::from(e),
+                Err(e) => return LaunchError::from(LaunchErrorKind::Bind(e)),
             };
 
             // Determine the address and port we actually binded to.


### PR DESCRIPTION
Specifically add `Bind` as a `LaunchErrorKind` discriminant to allow for errors binding (like trying to bind to port 80 without root) to be more understandable.