### PR TITLE
Update state guide to reflect Diesel reexport

### DIFF
--- a/examples/todo/Cargo.toml
+++ b/examples/todo/Cargo.toml
@@ -9,10 +9,7 @@ rocket_codegen = { path = "../../codegen" }
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
-r2d2 = "0.8"
-diesel = { version = "1.0", features = ["sqlite"] }
-diesel_derives = { version = "1.0", features = ["sqlite"] }
-r2d2-diesel = "1.0"
+diesel = { version = "1.0", features = ["sqlite", "r2d2"] }
 dotenv = "0.10"
 
 [dev-dependencies]

--- a/examples/todo/src/main.rs
+++ b/examples/todo/src/main.rs
@@ -3,11 +3,8 @@
 
 extern crate rocket;
 #[macro_use] extern crate diesel;
-#[macro_use] extern crate diesel_derives;
 #[macro_use] extern crate serde_derive;
 extern crate rocket_contrib;
-extern crate r2d2;
-extern crate r2d2_diesel;
 
 mod static_files;
 mod task;


### PR DESCRIPTION
Diesel now reexports r2d2 functionality, so rather than including that
library explicitly, it's better to leverage the reexport.