### PR TITLE
Add the `never_type` feature back

### DIFF
--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -3,6 +3,7 @@
 #![feature(plugin, decl_macro)]
 #![feature(try_trait)]
 #![feature(fnbox)]
+#![feature(never_type)]
 #![recursion_limit="256"]
 
 #![plugin(pear_codegen)]


### PR DESCRIPTION
 * The stabilization of this feature has been reverted in the latest nightly because of some bugs.  By adding this back in, we allow Rocket to compile on the latest nightly again.