### PR TITLE
Add support for listening on Unix socket

### DIFF
--- a/core/http/Cargo.toml
+++ b/core/http/Cargo.toml
@@ -36,5 +36,9 @@ version = "=0.3.0-rc.5"
 features = ["server"]
 optional = true
 
+[target.'cfg(windows)'.dependencies]
+# Used for Windows Unix domain socket support
+uds_windows = "0.1.4"
+
 [dev-dependencies]
 rocket = { version = "0.5.0-dev", path = "../lib" }

--- a/core/http/src/hyper.rs
+++ b/core/http/src/hyper.rs
@@ -10,13 +10,13 @@
 #[doc(hidden)] pub use hyper::server::Handler as Handler;
 
 #[doc(hidden)] pub use hyper::net;
-
 #[doc(hidden)] pub use hyper::method::Method;
 #[doc(hidden)] pub use hyper::status::StatusCode;
 #[doc(hidden)] pub use hyper::error::Error;
 #[doc(hidden)] pub use hyper::uri::RequestUri;
 #[doc(hidden)] pub use hyper::http::h1;
 #[doc(hidden)] pub use hyper::buffer;
+#[doc(hidden)] pub use hyper::Result;
 
 pub use hyper::mime;
 

--- a/core/http/src/lib.rs
+++ b/core/http/src/lib.rs
@@ -21,7 +21,7 @@ pub mod uri;
 pub mod ext;
 
 #[doc(hidden)]
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 pub mod unix;
 
 #[doc(hidden)]

--- a/core/http/src/lib.rs
+++ b/core/http/src/lib.rs
@@ -21,6 +21,10 @@ pub mod uri;
 pub mod ext;
 
 #[doc(hidden)]
+#[cfg(unix)]
+pub mod unix;
+
+#[doc(hidden)]
 #[cfg(feature = "tls")]
 pub mod tls;
 

--- a/core/http/src/tls.rs
+++ b/core/http/src/tls.rs
@@ -1,2 +1,2 @@
-pub use hyper_sync_rustls::{util, WrappedStream, ServerSession, TlsServer};
+pub use hyper_sync_rustls::{util, WrappedStream, ServerSession, TlsServer, TlsStream};
 pub use rustls::{Certificate, PrivateKey};

--- a/core/http/src/unix.rs
+++ b/core/http/src/unix.rs
@@ -4,7 +4,10 @@ use std::io::{self, Read, Write};
 use std::path::Path;
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 use std::time::Duration;
+#[cfg(unix)]
 use std::os::unix::net::{UnixListener, UnixStream};
+#[cfg(windows)]
+use uds_windows::{UnixListener, UnixStream};
 
 use crate::hyper;
 use crate::hyper::net::{NetworkStream, NetworkListener};

