### PR TITLE
Custom request methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
   "codegen_next/",
   "contrib/",
   "examples/cookies",
+  "examples/custom_method",
   "examples/errors",
   "examples/form_validation",
   "examples/hello_person",

--- a/codegen/src/decorators/route.rs
+++ b/codegen/src/decorators/route.rs
@@ -8,20 +8,13 @@ use utils::*;
 
 use syntax::codemap::{Span, Spanned, dummy_spanned};
 use syntax::tokenstream::TokenTree;
-use syntax::ast::{Arg, Ident, Item, Stmt, Expr, MetaItem, Path};
+use syntax::ast::{Arg, Ident, Item, Stmt, Expr, MetaItem};
 use syntax::ext::base::{Annotatable, ExtCtxt};
-use syntax::ext::build::AstBuilder;
 use syntax::parse::token;
 use syntax::symbol::LocalInternedString;
 use syntax::ptr::P;
 
 use rocket::http::{Method, MediaType};
-
-fn method_to_path(ecx: &ExtCtxt, method: Method) -> Path {
-    quote_enum!(ecx, method => ::rocket::http::Method {
-        Options, Get, Post, Put, Delete, Head, Trace, Connect, Patch;
-    })
-}
 
 // FIXME: I think we also want the attributes here.
 fn media_type_to_expr(ecx: &ExtCtxt, ct: Option<MediaType>) -> Option<P<Expr>> {
@@ -260,16 +253,17 @@ impl RouteParams {
         ).expect("consistent uri macro item")
     }
 
-    fn explode(&self, ecx: &ExtCtxt) -> (LocalInternedString, &str, Path, P<Expr>, P<Expr>) {
+    fn explode(&self, ecx: &ExtCtxt) -> (LocalInternedString, &str, &str, P<Expr>, P<Expr>) {
         let name = self.annotated_fn.ident().name.as_str();
         let path = &self.uri.node.as_str();
-        let method = method_to_path(ecx, self.method.node);
+        let method = self.method.node.as_str();
         let format = self.format.as_ref().map(|kv| kv.value().clone());
         let media_type = option_as_expr(ecx, &media_type_to_expr(ecx, format));
         let rank = option_as_expr(ecx, &self.rank);
 
         (name, path, method, media_type, rank)
     }
+
 }
 
 // FIXME: Compilation fails when parameters have the same name as the function!

