### PR TITLE
failed parsing in the case where `#` precedes `?`

### DIFF
--- a/lib/src/http/uri/uri.rs
+++ b/lib/src/http/uri/uri.rs
@@ -32,7 +32,8 @@ impl<'a> Uri<'a> {
 
         let end = uri.len();
         let (path, query, fragment) = match (qmark, hmark) {
-            (Some(i), Some(j)) => ((0, i), Some((i+1, j)), Some((j+1, end))),
+            (Some(i), Some(j)) if i < j => ((0, i), Some((i+1, j)), Some((j+1, end))),
+            (Some(_i), Some(j)) => ((0, j), None, Some((j+1, end))),
             (Some(i), None) => ((0, i), Some((i+1, end)), None),
             (None, Some(j)) => ((0, j), None, Some((j+1, end))),
             (None, None) => ((0, end), None, None),
@@ -547,6 +548,7 @@ mod tests {
         test_query("/a/b/c/d/e", None);
         test_query("/////", None);
         test_query("//a///", None);
+        test_query("/a/b/c#a?123", None);
     }
 
     #[test]
@@ -566,6 +568,7 @@ mod tests {
         test_fragment("/test#abc", Some("abc"));
         test_fragment("/#abc", Some("abc"));
         test_fragment("/a/b/c?123#a", Some("a"));
+        test_fragment("/a/b/c#a?123", Some("a?123"));
         test_fragment("/#a", Some("a"));
     }
 
@@ -588,5 +591,6 @@ mod tests {
         assert_eq!(uri_to_string("//a"), "/a".to_string());
         assert_eq!(uri_to_string("/a/b///c"), "/a/b/c".to_string());
         assert_eq!(uri_to_string("/a///b/c/d///"), "/a/b/c/d".to_string());
+        assert_eq!(uri_to_string("/a/b/c#a?123"), "/a/b/c#a?123".to_string());
     }
 }


### PR DESCRIPTION
fragment    = *( pchar / "/" / "?" )
https://www.ietf.org/rfc/rfc3986.txt