--- a/core/http/src/unix.rs
+++ b/core/http/src/unix.rs
@@ -1,0 +1,184 @@
+//! Provides hyper client and server bindings for unix domain sockets.
+
+use std::io::{self, Read, Write};
+use std::path::Path;
+use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+use std::time::Duration;
+use std::os::unix::net::{UnixListener, UnixStream};
+
+use crate::hyper;
+use crate::hyper::net::{NetworkStream, NetworkListener};
+use crate::hyper::Server;
+
+/// A type which implements hyper's NetworkStream trait.
+pub struct UnixSocketStream(pub UnixStream);
+
+impl Clone for UnixSocketStream {
+    #[inline]
+    fn clone(&self) -> UnixSocketStream {
+        UnixSocketStream(self.0.try_clone().unwrap())
+    }
+}
+
+impl NetworkStream for UnixSocketStream {
+    #[inline]
+    fn peer_addr(&mut self) -> io::Result<SocketAddr> {
+        self.0.peer_addr()
+            .map(|_| SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), 0)))
+    }
+
+    #[inline]
+    fn set_read_timeout(&self, dur: Option<Duration>) -> io::Result<()> {
+        self.0.set_read_timeout(dur)
+    }
+
+    #[inline]
+    fn set_write_timeout(&self, dur: Option<Duration>) -> io::Result<()> {
+        self.0.set_write_timeout(dur)
+    }
+}
+
+impl Read for UnixSocketStream {
+    #[inline]
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.0.read(buf)
+    }
+}
+
+impl Write for UnixSocketStream {
+    #[inline]
+    fn write(&mut self, msg: &[u8]) -> io::Result<usize> {
+        self.0.write(msg)
+    }
+
+    #[inline]
+    fn flush(&mut self) -> io::Result<()> {
+        self.0.flush()
+    }
+}
+
+/// A type which implements hyper's NetworkListener trait
+#[derive(Debug)]
+pub struct UnixSocketListener(pub UnixListener);
+
+impl Clone for UnixSocketListener {
+    #[inline]
+    fn clone(&self) -> UnixSocketListener {
+        UnixSocketListener(self.0.try_clone().unwrap())
+    }
+}
+
+impl UnixSocketListener {
+    /// Start listening to an address over HTTP.
+    pub fn new<P: AsRef<Path>>(addr: P) -> hyper::Result<UnixSocketListener> {
+        Ok(UnixSocketListener(UnixListener::bind(addr)?))
+    }
+}
+
+impl NetworkListener for UnixSocketListener {
+    type Stream = UnixSocketStream;
+
+    #[inline]
+    fn accept(&mut self) -> hyper::Result<UnixSocketStream> {
+        Ok(UnixSocketStream(self.0.accept()?.0))
+    }
+
+    #[inline]
+    fn local_addr(&mut self) -> io::Result<SocketAddr> {
+        // return a dummy addr
+        self.0.local_addr().map(|_| {
+            SocketAddr::V4(
+                SocketAddrV4::new(
+                    Ipv4Addr::new(0, 0, 0, 0), 0
+                )
+            )
+        })
+    }
+}
+
+/// A type that provides a factory interface for creating unix socket based
+/// hyper servers.
+pub struct UnixSocketServer;
+
+impl UnixSocketServer {
+    /// creates a new hyper Server from a unix socket path
+    pub fn http<P>(path: P) -> hyper::Result<Server<UnixSocketListener>>
+        where P: AsRef<Path>
+    {
+        UnixSocketListener::new(path).map(Server::new)
+    }
+}
+
+#[cfg(feature = "tls")]
+mod tls {
+    use super::*;
+
+    use crate::hyper::{self, net::SslServer};
+    use crate::tls::{TlsStream, ServerSession, TlsServer, WrappedStream};
+    use crate::unix::UnixSocketStream;
+
+    pub type UnixHttpsStream = WrappedStream<ServerSession, UnixSocketStream>;
+
+    impl UnixSocketServer {
+        pub fn https<P, S>(path: P, ssl: S) -> hyper::Result<Server<HttpsListener<S>>>
+            where P: AsRef<Path>, S: SslServer<UnixSocketStream> + Clone
+        {
+            HttpsListener::new(path, ssl).map(Server::new)
+        }
+    }
+
+    #[derive(Clone)]
+    pub struct HttpsListener<S: SslServer<UnixSocketStream>> {
+        listener: UnixSocketListener,
+        ssl: S,
+    }
+
+    impl<S: SslServer<UnixSocketStream>> HttpsListener<S> {
+        /// Start listening to an address over HTTPS.
+        pub fn new<P>(path: P, ssl: S) -> hyper::Result<HttpsListener<S>>
+            where P: AsRef<Path>
+        {
+            UnixSocketListener::new(path)
+                .map(|listener| HttpsListener { listener, ssl })
+        }
+    }
+
+    impl<S> NetworkListener for HttpsListener<S>
+        where S: SslServer<UnixSocketStream> + Clone
+    {
+        type Stream = S::Stream;
+
+        #[inline]
+        fn accept(&mut self) -> hyper::Result<S::Stream> {
+            self.listener.accept().and_then(|s| self.ssl.wrap_server(s))
+        }
+
+        #[inline]
+        fn local_addr(&mut self) -> io::Result<SocketAddr> {
+            self.listener.local_addr()
+        }
+
+        fn set_read_timeout(&mut self, duration: Option<Duration>) {
+            self.listener.set_read_timeout(duration)
+        }
+
+        fn set_write_timeout(&mut self, duration: Option<Duration>) {
+            self.listener.set_write_timeout(duration)
+        }
+    }
+
+    impl SslServer<UnixSocketStream> for TlsServer {
+        type Stream = WrappedStream<ServerSession, UnixSocketStream>;
+
+        fn wrap_server(
+            &self,
+            stream: UnixSocketStream
+        ) -> hyper::Result<WrappedStream<ServerSession, UnixSocketStream>> {
+            let tls = TlsStream::new(rustls::ServerSession::new(&self.cfg), stream);
+            Ok(WrappedStream::new(tls))
+        }
+    }
+}
+
+#[cfg(feature = "tls")]
+pub use self::tls::*;

