### PR TITLE
Parser error message: replace `above` by `below`.

### DIFF
--- a/codegen/src/parser/route.rs
+++ b/codegen/src/parser/route.rs
@@ -42,7 +42,7 @@ impl RouteParams {
     ) -> RouteParams {
         let function = Function::from(annotated).unwrap_or_else(|item_sp| {
             ecx.span_err(sp, "this attribute can only be used on functions...");
-            ecx.span_fatal(item_sp, "...but was applied to the item above.");
+            ecx.span_fatal(item_sp, "...but was applied to the item below.");
         });
 
         let meta_items = meta_item.meta_item_list().unwrap_or_else(|| {


### PR DESCRIPTION
Hi,

In this case:

```rust
#![feature(plugin, decl_macro)]
#![plugin(rocket_codegen)]

extern crate rocket;

#[cfg(test)] mod tests;

struct Foo;

impl Foo {

    #[get("/")]
	fn hello() -> &'static str {
		"Hello, world!"
	}

}

fn main() {
    rocket::ignite().mount("/", routes![hello]).launch();
}
```

I'm getting:

```rust
error: this attribute can only be used on functions...
  --> examples\hello_world\src\main.rs:12:5
   |
12 |     #[get("/")]
   |     ^^^^^^^^^^^

error: ...but was applied to the item above.
  --> examples\hello_world\src\main.rs:13:2
   |
13 |       fn hello() -> &'static str {
   |  _____^
14 | |         "Hello, world!"
15 | |     }
   | |_____^

error: Could not compile `hello_world`.
```

> ...but was applied to the item **above**.

But `fn hello` is **below** this error message.