### PR TITLE
Implement request-state local cache

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
   "examples/content_types",
   "examples/ranking",
   "examples/testing",
+  "examples/request_state_local_cache",
   "examples/request_guard",
   "examples/stream",
   "examples/json",

--- a/core/lib/src/request/request.rs
+++ b/core/lib/src/request/request.rs
@@ -91,10 +91,10 @@ impl<'r> Request<'r> {
     /// ```rust
     /// # use rocket::http::Method;
     /// # use rocket::Request;
-    /// # struct User();
-    /// fn current_user(_: &Request) -> User {
+    /// # struct User;
+    /// fn current_user() -> User {
     ///     // Load user...
-    ///     # User()
+    ///     # User
     /// }
     ///
     /// # Request::example(Method::Get, "/uri", |request| {
@@ -103,12 +103,12 @@ impl<'r> Request<'r> {
     /// ```
     pub fn local_cache<T, F>(&self, f: F) -> &T
         where T: Send + Sync + 'static,
-              F: FnOnce(&Request) -> T {
+              F: FnOnce() -> T {
 
         match self.state.cache.try_get() {
             Some(cached) => cached,
             None => {
-                self.state.cache.set(f(self));
+                self.state.cache.set(f());
                 self.state.cache.get()
             }
         }

--- a/core/lib/src/request/request.rs
+++ b/core/lib/src/request/request.rs
@@ -85,6 +85,22 @@ impl<'r> Request<'r> {
     /// state of `self`. If no such value has previously been cached for
     /// this request, `f` is called to produce the value which is subsequently
     /// returned.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use rocket::http::Method;
+    /// # use rocket::Request;
+    /// # struct User();
+    /// fn current_user(_: &Request) -> User {
+    ///     // Load user...
+    ///     # User()
+    /// }
+    ///
+    /// # Request::example(Method::Get, "/uri", |request| {
+    /// let user = request.local_cache(current_user);
+    /// # });
+    /// ```
     pub fn local_cache<T, F>(&self, f: F) -> &T
         where T: Send + Sync + 'static,
               F: FnOnce(&Request) -> T {

--- a/examples/request_state_local_cache/Cargo.toml
+++ b/examples/request_state_local_cache/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "request_state_local_cache"
+version = "0.0.0"
+workspace = "../../"
+publish = false
+
+[dependencies]
+rocket = { path = "../../core/lib" }
+rocket_codegen = { path = "../../core/codegen" }

--- a/examples/request_state_local_cache/src/main.rs
+++ b/examples/request_state_local_cache/src/main.rs
@@ -1,0 +1,73 @@
+#![feature(plugin, decl_macro)]
+#![plugin(rocket_codegen)]
+extern crate rocket;
+
+use std::thread;
+use std::time::Duration;
+
+use rocket::request::{self, Request, FromRequest};
+use rocket::outcome::Outcome::*;
+
+#[cfg(test)] mod tests;
+
+#[derive(Clone, Copy)]
+struct Sleep();
+struct SleepCached(Sleep);
+struct ForwardGuard();
+
+impl<'a, 'r> FromRequest<'a, 'r> for ForwardGuard {
+    type Error = ();
+
+    fn from_request(_: &'a Request<'r>) -> request::Outcome<Self, ()> {
+        Forward(())
+    }
+}
+
+impl Sleep {
+    fn get(_: &Request) -> Sleep {
+        thread::sleep(Duration::from_secs(3));
+        Sleep()
+    }
+}
+
+impl<'a, 'r> FromRequest<'a, 'r> for Sleep {
+    type Error = ();
+
+    fn from_request(request: &'a Request<'r>) -> request::Outcome<Self, ()> {
+        Success(Sleep::get(request))
+    }
+}
+
+impl<'a, 'r> FromRequest<'a, 'r> for SleepCached {
+    type Error = ();
+
+    fn from_request(request: &'a Request<'r>) -> request::Outcome<Self, ()> {
+        let s = request.local_cache(Sleep::get);
+        Success(SleepCached(*s))
+    }
+}
+
+#[get("/")]
+fn index(_s: Sleep, _f: ForwardGuard) {
+}
+
+#[get("/", rank = 2)]
+fn index2(_s: Sleep) {
+}
+
+#[get("/cached")]
+fn index_cached(_s: SleepCached, _f: ForwardGuard) {
+}
+
+#[get("/cached", rank = 2)]
+fn index_cached2(_s: SleepCached) {
+}
+
+fn rocket() -> rocket::Rocket {
+    rocket::ignite()
+        .mount("/", routes!(index, index2, index_cached, index_cached2))
+}
+
+fn main() {
+    rocket().launch();
+}

--- a/examples/request_state_local_cache/src/main.rs
+++ b/examples/request_state_local_cache/src/main.rs
@@ -9,24 +9,27 @@ use rocket::outcome::Outcome::*;
 
 #[cfg(test)] mod tests;
 
+#[derive(Default)]
 struct Atomics {
-    first: AtomicUsize,
-    second: AtomicUsize,
+    uncached: AtomicUsize,
+    cached: AtomicUsize,
 }
 
-struct Guard1();
-struct Guard2();
+struct Guard1;
+struct Guard2;
 
 impl<'a, 'r> FromRequest<'a, 'r> for Guard1 {
     type Error = ();
 
     fn from_request(req: &'a Request<'r>) -> request::Outcome<Self, ()> {
-        req.guard::<State<Atomics>>()?.first.fetch_add(1, Ordering::Relaxed);
-        req.local_cache(|req| {
-            req.guard::<State<Atomics>>().unwrap().second.fetch_add(1, Ordering::Relaxed);
+        req.local_cache(|| {
+            let atomics = req.guard::<State<Atomics>>().unwrap();
+            atomics.cached.fetch_add(1, Ordering::Relaxed);
         });
+        let atomics = req.guard::<State<Atomics>>()?;
+        atomics.uncached.fetch_add(1, Ordering::Relaxed);
 
-        Success(Guard1())
+        Success(Guard1)
     }
 }
 
@@ -34,26 +37,20 @@ impl<'a, 'r> FromRequest<'a, 'r> for Guard2 {
     type Error = ();
 
     fn from_request(req: &'a Request<'r>) -> request::Outcome<Self, ()> {
-        req.guard::<State<Atomics>>()?.first.fetch_add(1, Ordering::Relaxed);
-        req.local_cache(|req| {
-            req.guard::<State<Atomics>>().unwrap().second.fetch_add(1, Ordering::Relaxed);
-        });
-
-        Success(Guard2())
+        req.guard::<Guard1>()?;
+        Success(Guard2)
     }
 }
 
 
 #[get("/")]
 fn index(_g1: Guard1, _g2: Guard2) {
+    // This exists only to run the request guards.
 }
 
 fn rocket() -> rocket::Rocket {
     rocket::ignite()
-        .manage(Atomics{
-            first: AtomicUsize::new(0),
-            second: AtomicUsize::new(0),
-        })
+        .manage(Atomics::default())
         .mount("/", routes!(index))
 }
 

--- a/examples/request_state_local_cache/src/tests.rs
+++ b/examples/request_state_local_cache/src/tests.rs
@@ -1,0 +1,33 @@
+use std::time::{Instant, Duration};
+
+use super::rocket;
+use rocket::local::Client;
+
+fn normal_time() -> Duration {
+    let client = Client::new(rocket()).unwrap();
+
+    let start = Instant::now();
+    client.get("/").dispatch();
+    let end = Instant::now();
+
+    end - start
+}
+
+fn cached_time() -> Duration {
+    let client = Client::new(rocket()).unwrap();
+
+    let start = Instant::now();
+    client.get("/cached").dispatch();
+    let end = Instant::now();
+
+    end - start
+}
+
+#[test]
+fn cache_is_faster() {
+    let normal = normal_time();
+    let cached = cached_time();
+
+    assert!(normal > cached, "Cached is faster");
+    assert!((normal - cached).as_secs() >= 3, "Cached is at least 3 secs faster");
+}

--- a/examples/request_state_local_cache/src/tests.rs
+++ b/examples/request_state_local_cache/src/tests.rs
@@ -9,7 +9,7 @@ fn test() {
     let client = Client::new(rocket()).unwrap();
     client.get("/").dispatch();
 
-    let atomics = &client.rocket().state::<Atomics>().unwrap();
-    assert!(atomics.uncached.load(Ordering::Relaxed) == 2, "First is two");
-    assert!(atomics.cached.load(Ordering::Relaxed) == 1, "Second is one");
+    let atomics = client.rocket().state::<Atomics>().unwrap();
+    assert_eq!(atomics.uncached.load(Ordering::Relaxed), 2);
+    assert_eq!(atomics.cached.load(Ordering::Relaxed), 1);
 }

--- a/examples/request_state_local_cache/src/tests.rs
+++ b/examples/request_state_local_cache/src/tests.rs
@@ -9,6 +9,7 @@ fn test() {
     let client = Client::new(rocket()).unwrap();
     client.get("/").dispatch();
 
-    assert!(client.rocket().state::<Atomics>().unwrap().first.load(Ordering::Relaxed) == 2, "First is two");
-    assert!(client.rocket().state::<Atomics>().unwrap().second.load(Ordering::Relaxed) == 1, "Secon is one");
+    let atomics = &client.rocket().state::<Atomics>().unwrap();
+    assert!(atomics.uncached.load(Ordering::Relaxed) == 2, "First is two");
+    assert!(atomics.cached.load(Ordering::Relaxed) == 1, "Second is one");
 }

--- a/examples/request_state_local_cache/src/tests.rs
+++ b/examples/request_state_local_cache/src/tests.rs
@@ -1,33 +1,14 @@
-use std::time::{Instant, Duration};
+use std::sync::atomic::{Ordering};
 
+use ::Atomics;
 use super::rocket;
 use rocket::local::Client;
 
-fn normal_time() -> Duration {
-    let client = Client::new(rocket()).unwrap();
-
-    let start = Instant::now();
-    client.get("/").dispatch();
-    let end = Instant::now();
-
-    end - start
-}
-
-fn cached_time() -> Duration {
-    let client = Client::new(rocket()).unwrap();
-
-    let start = Instant::now();
-    client.get("/cached").dispatch();
-    let end = Instant::now();
-
-    end - start
-}
-
 #[test]
-fn cache_is_faster() {
-    let normal = normal_time();
-    let cached = cached_time();
+fn test() {
+    let client = Client::new(rocket()).unwrap();
+    client.get("/").dispatch();
 
-    assert!(normal > cached, "Cached is faster");
-    assert!((normal - cached).as_secs() >= 3, "Cached is at least 3 secs faster");
+    assert!(client.rocket().state::<Atomics>().unwrap().first.load(Ordering::Relaxed) == 2, "First is two");
+    assert!(client.rocket().state::<Atomics>().unwrap().second.load(Ordering::Relaxed) == 1, "Secon is one");
 }


### PR DESCRIPTION
Opening this PR for feedback. Based completely on @SergioBenitez's design.

I guess the next step is to extend the `state` crate to allow more relaxed bounds for `T` in the `local_cache`?

The `cache` needs to be wrapped in `Rc` so it gets `Clone`, but it was mentioned that in future `Request` might be send to another thread to be processed, so should we already use `Arc` instead?

Simple example usage https://gist.github.com/vhakulinen/fb84746fa102761c0683f694523a47cd.

Closes #654.