--- a/core/lib/Cargo.toml
+++ b/core/lib/Cargo.toml
@@ -37,6 +37,10 @@ base64 = "0.10"
 pear = "0.1"
 atty = "0.2"
 
+[target.'cfg(unix)'.dependencies]
+# Used for unix domain socket file locking.
+fs2 = "0.4"
+
 [build-dependencies]
 yansi = "0.5"
 version_check = "0.9.1"

--- a/core/lib/Cargo.toml
+++ b/core/lib/Cargo.toml
@@ -37,8 +37,8 @@ base64 = "0.10"
 pear = "0.1"
 atty = "0.2"
 
-[target.'cfg(unix)'.dependencies]
-# Used for unix domain socket file locking.
+[target.'cfg(any(unix, windows))'.dependencies]
+# Used for Unix domain socket file locking.
 fs2 = "0.4"
 
 [build-dependencies]

--- a/core/lib/src/config/address.rs
+++ b/core/lib/src/config/address.rs
@@ -1,0 +1,77 @@
+use std::{io, fmt};
+use std::str::FromStr;
+use std::path::PathBuf;
+use std::net::{IpAddr, ToSocketAddrs};
+
+/// The configured address to serve a Rocket application on.
+///
+/// Addresses can be specified as either IP addresses or hostnames. On Unix
+/// platforms, addresses can also be paths to Unix domain sockets specified as
+/// `unix:path/to/socket`.
+///
+/// When a hostname is specified, it is resolved to the _first available_ IP
+/// address for the given hostname. Rocket _does not_ bind to all addresses
+/// available for a given hostname. For example, if both `127.0.0.1` and `::1`
+/// are specified for `localhost`, the first address available of the two will
+/// be used, and the other address will be ignored by Rocket.
+///
+/// When a Unix domain socket is specified, a lock file named
+/// `path/to/socket.lock` is created and locked. If locking fails, application
+/// launch is aborted. Additionally, if `path/to/socket` does not exist, it is
+/// created. Both the lock file and the socket file are unconditionally deleted
+/// upon server termination.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Address {
+    /// The hostname to serve over TCP.
+    Hostname(String),
+    /// The IP address to serve over TCP.
+    Ip(IpAddr),
+    /// The path to the unix domain socket.
+    Unix(PathBuf),
+}
+
+impl Address {
+    crate const UNIX_PREFIX: &'static str = "unix:";
+
+    crate fn is_unix(&self) -> bool {
+        match self {
+            Address::Unix(..) => true,
+            _ => false
+        }
+    }
+}
+
+impl FromStr for Address {
+    type Err = io::Error;
+
+    fn from_str(string: &str) -> io::Result<Self> {
+        #[cfg(unix)]
+        {
+            if string.starts_with(Address::UNIX_PREFIX) {
+                let address = &string[Address::UNIX_PREFIX.len()..];
+                return Ok(Address::Unix(address.into()));
+            }
+        }
+
+        // Use `to_socket_addr` to check for address resolution, _not_ for parsing.
+        if (string, 0).to_socket_addrs()?.next().is_some() {
+            if let Ok(ip) = IpAddr::from_str(string) {
+                return Ok(Address::Ip(ip));
+            } else {
+                return Ok(Address::Hostname(string.into()));
+            }
+        }
+
+        Err(io::Error::new(io::ErrorKind::Other, "failed to resolve TCP address"))
+    }
+}
+
+impl fmt::Display for Address {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Address::Hostname(name) => name.fmt(f),
+            Address::Ip(addr) => addr.fmt(f),
+            Address::Unix(path) => write!(f, "{}{}", Address::UNIX_PREFIX, path.display()),
+        }
+    }
+}

