### PR TITLE
Add doc string to silence missing_docs lint

### DIFF
--- a/codegen/src/decorators/catch.rs
+++ b/codegen/src/decorators/catch.rs
@@ -83,6 +83,7 @@ pub fn catch_decorator(
     // Push the static catch info. This is what the `catchers!` macro refers to.
     let struct_name = user_fn_name.prepend(CATCH_STRUCT_PREFIX);
     emit_item(&mut output, quote_item!(ecx,
+        /// Rocket code generated static catch information structure.
         #[allow(non_upper_case_globals)]
         pub static $struct_name: ::rocket::StaticCatchInfo =
             ::rocket::StaticCatchInfo {


### PR DESCRIPTION
Basically the same as https://github.com/SergioBenitez/Rocket/commit/0d18faf91ee473b29e91bb26e94908c2976777b9 but for catch instead of route.