### PR TITLE
Replace `macro_reexport` with `pub use`

### DIFF
--- a/contrib/src/lib.rs
+++ b/contrib/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(macro_reexport)]
+#![feature(use_extern_macros)]
 
 // TODO: Version URLs.
 #![doc(html_root_url = "https://api.rocket.rs")]
@@ -44,8 +44,10 @@
 extern crate serde;
 
 #[cfg(feature = "json")]
-#[cfg_attr(feature = "json", macro_reexport(json_internal))]
 extern crate serde_json;
+
+#[cfg(feature = "json")]
+pub use serde_json::json_internal;
 
 #[cfg(feature = "handlebars_templates")]
 pub extern crate handlebars;


### PR DESCRIPTION
This fixes `contrib` for the 2018-05-02 nightly ([#49982](https://github.com/rust-lang/rust/pull/49982)).

Fixes #626.
Fixes #632.