### PR TITLE
Update codegen for 2018-06-12 nightly.

### DIFF
--- a/codegen/build.rs
+++ b/codegen/build.rs
@@ -8,7 +8,7 @@ use yansi::Color::{Red, Yellow, Blue, White};
 use version_check::{supports_features, is_min_version, is_min_date};
 
 // Specifies the minimum nightly version needed to compile Rocket's codegen.
-const MIN_DATE: &'static str = "2018-05-30";
+const MIN_DATE: &'static str = "2018-06-12";
 const MIN_VERSION: &'static str = "1.28.0-nightly";
 
 fn main() {

--- a/codegen/src/utils/parser_ext.rs
+++ b/codegen/src/utils/parser_ext.rs
@@ -1,8 +1,7 @@
 use syntax::parse::parser::{PathStyle, Parser};
-use syntax::parse::PResult;
+use syntax::parse::{SeqSep, PResult};
 use syntax::ast::Path;
 use syntax::parse::token::Token::{Eof, Comma};
-use syntax::parse::common::SeqSep;
 
 pub trait ParserExt<'a> {
     fn parse_paths(&mut self) -> PResult<'a, Vec<Path>>;


### PR DESCRIPTION
See #660. These changes are sufficient for the 0.3 branch only, not master.