--- a/core/lib/src/config/address.rs
+++ b/core/lib/src/config/address.rs
@@ -45,7 +45,7 @@ impl FromStr for Address {
     type Err = io::Error;
 
     fn from_str(string: &str) -> io::Result<Self> {
-        #[cfg(unix)]
+        #[cfg(any(unix, windows))]
         {
             if string.starts_with(Address::UNIX_PREFIX) {
                 let address = &string[Address::UNIX_PREFIX.len()..];

--- a/core/lib/src/config/config.rs
+++ b/core/lib/src/config/config.rs
@@ -341,7 +341,8 @@ impl Config {
     /// # Errors
     ///
     /// If `address` is not a valid IP address, hostname or (on Unix platforms
-    /// only) a Unix domain socket, returns a `BadType` error.
+    /// or Windows 10/Server version 1809 and later only) a Unix domain socket,
+    /// returns a `BadType` error.
     ///
     /// # Example
     ///
@@ -355,8 +356,8 @@ impl Config {
     /// ```
     pub fn set_address<A: Into<String>>(&mut self, address: A) -> Result<()> {
         let address = address.into().parse::<Address>().map_err(|_| {
-            #[cfg(unix)] let msg = "a valid hostname, IP, or Unix domain socket path";
-            #[cfg(not(unix))] let msg = "a valid hostname or IP";
+            #[cfg(any(unix, windows))] let msg = "a valid hostname, IP, or Unix domain socket path";
+            #[cfg(not(any(unix, windows)))] let msg = "a valid hostname or IP";
             self.bad_type("address", "string", msg)
         })?;
 

--- a/core/lib/src/config/custom_values.rs
+++ b/core/lib/src/config/custom_values.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::ops::{Deref, DerefMut};
 
 #[cfg(feature = "tls")] use crate::http::tls::{Certificate, PrivateKey};
 
@@ -39,6 +40,54 @@ impl fmt::Display for SecretKey {
 
         #[cfg(not(feature = "private-cookies"))]
         write!(f, "private-cookies disabled")
+    }
+}
+
+/// The configured port to serve a Rocket application on.
+#[derive(Copy, Clone, Debug)]
+pub enum Port {
+    Generated(u16),
+    Provided(u16)
+}
+
+impl Deref for Port {
+    type Target = u16;
+
+    fn deref(&self) -> &u16 {
+        match self { Port::Generated(v) | Port::Provided(v) => v }
+    }
+}
+
+impl DerefMut for Port {
+    fn deref_mut(&mut self) -> &mut u16 {
+        match self { Port::Generated(v) | Port::Provided(v) => v }
+    }
+}
+
+impl PartialEq for Port {
+    fn eq(&self, other: &Self) -> bool {
+        self.value() == other.value()
+    }
+}
+
+impl Port {
+    crate fn value(self) -> u16 {
+        match self {
+            Port::Generated(v) | Port::Provided(v) => v
+        }
+    }
+
+    crate fn is_generated(&self) -> bool {
+        match *self {
+            Port::Generated(_) => true,
+            _ => false
+        }
+    }
+}
+
+impl fmt::Display for Port {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.value().fmt(f)
     }
 }
 

--- a/core/lib/src/config/error.rs
+++ b/core/lib/src/config/error.rs
@@ -149,7 +149,7 @@ impl fmt::Display for ConfigError {
             }
             BadEnvVal(ref k, ref v, _) => {
                 write!(f, "environment variable '{}={}' could not be parsed", k, v)
-            }
+            },
         }
     }
 }

--- a/core/lib/src/config/mod.rs
+++ b/core/lib/src/config/mod.rs
@@ -659,7 +659,7 @@ mod test {
                           default_config(Development).address("0.0.0.0")
                       });
 
