### PR TITLE
Fix #643

### DIFF
--- a/lib/src/http/header.rs
+++ b/lib/src/http/header.rs
@@ -541,7 +541,7 @@ impl<'h> HeaderMap<'h> {
     pub fn iter<'s>(&'s self) -> impl Iterator<Item=Header<'s>> {
         self.headers.iter().flat_map(|(key, values)| {
             values.iter().map(move |val| {
-                Header::new(key.as_str(), val.borrow())
+                Header::new(key.as_str(), &**val)
             })
         })
     }


### PR DESCRIPTION
Fixes #643

`Deref` of a `Cow<'_, str>` will always yield a `str`, so this should resolve any ambiguity during type inference.