--- a/codegen/src/parser/route.rs
+++ b/codegen/src/parser/route.rs
@@ -187,7 +187,7 @@ fn parse_method(ecx: &ExtCtxt, meta_item: &NestedMetaItem) -> Spanned<Method> {
         }
     }
     if let Some(word) = meta_item.word() {
-        if let Ok(method) = Method::from_str(&word.ident.name.as_str()) {
+        if let Ok(method) = Method::from_str(&word.name().as_str()) {
             if is_valid_method(method.clone()) {
                 return span(method, word.span());
             }

--- a/codegen/src/parser/route.rs
+++ b/codegen/src/parser/route.rs
@@ -131,7 +131,7 @@ impl RouteParams {
 fn is_valid_method(method: Method) -> bool {
     use rocket::http::Method::*;
     match method {
-        Get | Put | Post | Delete | Head | Patch | Options => true,
+        Get | Put | Post | Delete | Head | Patch | Options | Extension(_) => true,
         Trace | Connect => false
     }
 }
@@ -166,11 +166,29 @@ pub fn param_to_ident(ecx: &ExtCtxt, s: Spanned<&str>) -> Option<Spanned<Ident>>
 fn parse_method(ecx: &ExtCtxt, meta_item: &NestedMetaItem) -> Spanned<Method> {
     let default_method = dummy_spanned(Method::Get);
     let valid_methods = "valid methods are: `GET`, `PUT`, `POST`, `DELETE`, \
-        `HEAD`, `PATCH`, `OPTIONS`";
+                         `HEAD`, `PATCH`, `OPTIONS`";
 
+    if let Some(lit) = meta_item.literal() {
+        if let LitKind::Str(sym, _) = lit.node {
+            if let Ok(method) = Method::from_str(&sym.as_str()) {
+                if is_valid_method(method.clone()) {
+                    return span(method, lit.span);
+                }
+            }
+
+            let msg = format!("'{}' is not a valid method", &sym.as_str());
+            ecx.struct_span_err(lit.span, &msg).help(valid_methods).emit();
+            return default_method;
+
+        } else {
+            let msg = format!("not a string literal");
+            ecx.struct_span_err(lit.span, &msg).help(valid_methods).emit();
+            return default_method;
+        }
+    }
     if let Some(word) = meta_item.word() {
-        if let Ok(method) = Method::from_str(&word.name().as_str()) {
-            if is_valid_method(method) {
+        if let Ok(method) = Method::from_str(&word.ident.name.as_str()) {
+            if is_valid_method(method.clone()) {
                 return span(method, word.span());
             }
         }
@@ -179,7 +197,6 @@ fn parse_method(ecx: &ExtCtxt, meta_item: &NestedMetaItem) -> Spanned<Method> {
         ecx.struct_span_err(word.span, &msg).help(valid_methods).emit();
         return default_method;
     }
-
     // Fallthrough. Emit a generic error message and return default method.
     let msg = "expected a valid HTTP method identifier";
     ecx.struct_span_err(meta_item.span, msg).help(valid_methods).emit();

--- a/codegen/src/utils/mod.rs
+++ b/codegen/src/utils/mod.rs
@@ -137,25 +137,6 @@ pub fn split_idents(path: &str) -> Vec<Ident> {
     path.split("::").map(|segment| Ident::from_str(segment)).collect()
 }
 
-macro_rules! quote_enum {
-    ($ecx:expr, $var:expr => $(::$root:ident)+
-     { $($variant:ident),+ ; $($extra:pat => $result:expr),* }) => ({
-        use syntax::codemap::DUMMY_SP;
-        use syntax::ast::Ident;
-        use $(::$root)+::*;
-        let root_idents = vec![$(Ident::from_str(stringify!($root))),+];
-        match $var {
-            $($variant => {
-                let variant = Ident::from_str(stringify!($variant));
-                let mut idents = root_idents.clone();
-                idents.push(variant);
-                $ecx.path_global(DUMMY_SP, idents)
-            })+
-            $($extra => $result),*
-        }
-    })
-}
-
 macro_rules! try_parse {
     ($sp:expr, $parse:expr) => (
         match $parse {

--- a/codegen/tests/methods.rs
+++ b/codegen/tests/methods.rs
@@ -24,5 +24,7 @@ extern crate rocket;
 #[options("/")] fn options() {  }
 #[route(OPTIONS, "/")] fn options_r() {  }
 
+#[route("CUSTOM", "/")] fn custom_r() { }
+
 #[test]
 fn main() { }

--- a/codegen/tests/ui/route-bad-method.rs
+++ b/codegen/tests/ui/route-bad-method.rs
@@ -3,17 +3,11 @@
 
 extern crate rocket;
 
-#[route(FIX, "/hello")]
+#[route("GET", "/hello")]
 fn get1() -> &'static str { "hi" }
 
-#[route("hi", "/hello")]
+#[route(120, "/hello")]
 fn get2() -> &'static str { "hi" }
 
-#[route("GET", "/hello")]
+#[route("CONNECT", "/hello")]
 fn get3() -> &'static str { "hi" }
-
-#[route(120, "/hello")]
-fn get4() -> &'static str { "hi" }
-
-#[route(CONNECT, "/hello")]
-fn get5() -> &'static str { "hi" }

--- a/codegen/tests/ui/route-bad-method.stderr
+++ b/codegen/tests/ui/route-bad-method.stderr
@@ -1,42 +1,18 @@
-error: 'FIX' is not a valid method
- --> $DIR/route-bad-method.rs:6:9
+error: not a string literal
+ --> $DIR/route-bad-method.rs:9:9
   |
-6 | #[route(FIX, "/hello")]
+9 | #[route(120, "/hello")]
   |         ^^^
   |
   = help: valid methods are: `GET`, `PUT`, `POST`, `DELETE`, `HEAD`, `PATCH`, `OPTIONS`
 
-error: expected a valid HTTP method identifier
- --> $DIR/route-bad-method.rs:9:9
-  |
-9 | #[route("hi", "/hello")]
-  |         ^^^^
-  |
-  = help: valid methods are: `GET`, `PUT`, `POST`, `DELETE`, `HEAD`, `PATCH`, `OPTIONS`
-
-error: expected a valid HTTP method identifier
+error: 'CONNECT' is not a valid method
   --> $DIR/route-bad-method.rs:12:9
    |
-12 | #[route("GET", "/hello")]
-   |         ^^^^^
+12 | #[route("CONNECT", "/hello")]
+   |         ^^^^^^^^^
    |
    = help: valid methods are: `GET`, `PUT`, `POST`, `DELETE`, `HEAD`, `PATCH`, `OPTIONS`
 
-error: expected a valid HTTP method identifier
-  --> $DIR/route-bad-method.rs:15:9
-   |
-15 | #[route(120, "/hello")]
-   |         ^^^
-   |
-   = help: valid methods are: `GET`, `PUT`, `POST`, `DELETE`, `HEAD`, `PATCH`, `OPTIONS`
-
-error: 'CONNECT' is not a valid method
-  --> $DIR/route-bad-method.rs:18:9
-   |
-18 | #[route(CONNECT, "/hello")]
-   |         ^^^^^^^
-   |
-   = help: valid methods are: `GET`, `PUT`, `POST`, `DELETE`, `HEAD`, `PATCH`, `OPTIONS`
-
-error: aborting due to 5 previous errors
+error: aborting due to 2 previous errors
 

--- a/examples/custom_method/Cargo.toml
+++ b/examples/custom_method/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "custom_method"
+version = "0.0.0"
+workspace = "../../"
+
+[dependencies]
+rocket = { path = "../../lib" }
+rocket_codegen = { path = "../../codegen" }

--- a/examples/custom_method/src/main.rs
+++ b/examples/custom_method/src/main.rs
@@ -1,0 +1,15 @@
+#![feature(plugin, decl_macro)]
+#![plugin(rocket_codegen)]
+
+extern crate rocket;
+
+#[cfg(test)] mod tests;
+
+#[route("CUSTOM", "/")]
+fn hello() -> &'static str {
+    "Hello, world!"
+}
+
+fn main() {
+    rocket::ignite().mount("/", routes![hello]).launch();
+}

--- a/examples/custom_method/src/tests.rs
+++ b/examples/custom_method/src/tests.rs
@@ -1,0 +1,11 @@
+use super::rocket;
+use rocket::local::Client;
+use rocket::http::Method;
+
+#[test]
+fn hello_world() {
+    let rocket = rocket::ignite().mount("/", routes![super::hello]);
+    let client = Client::new(rocket).unwrap();
+    let mut response = client.req(Method::Extension("CUSTOM".to_string()), "/").dispatch();
+    assert_eq!(response.body_string(), Some("Hello, world!".into()));
+}

--- a/examples/handlebars_templates/src/tests.rs
+++ b/examples/handlebars_templates/src/tests.rs
@@ -15,7 +15,7 @@ macro_rules! dispatch {
 fn test_root() {
     // Check that the redirect works.
     for method in &[Get, Head] {
-        dispatch!(*method, "/", |_: &Client, mut response: LocalResponse| {
+        dispatch!(method.clone(), "/", |_: &Client, mut response: LocalResponse| {
             assert_eq!(response.status(), Status::SeeOther);
             assert!(response.body().is_none());
 
@@ -26,7 +26,7 @@ fn test_root() {
 
     // Check that other request methods are not accepted (and instead caught).
     for method in &[Post, Put, Delete, Options, Trace, Connect, Patch] {
-        dispatch!(*method, "/", |client: &Client, mut response: LocalResponse| {
+        dispatch!(method.clone(), "/", |client: &Client, mut response: LocalResponse| {
             let mut map = ::std::collections::HashMap::new();
             map.insert("path", "/");
             let expected = Template::show(client.rocket(), "error/404", &map).unwrap();

--- a/examples/tera_templates/src/tests.rs
+++ b/examples/tera_templates/src/tests.rs
@@ -15,7 +15,7 @@ macro_rules! dispatch {
 fn test_root() {
     // Check that the redirect works.
     for method in &[Get, Head] {
-        dispatch!(*method, "/", |_: &Client, mut response: LocalResponse| {
+        dispatch!(method.clone(), "/", |_: &Client, mut response: LocalResponse| {
             assert_eq!(response.status(), Status::SeeOther);
             assert!(response.body().is_none());
 
@@ -26,7 +26,7 @@ fn test_root() {
 
     // Check that other request methods are not accepted (and instead caught).
     for method in &[Post, Put, Delete, Options, Trace, Connect, Patch] {
-        dispatch!(*method, "/", |client: &Client, mut response: LocalResponse| {
+        dispatch!(method.clone(), "/", |client: &Client, mut response: LocalResponse| {
             let mut map = ::std::collections::HashMap::new();
             map.insert("path", "/");
             let expected = Template::show(client.rocket(), "error/404", &map).unwrap();

--- a/lib/src/codegen.rs
+++ b/lib/src/codegen.rs
@@ -1,9 +1,9 @@
 use handler::{Handler, ErrorHandler};
-use http::{Method, MediaType};
+use http::{MediaType};
 
 pub struct StaticRouteInfo {
     pub name: &'static str,
-    pub method: Method,
+    pub method: &'static str,
     pub path: &'static str,
     pub format: Option<MediaType>,
     pub handler: Handler,

--- a/lib/src/request/request.rs
+++ b/lib/src/request/request.rs
@@ -37,7 +37,7 @@ struct RequestState<'r> {
 /// data. This includes the HTTP method, URI, cookies, headers, and more.
 #[derive(Clone)]
 pub struct Request<'r> {
-    method: Cell<Method>,
+    method: RefCell<Method>,
     uri: Uri<'r>,
     headers: HeaderMap<'r>,
     remote: Option<SocketAddr>,
@@ -55,7 +55,7 @@ impl<'r> Request<'r> {
         uri: U
     ) -> Request<'r> {
         Request {
-            method: Cell::new(method),
+            method: RefCell::new(method),
             uri: uri.into(),
             headers: HeaderMap::new(),
             remote: None,
@@ -93,7 +93,7 @@ impl<'r> Request<'r> {
     /// ```
     #[inline(always)]
     pub fn method(&self) -> Method {
-        self.method.get()
+        self.method.borrow().clone()
     }
 
     /// Set the method of `self`.
@@ -621,7 +621,7 @@ impl<'r> Request<'r> {
     /// Set the method of `self`, even when `self` is a shared reference.
     #[inline(always)]
     pub(crate) fn _set_method(&self, method: Method) {
-        self.method.set(method);
+        self.method.replace(method);
     }
 
     /// Replace all of the cookies in `self` with those in `jar`.

--- a/lib/src/router/collider.rs
+++ b/lib/src/router/collider.rs
@@ -365,7 +365,7 @@ mod tests {
         where S1: Into<Option<&'static str>>, S2: Into<Option<&'static str>>
     {
         let rocket = Rocket::custom(Config::development().unwrap(), true);
-        let mut req = Request::new(&rocket, m, "/");
+        let mut req = Request::new(&rocket, m.clone(), "/");
         if let Some(mt_str) = mt1.into() {
             if m.supports_payload() {
                 req.replace_header(mt_str.parse::<ContentType>().unwrap());

--- a/lib/src/router/mod.rs
+++ b/lib/src/router/mod.rs
@@ -23,7 +23,7 @@ impl Router {
     }
 
     pub fn add(&mut self, route: Route) {
-        let selector = route.method;
+        let selector = route.method.clone();
         let entries = self.routes.entry(selector).or_insert_with(|| vec![]);
         let i = entries.binary_search_by_key(&route.rank, |r| r.rank).unwrap_or_else(|i| i);
         entries.insert(i, route);

--- a/lib/src/router/route.rs
+++ b/lib/src/router/route.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 use std::convert::From;
+use std::str::FromStr;
 
 use yansi::Color::*;
 
@@ -225,7 +226,7 @@ impl Clone for Route {
     fn clone(&self) -> Route {
         Route {
             name: self.name,
-            method: self.method,
+            method: self.method.clone(),
             handler: self.handler,
             rank: self.rank,
             base: self.base.clone(),
@@ -265,7 +266,7 @@ impl fmt::Debug for Route {
 #[doc(hidden)]
 impl<'a> From<&'a StaticRouteInfo> for Route {
     fn from(info: &'a StaticRouteInfo) -> Route {
-        let mut route = Route::new(info.method, info.path, info.handler);
+        let mut route = Route::new(Method::from_str(info.method).expect("invalid StaticRouteInfo"), info.path, info.handler);
         route.format = info.format.clone();
         route.name = Some(info.name);
         if let Some(rank) = info.rank {


### PR DESCRIPTION
Core: 
  - Add `Extension(String)` to Method enum
  - Remove `Copy` trait from Method enum (breaking)
  - `Method.from_str()` makes an `Extension` if the string given doesn't match, meaning it can never fail. (still returns a result for compatibility).
  - `Method.as_str()` now returns a string with the lifetime of the method object, not static.
  - Make `method` in `StaticRequestInfo` a `&str`

Codegen: 
  - `request` decorator can now take a string literal as the method argument.

Examples:
  - Add example for custom methods

Fixes #232 