-        #[cfg(unix)]
+        #[cfg(any(unix, windows))]
         {
             check_config!(RocketConfig::parse(r#"
                             [dev]
@@ -696,7 +696,7 @@ mod test {
             address = "1.2.3.4:100"
         "#.to_string(), TEST_CONFIG_FILENAME).is_err());
 
-        #[cfg(unix)]
+        #[cfg(any(unix, windows))]
         {
             assert!(RocketConfig::parse(r#"
                 [staging]
@@ -706,15 +706,6 @@ mod test {
             assert!(RocketConfig::parse(r#"
                 [staging]
                 address = "/tmp/rocket.sock"
-            "#.to_string(), TEST_CONFIG_FILENAME).is_err());
-        }
-
-        #[cfg(windows)]
-        {
-            // No Unix domain socket support for Windows in Rocket yet.
-            assert!(RocketConfig::parse(r#"
-                [staging]
-                address = "unix:/tmp/rocket.sock"
             "#.to_string(), TEST_CONFIG_FILENAME).is_err());
         }
     }

--- a/core/lib/src/data/net_stream.rs
+++ b/core/lib/src/data/net_stream.rs
@@ -8,6 +8,8 @@ use crate::http::hyper::net::{HttpStream, NetworkStream};
 use self::NetStream::*;
 
 #[cfg(feature = "tls")] pub type HttpsStream = WrappedStream<ServerSession>;
+#[cfg(unix)] use crate::http::unix::UnixSocketStream;
+#[cfg(all(unix, feature = "tls"))] use crate::http::unix::UnixHttpsStream;
 
 // This is a representation of all of the possible network streams we might get.
 // This really shouldn't be necessary, but, you know, Hyper.
@@ -16,6 +18,10 @@ pub enum NetStream {
     Http(HttpStream),
     #[cfg(feature = "tls")]
     Https(HttpsStream),
+    #[cfg(unix)]
+    UnixHttp(UnixSocketStream),
+    #[cfg(all(unix, feature = "tls"))]
+    UnixHttps(UnixHttpsStream),
     Empty,
 }
 
@@ -26,6 +32,8 @@ impl io::Read for NetStream {
         let res = match *self {
             Http(ref mut stream) => stream.read(buf),
             #[cfg(feature = "tls")] Https(ref mut stream) => stream.read(buf),
+            #[cfg(unix)] UnixHttp(ref mut stream) => stream.read(buf),
+            #[cfg(all(unix, feature = "tls"))] UnixHttps(ref mut stream) => stream.read(buf),
             Empty => Ok(0),
         };
 
@@ -39,8 +47,10 @@ impl io::Write for NetStream {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         trace_!("NetStream::write()");
         match *self {
-            Http(ref mut stream) => stream.write(buf),
-            #[cfg(feature = "tls")] Https(ref mut stream) => stream.write(buf),
+            Http(ref mut s) => s.write(buf),
+            #[cfg(feature = "tls")] Https(ref mut s) => s.write(buf),
+            #[cfg(unix)] UnixHttp(ref mut s) => s.write(buf),
+            #[cfg(all(unix, feature = "tls"))] UnixHttps(ref mut s) => s.write(buf),
             Empty => Ok(0),
         }
     }
@@ -48,8 +58,10 @@ impl io::Write for NetStream {
     #[inline(always)]
     fn flush(&mut self) -> io::Result<()> {
         match *self {
-            Http(ref mut stream) => stream.flush(),
-            #[cfg(feature = "tls")] Https(ref mut stream) => stream.flush(),
+            Http(ref mut s) => s.flush(),
+            #[cfg(feature = "tls")] Https(ref mut s) => s.flush(),
+            #[cfg(unix)] UnixHttp(ref mut s) => s.flush(),
+            #[cfg(all(unix, feature = "tls"))] UnixHttps(ref mut s) => s.flush(),
             Empty => Ok(()),
         }
     }
@@ -59,26 +71,32 @@ impl NetworkStream for NetStream {
     #[inline(always)]
     fn peer_addr(&mut self) -> io::Result<SocketAddr> {
         match *self {
-            Http(ref mut stream) => stream.peer_addr(),
-            #[cfg(feature = "tls")] Https(ref mut stream) => stream.peer_addr(),
+            Http(ref mut s) => s.peer_addr(),
+            #[cfg(feature = "tls")] Https(ref mut s) => s.peer_addr(),
+            #[cfg(unix)] UnixHttp(ref mut s) => s.peer_addr(),
+            #[cfg(all(unix, feature = "tls"))] UnixHttps(ref mut s) => s.peer_addr(),
             Empty => Err(io::Error::from(io::ErrorKind::AddrNotAvailable)),
         }
     }
 
     #[inline(always)]
-    fn set_read_timeout(&self, dur: Option<Duration>) -> io::Result<()> {
+    fn set_read_timeout(&self, d: Option<Duration>) -> io::Result<()> {
         match *self {
-            Http(ref stream) => stream.set_read_timeout(dur),
-            #[cfg(feature = "tls")] Https(ref stream) => stream.set_read_timeout(dur),
+            Http(ref s) => s.set_read_timeout(d),
+            #[cfg(feature = "tls")] Https(ref s) => s.set_read_timeout(d),
+            #[cfg(unix)] UnixHttp(ref s) => s.set_read_timeout(d),
+            #[cfg(all(unix, feature = "tls"))] UnixHttps(ref s) => s.set_read_timeout(d),
             Empty => Ok(()),
         }
     }
 
     #[inline(always)]
-    fn set_write_timeout(&self, dur: Option<Duration>) -> io::Result<()> {
+    fn set_write_timeout(&self, d: Option<Duration>) -> io::Result<()> {
         match *self {
-            Http(ref stream) => stream.set_write_timeout(dur),
-            #[cfg(feature = "tls")] Https(ref stream) => stream.set_write_timeout(dur),
+            Http(ref s) => s.set_write_timeout(d),
+            #[cfg(feature = "tls")] Https(ref s) => s.set_write_timeout(d),
+            #[cfg(unix)] UnixHttp(ref s) => s.set_write_timeout(d),
+            #[cfg(all(unix, feature = "tls"))] UnixHttps(ref s) => s.set_write_timeout(d),
             Empty => Ok(()),
         }
     }
@@ -86,9 +104,35 @@ impl NetworkStream for NetStream {
     #[inline(always)]
     fn close(&mut self, how: Shutdown) -> io::Result<()> {
         match *self {
-            Http(ref mut stream) => stream.close(how),
-            #[cfg(feature = "tls")] Https(ref mut stream) => stream.close(how),
+            Http(ref mut s) => s.close(how),
+            #[cfg(feature = "tls")] Https(ref mut s) => s.close(how),
+            #[cfg(unix)] UnixHttp(ref mut s) => s.close(how),
+            #[cfg(all(unix, feature = "tls"))] UnixHttps(ref mut s) => s.close(how),
             Empty => Ok(()),
         }
     }
+}
+
+#[inline]
+#[cfg(all(unix, not(feature = "tls")))]
+crate fn try_socket_stream_downcast(stream: &mut dyn NetworkStream) -> Option<NetStream> {
+    stream.downcast_ref::<UnixSocketStream>()
+        .map(|s| NetStream::UnixHttp(s.clone()))
+}
+
+#[inline]
+#[cfg(all(unix, feature = "tls"))]
+crate fn try_socket_stream_downcast(stream: &mut dyn NetworkStream) -> Option<NetStream> {
+    stream.downcast_ref::<UnixHttpsStream>()
+        .map(|s| NetStream::UnixHttps(s.clone()))
+        .or_else(|| {
+            stream.downcast_ref::<UnixSocketStream>()
+                .map(|s| NetStream::UnixHttp(s.clone()))
+        })
+}
+
+#[inline]
+#[cfg(not(unix))]
+crate fn try_socket_stream_downcast(_stream: &mut dyn NetworkStream) -> Option<NetStream> {
+    None
 }

--- a/core/lib/src/lib.rs
+++ b/core/lib/src/lib.rs
@@ -125,6 +125,7 @@ pub mod http {
     pub use rocket_http::*;
 }
 
+#[cfg(unix)] #[macro_use] mod unix;
 mod router;
 mod rocket;
 mod codegen;

--- a/core/lib/src/lib.rs
+++ b/core/lib/src/lib.rs
@@ -125,7 +125,7 @@ pub mod http {
     pub use rocket_http::*;
 }
 
-#[cfg(unix)] #[macro_use] mod unix;
+#[cfg(any(unix, windows))] #[macro_use] mod unix;
 mod router;
 mod rocket;
 mod codegen;

--- a/core/lib/src/rocket.rs
+++ b/core/lib/src/rocket.rs
@@ -94,7 +94,7 @@ impl hyper::Handler for Rocket {
 #[cfg(not(feature = "tls"))]
 macro_rules! serve {
     ($rocket:expr, |$server:ident, $proto:ident| $continue:expr) => ({
-        #[cfg(unix)]
+        #[cfg(any(unix, windows))]
         {
             if $rocket.config.address.is_unix() {
                 serve_unix_socket!($rocket, |$server, $proto| $continue);
@@ -109,7 +109,7 @@ macro_rules! serve {
 #[cfg(feature = "tls")]
 macro_rules! serve {
     ($rocket:expr, |$server:ident, $proto:ident| $continue:expr) => ({
-        #[cfg(unix)]
+        #[cfg(any(unix, windows))]
         {
             if $rocket.config.address.is_unix() {
                 serve_unix_socket!($rocket, |$server, $proto| $continue);

--- a/core/lib/src/unix.rs
+++ b/core/lib/src/unix.rs
@@ -25,7 +25,7 @@ crate fn lock_socket<P: AsRef<Path>>(path: P) -> Result<File, LaunchError> {
     Ok(lock_file)
 }
 
-#[cfg(all(unix, not(feature = "tls")))]
+#[cfg(not(feature = "tls"))]
 macro_rules! serve_unix_socket {
     ($rocket:expr, |$server:ident, $proto:ident| $continue:expr) => ({
         use $crate::http::unix::UnixSocketServer;
@@ -42,7 +42,7 @@ macro_rules! serve_unix_socket {
     })
 }
 
-#[cfg(all(unix, feature = "tls"))]
+#[cfg(feature = "tls")]
 macro_rules! serve_unix_socket {
     ($rocket:expr, |$server:ident, $proto:ident| $continue:expr) => ({
         use $crate::http::unix::UnixSocketServer;

--- a/core/lib/src/unix.rs
+++ b/core/lib/src/unix.rs
@@ -1,0 +1,66 @@
+use crate::error::{LaunchError, LaunchErrorKind};
+use std::path::Path;
+use std::fs::{self, File};
+
+crate fn lock_socket<P: AsRef<Path>>(path: P) -> Result<File, LaunchError> {
+    use fs2::FileExt;
+
+    let path = path.as_ref();
+    let lock_path = path.with_extension("lock");
+
+    let lock_file = fs::OpenOptions::new()
+        .read(true).write(true).create(true)
+        .open(&lock_path)?;
+
+    lock_file
+        .try_lock_exclusive()
+        .map_err(|e| LaunchError::new(LaunchErrorKind::FailedSocketLock(lock_path, e)))?;
+
+    if path.exists() {
+        fs::remove_file(path)?;
+    }
+
+    // On Unix, the file remains until the last handle to it is closed. We
+    // return the handle to the user. When it is dropped, the lock will free.
+    Ok(lock_file)
+}
+
+#[cfg(all(unix, not(feature = "tls")))]
+macro_rules! serve_unix_socket {
+    ($rocket:expr, |$server:ident, $proto:ident| $continue:expr) => ({
+        use $crate::http::unix::UnixSocketServer;
+        use $crate::config::Address;
+
+        let path = $rocket.config.full_address();
+        let _lock_file = match $crate::unix::lock_socket(&path) {
+            Ok(file) => file,
+            Err(e) => return e
+        };
+
+        let ($proto, $server) = (Address::UNIX_PREFIX, UnixSocketServer::http(path));
+        $continue
+    })
+}
+
+#[cfg(all(unix, feature = "tls"))]
+macro_rules! serve_unix_socket {
+    ($rocket:expr, |$server:ident, $proto:ident| $continue:expr) => ({
+        use $crate::http::unix::UnixSocketServer;
+        use $crate::config::Address;
+
+        let path = $rocket.config.full_address();
+        let _lock_file = match $crate::unix::lock_socket(&path) {
+            Ok(file) => file,
+            Err(e) => return e
+        };
+
+        if let Some(tls) = $rocket.config.tls.clone() {
+            let tls = $crate::http::tls::TlsServer::new(tls.certs, tls.key);
+            let ($proto, $server) = (Address::UNIX_PREFIX, UnixSocketServer::https(path, tls));
+            $continue
+        } else {
+            let ($proto, $server) = (Address::UNIX_PREFIX, UnixSocketServer::http(path));
+            $continue
+        }
+    })
+}

--- a/examples/config/tests/common/mod.rs
+++ b/examples/config/tests/common/mod.rs
@@ -16,8 +16,8 @@ fn check_config(config: State<'_, LocalConfig>) -> Option<()> {
     let config = &config.0;
     match &*environment {
         "development" => {
-            assert_eq!(config.address, "localhost".to_string());
-            assert_eq!(config.port, 8000);
+            assert_eq!(config.address.to_string(), "localhost");
+            assert_eq!(*config.port, 8000);
             assert_eq!(config.workers, 1);
             assert_eq!(config.log_level, LoggingLevel::Normal);
             assert_eq!(config.environment, config::Environment::Development);
@@ -26,16 +26,16 @@ fn check_config(config: State<'_, LocalConfig>) -> Option<()> {
             assert_eq!(config.get_bool("is_extra"), Ok(true));
         }
         "staging" => {
-            assert_eq!(config.address, "0.0.0.0".to_string());
-            assert_eq!(config.port, 8000);
+            assert_eq!(config.address.to_string(), "0.0.0.0");
+            assert_eq!(*config.port, 8000);
             assert_eq!(config.workers, 8);
             assert_eq!(config.log_level, LoggingLevel::Normal);
             assert_eq!(config.environment, config::Environment::Staging);
             assert_eq!(config.extras().count(), 0);
         }
         "production" => {
-            assert_eq!(config.address, "0.0.0.0".to_string());
-            assert_eq!(config.port, 8000);
+            assert_eq!(config.address.to_string(), "0.0.0.0");
+            assert_eq!(*config.port, 8000);
             assert_eq!(config.workers, 12);
             assert_eq!(config.log_level, LoggingLevel::Critical);
             assert_eq!(config.environment, config::Environment::Production);


### PR DESCRIPTION
TODO:

- [x] Safely delete existing socket on startup
- [x] Emit error when both `address` and `port` are specified(But what if I want to listen on both tcp and unix sockets?)
- [x] TLS over unix socket

Closes #545 