### PR TITLE
Reimplement routes! and catchers! as proc_macros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,4 +41,5 @@ members = [
   "examples/raw_sqlite",
   "examples/tls",
   "examples/fairings",
+  "examples/hello_2018",
 ]

--- a/contrib/lib/tests/templates.rs
+++ b/contrib/lib/tests/templates.rs
@@ -1,7 +1,7 @@
-#![feature(plugin, decl_macro)]
+#![feature(plugin, decl_macro, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 
-extern crate rocket;
+#[macro_use] extern crate rocket;
 extern crate rocket_contrib;
 
 #[cfg(feature = "templates")]

--- a/core/codegen/src/lib.rs
+++ b/core/codegen/src/lib.rs
@@ -438,8 +438,6 @@ macro_rules! register_macros {
 #[plugin_registrar]
 pub fn plugin_registrar(reg: &mut Registry) {
     register_macros!(reg,
-        "routes" => routes,
-        "catchers" => catchers,
         "uri" => uri,
         "rocket_internal_uri" => uri_internal
     );

--- a/core/codegen/src/macros/mod.rs
+++ b/core/codegen/src/macros/mod.rs
@@ -1,14 +1,8 @@
 mod uri;
 
-use {ROUTE_STRUCT_PREFIX, CATCH_STRUCT_PREFIX};
-use utils::{sep_by_tok, ParserExt, IdentExt};
+use utils::IdentExt;
 
-use syntax::source_map::Span;
-use syntax::tokenstream::TokenTree;
-use syntax::ast::{Path, Expr};
-use syntax::ext::base::{DummyResult, ExtCtxt, MacResult, MacEager};
-use syntax::parse::token::Token;
-use syntax::ptr::P;
+use syntax::ast::Path;
 
 pub use self::uri::{uri, uri_internal};
 
@@ -17,56 +11,4 @@ pub fn prefix_path(prefix: &str, path: &mut Path) {
     let last = path.segments.len() - 1;
     let last_seg = &mut path.segments[last];
     last_seg.ident = last_seg.ident.prepend(prefix);
-}
-
-#[inline]
-pub fn prefix_paths(prefix: &str, paths: &mut Vec<Path>) {
-    for p in paths {
-        prefix_path(prefix, p);
-    }
-}
-
-pub fn prefixing_vec_macro<F>(
-    prefix: &str,
-    mut to_expr: F,
-    ecx: &mut ExtCtxt,
-    sp: Span,
-    args: &[TokenTree]) -> Box<MacResult + 'static>
-where F: FnMut(&ExtCtxt, Path) -> P<Expr>
-{
-    let mut parser = ecx.new_parser_from_tts(args);
-    match parser.parse_paths() {
-        Ok(mut paths) => {
-            // Prefix each path terminator and build up the P<Expr> for each path.
-            prefix_paths(prefix, &mut paths);
-            let path_exprs: Vec<P<Expr>> = paths.into_iter()
-                .map(|path| to_expr(ecx, path))
-                .collect();
-
-            // Now put them all in one vector and return the thing.
-            let path_list = sep_by_tok(ecx, &path_exprs, Token::Comma);
-            let output = quote_expr!(ecx, vec![$path_list]).into_inner();
-            MacEager::expr(P(output))
-        }
-        Err(mut e) => {
-            e.emit();
-            DummyResult::expr(sp)
-        }
-    }
-}
-
-#[rustfmt_skip]
-pub fn routes(ecx: &mut ExtCtxt, sp: Span, args: &[TokenTree])
-        -> Box<MacResult + 'static> {
-    prefixing_vec_macro(ROUTE_STRUCT_PREFIX, |ecx, path| {
-        quote_expr!(ecx, ::rocket::Route::from(&$path))
-    }, ecx, sp, args)
-}
-
-#[rustfmt_skip]
-pub fn catchers(ecx: &mut ExtCtxt, sp: Span, args: &[TokenTree])
-        -> Box<MacResult + 'static> {
-    prefixing_vec_macro(CATCH_STRUCT_PREFIX, |ecx, path| {
-        quote_expr!(ecx, ::rocket::Catcher::from(&$path))
-    }, ecx, sp, args)
 }

--- a/core/codegen/tests/complete-decorator.rs
+++ b/core/codegen/tests/complete-decorator.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro)]
+#![feature(plugin, decl_macro, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;

--- a/core/codegen/tests/dynamic-paths.rs
+++ b/core/codegen/tests/dynamic-paths.rs
@@ -1,8 +1,8 @@
-#![feature(plugin, decl_macro)]
+#![feature(plugin, decl_macro, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 #![allow(dead_code, unused_variables)]
 
-extern crate rocket;
+#[macro_use] extern crate rocket;
 
 #[get("/test/<one>/<two>/<three>")]
 fn get(one: String, two: usize, three: isize) -> &'static str { "hi" }

--- a/core/codegen/tests/instanced-mounting.rs
+++ b/core/codegen/tests/instanced-mounting.rs
@@ -1,8 +1,8 @@
-#![feature(plugin, decl_macro)]
+#![feature(plugin, decl_macro, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 #![allow(dead_code, unused_variables)]
 
-extern crate rocket;
+#[macro_use] extern crate rocket;
 
 #[get("/one")]
 fn one() {  }

--- a/core/codegen/tests/issue-1-colliding-names.rs
+++ b/core/codegen/tests/issue-1-colliding-names.rs
@@ -1,7 +1,7 @@
-#![feature(plugin, decl_macro)]
+#![feature(plugin, decl_macro, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 
-extern crate rocket;
+#[macro_use] extern crate rocket;
 
 #[get("/<todo>")]
 fn todo(todo: String) -> String {

--- a/core/codegen/tests/refactored_rocket_no_lint_errors.rs
+++ b/core/codegen/tests/refactored_rocket_no_lint_errors.rs
@@ -1,8 +1,8 @@
-#![feature(plugin, decl_macro)]
+#![feature(plugin, decl_macro, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 #![allow(dead_code, unused_variables)]
 
-extern crate rocket;
+#[macro_use] extern crate rocket;
 
 use rocket::{Rocket, State};
 

--- a/core/codegen/tests/type-alias-lints.rs
+++ b/core/codegen/tests/type-alias-lints.rs
@@ -1,8 +1,8 @@
-#![feature(plugin, decl_macro)]
+#![feature(plugin, decl_macro, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 #![allow(dead_code, unused_variables)]
 
-extern crate rocket;
+#[macro_use] extern crate rocket;
 
 use rocket::State;
 

--- a/core/codegen_next/Cargo.toml
+++ b/core/codegen_next/Cargo.toml
@@ -26,4 +26,5 @@ rev = "160da392"
 
 [dev-dependencies]
 rocket = { version = "0.4.0-dev", path = "../lib" }
+rocket_codegen = { version = "0.4.0-dev", path = "../codegen" }
 compiletest_rs = "0.3.14"

--- a/core/codegen_next/src/lib.rs
+++ b/core/codegen_next/src/lib.rs
@@ -9,6 +9,7 @@ extern crate rocket_http;
 
 mod derive;
 mod http_codegen;
+mod prefixing_vec;
 
 crate use derive_utils::{syn, proc_macro2};
 
@@ -27,4 +28,21 @@ pub fn derive_from_form(input: TokenStream) -> TokenStream {
 #[proc_macro_derive(Responder, attributes(response))]
 pub fn derive_responder(input: TokenStream) -> TokenStream {
     derive::responder::derive_responder(input)
+}
+
+const ROUTE_STRUCT_PREFIX: &'static str = "static_rocket_route_info_for_";
+#[proc_macro]
+pub fn routes(input: TokenStream) -> TokenStream {
+    prefixing_vec::prefixing_vec_macro(ROUTE_STRUCT_PREFIX, |path| {
+        quote!(::rocket::Route::from(&#path))
+    }, input)
+}
+
+
+const CATCH_STRUCT_PREFIX: &'static str = "static_rocket_catch_info_for_";
+#[proc_macro]
+pub fn catchers(input: TokenStream) -> TokenStream {
+    prefixing_vec::prefixing_vec_macro(CATCH_STRUCT_PREFIX, |path| {
+        quote!(::rocket::Catcher::from(&#path))
+    }, input)
 }

--- a/core/codegen_next/src/lib.rs
+++ b/core/codegen_next/src/lib.rs
@@ -32,7 +32,7 @@ pub fn derive_responder(input: TokenStream) -> TokenStream {
 
 const ROUTE_STRUCT_PREFIX: &'static str = "static_rocket_route_info_for_";
 #[proc_macro]
-pub fn routes(input: TokenStream) -> TokenStream {
+pub fn rocket_routes_internal(input: TokenStream) -> TokenStream {
     prefixing_vec::prefixing_vec_macro(ROUTE_STRUCT_PREFIX, |path| {
         quote!(::rocket::Route::from(&#path))
     }, input)
@@ -41,7 +41,7 @@ pub fn routes(input: TokenStream) -> TokenStream {
 
 const CATCH_STRUCT_PREFIX: &'static str = "static_rocket_catch_info_for_";
 #[proc_macro]
-pub fn catchers(input: TokenStream) -> TokenStream {
+pub fn rocket_catchers_internal(input: TokenStream) -> TokenStream {
     prefixing_vec::prefixing_vec_macro(CATCH_STRUCT_PREFIX, |path| {
         quote!(::rocket::Catcher::from(&#path))
     }, input)

--- a/core/codegen_next/src/prefixing_vec.rs
+++ b/core/codegen_next/src/prefixing_vec.rs
@@ -1,0 +1,44 @@
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+
+use syn::{Ident, Path};
+
+use derive_utils::parser::{Parser, Seperator, Result as PResult};
+
+#[inline]
+fn prefix_path(prefix: &str, path: &mut Path) {
+    let mut last_seg = path.segments.last_mut().expect("last path segment");
+    let last_value = last_seg.value_mut();
+    last_value.ident = Ident::new(&format!("{}{}", prefix, last_value.ident), last_value.ident.span());
+}
+
+pub fn prefixing_vec_macro_internal<F>(prefix: &str, to_expr: F, args: TokenStream) -> PResult<TokenStream>
+        where F: FnMut(Path) -> TokenStream2
+{
+    let mut parser = Parser::new(args);
+    let mut paths = parser.parse_sep(Seperator::Comma, |p| {
+        p.parse::<Path>()
+    })?;
+    parser.eof().map_err(|_| {
+        parser.current_span()
+            .error("expected `,` or `::` or end of macro invocation")
+    })?;
+
+    for ref mut p in &mut paths {
+        prefix_path(prefix, p);
+    }
+    let path_exprs: Vec<_> = paths.into_iter().map(to_expr).collect();
+
+    let tokens = quote! { vec![#(#path_exprs),*] };
+    Ok(tokens.into())
+}
+
+pub fn prefixing_vec_macro<F>(prefix: &str, to_expr: F, args: TokenStream) -> TokenStream
+    where F: FnMut(Path) -> TokenStream2
+{
+    prefixing_vec_macro_internal(prefix, to_expr, args)
+        .unwrap_or_else(|diag| {
+            diag.emit();
+            (quote! { vec![] }).into()
+        })
+}

--- a/core/codegen_next/tests/compile-fail/catchers.rs
+++ b/core/codegen_next/tests/compile-fail/catchers.rs
@@ -1,0 +1,8 @@
+#![feature(plugin, decl_macro, proc_macro_non_items)]
+
+#[macro_use] extern crate rocket;
+
+fn main() {
+    let _ = catchers![a b]; //~ ERROR expected
+}
+

--- a/core/codegen_next/tests/route.rs
+++ b/core/codegen_next/tests/route.rs
@@ -1,0 +1,13 @@
+#![feature(plugin, decl_macro, proc_macro_non_items)]
+#![plugin(rocket_codegen)]
+
+extern crate rocket;
+
+use rocket::routes;
+
+#[get("/")]
+fn get() {}
+
+fn main() {
+    rocket::ignite().mount("/", routes![get]);
+}

--- a/core/codegen_next/tests/route.rs
+++ b/core/codegen_next/tests/route.rs
@@ -1,9 +1,7 @@
 #![feature(plugin, decl_macro, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 
-extern crate rocket;
-
-use rocket::routes;
+#[macro_use] extern crate rocket;
 
 #[get("/")]
 fn get() {}

--- a/core/codegen_next/tests/ui-fail/routes.rs
+++ b/core/codegen_next/tests/ui-fail/routes.rs
@@ -1,0 +1,8 @@
+#![feature(plugin, decl_macro, proc_macro_non_items)]
+
+#[macro_use] extern crate rocket;
+
+fn main() {
+    let _ = routes![a b];
+    //~^ ERROR expected
+}

--- a/core/codegen_next/tests/ui-fail/routes.stderr
+++ b/core/codegen_next/tests/ui-fail/routes.stderr
@@ -1,0 +1,8 @@
+error: expected `,` or `::` or end of macro invocation
+ --> $DIR/routes.rs:6:23
+  |
+6 |     let _ = routes![a b];
+  |                       ^
+
+error: aborting due to previous error
+

--- a/core/lib/src/catcher.rs
+++ b/core/lib/src/catcher.rs
@@ -35,10 +35,10 @@ use yansi::Color::*;
 /// declared using the `catch` decorator, as follows:
 ///
 /// ```rust
-/// #![feature(plugin, decl_macro)]
+/// #![feature(plugin, decl_macro, proc_macro_non_items)]
 /// #![plugin(rocket_codegen)]
 ///
-/// extern crate rocket;
+/// #[macro_use] extern crate rocket;
 ///
 /// use rocket::Request;
 ///

--- a/core/lib/src/handler.rs
+++ b/core/lib/src/handler.rs
@@ -87,9 +87,9 @@ pub type Outcome<'r> = outcome::Outcome<Response<'r>, Status, Data>;
 /// managed state and a static route, as follows:
 ///
 /// ```rust
-/// # #![feature(plugin, decl_macro)]
+/// # #![feature(plugin, decl_macro, proc_macro_non_items)]
 /// # #![plugin(rocket_codegen)]
-/// # extern crate rocket;
+/// # #[macro_use] extern crate rocket;
 /// #
 /// # #[derive(Copy, Clone)]
 /// # enum Kind {

--- a/core/lib/src/lib.rs
+++ b/core/lib/src/lib.rs
@@ -102,6 +102,16 @@
 #[allow(unused_imports)] #[macro_use] extern crate rocket_codegen_next;
 #[doc(hidden)] pub use rocket_codegen_next::*;
 
+#[macro_export]
+macro_rules! routes {
+    ($($input:tt)*) => { $crate::rocket_routes_internal![$($input)*] };
+}
+
+#[macro_export]
+macro_rules! catchers {
+    ($($input:tt)*) => { $crate::rocket_catchers_internal![$($input)*] };
+}
+
 extern crate rocket_http;
 #[macro_use] extern crate log;
 #[macro_use] extern crate pear;

--- a/core/lib/src/lib.rs
+++ b/core/lib/src/lib.rs
@@ -67,10 +67,10 @@
 //! write Rocket applications. Here's a simple example to get you started:
 //!
 //! ```rust
-//! #![feature(plugin, decl_macro)]
+//! #![feature(plugin, decl_macro, proc_macro_non_items)]
 //! #![plugin(rocket_codegen)]
 //!
-//! extern crate rocket;
+//! #[macro_use] extern crate rocket;
 //!
 //! #[get("/")]
 //! fn hello() -> &'static str {

--- a/core/lib/src/request/state.rs
+++ b/core/lib/src/request/state.rs
@@ -21,9 +21,9 @@ use http::Status;
 /// following example does just this:
 ///
 /// ```rust
-/// # #![feature(plugin, decl_macro)]
+/// # #![feature(plugin, decl_macro, proc_macro_non_items)]
 /// # #![plugin(rocket_codegen)]
-/// # extern crate rocket;
+/// # #[macro_use] extern crate rocket;
 /// use rocket::State;
 ///
 /// // In a real application, this would likely be more complex.

--- a/core/lib/src/response/flash.rs
+++ b/core/lib/src/response/flash.rs
@@ -47,10 +47,10 @@ const FLASH_COOKIE_NAME: &str = "_flash";
 /// message on both the request and response sides.
 ///
 /// ```rust
-/// # #![feature(plugin, decl_macro)]
+/// # #![feature(plugin, decl_macro, proc_macro_non_items)]
 /// # #![plugin(rocket_codegen)]
 /// #
-/// # extern crate rocket;
+/// # #[macro_use] extern crate rocket;
 /// #
 /// use rocket::response::{Flash, Redirect};
 /// use rocket::request::FlashMessage;

--- a/core/lib/src/rocket.rs
+++ b/core/lib/src/rocket.rs
@@ -456,9 +456,9 @@ impl Rocket {
     /// dispatched to the `hi` route.
     ///
     /// ```rust
-    /// # #![feature(plugin, decl_macro)]
+    /// # #![feature(plugin, decl_macro, proc_macro_non_items)]
     /// # #![plugin(rocket_codegen)]
-    /// # extern crate rocket;
+    /// # #[macro_use] extern crate rocket;
     /// #
     /// #[get("/world")]
     /// fn hi() -> &'static str {
@@ -543,10 +543,10 @@ impl Rocket {
     /// # Examples
     ///
     /// ```rust
-    /// #![feature(plugin, decl_macro)]
+    /// #![feature(plugin, decl_macro, proc_macro_non_items)]
     /// #![plugin(rocket_codegen)]
     ///
-    /// extern crate rocket;
+    /// #[macro_use] extern crate rocket;
     ///
     /// use rocket::Request;
     ///
@@ -602,9 +602,9 @@ impl Rocket {
     /// # Example
     ///
     /// ```rust
-    /// # #![feature(plugin, decl_macro)]
+    /// # #![feature(plugin, decl_macro, proc_macro_non_items)]
     /// # #![plugin(rocket_codegen)]
-    /// # extern crate rocket;
+    /// # #[macro_use] extern crate rocket;
     /// use rocket::State;
     ///
     /// struct MyValue(usize);
@@ -757,9 +757,9 @@ impl Rocket {
     /// # Example
     ///
     /// ```rust
-    /// # #![feature(plugin, decl_macro)]
+    /// # #![feature(plugin, decl_macro, proc_macro_non_items)]
     /// # #![plugin(rocket_codegen)]
-    /// # extern crate rocket;
+    /// # #[macro_use] extern crate rocket;
     /// use rocket::Rocket;
     /// use rocket::fairing::AdHoc;
     ///

--- a/core/lib/tests/absolute-uris-okay-issue-443.rs
+++ b/core/lib/tests/absolute-uris-okay-issue-443.rs
@@ -1,7 +1,7 @@
-#![feature(plugin, decl_macro)]
+#![feature(plugin, decl_macro, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 
-extern crate rocket;
+#[macro_use] extern crate rocket;
 
 use rocket::response::Redirect;
 

--- a/core/lib/tests/fairing_before_head_strip-issue-546.rs
+++ b/core/lib/tests/fairing_before_head_strip-issue-546.rs
@@ -1,7 +1,7 @@
-#![feature(plugin, decl_macro)]
+#![feature(plugin, decl_macro, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 
-extern crate rocket;
+#[macro_use] extern crate rocket;
 
 const RESPONSE_STRING: &'static str = "This is the body. Hello, world!";
 

--- a/core/lib/tests/flash-lazy-removes-issue-466.rs
+++ b/core/lib/tests/flash-lazy-removes-issue-466.rs
@@ -1,7 +1,7 @@
-#![feature(plugin, decl_macro)]
+#![feature(plugin, decl_macro, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 
-extern crate rocket;
+#[macro_use] extern crate rocket;
 
 use rocket::request::FlashMessage;
 use rocket::response::Flash;

--- a/core/lib/tests/form_method-issue-45.rs
+++ b/core/lib/tests/form_method-issue-45.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro)]
+#![feature(plugin, decl_macro, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;

--- a/core/lib/tests/form_value_decoding-issue-82.rs
+++ b/core/lib/tests/form_value_decoding-issue-82.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro)]
+#![feature(plugin, decl_macro, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;

--- a/core/lib/tests/head_handling.rs
+++ b/core/lib/tests/head_handling.rs
@@ -1,7 +1,7 @@
-#![feature(plugin, decl_macro)]
+#![feature(plugin, decl_macro, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 
-extern crate rocket;
+#[macro_use] extern crate rocket;
 
 use rocket::response::{status, content};
 

--- a/core/lib/tests/limits.rs
+++ b/core/lib/tests/limits.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro)]
+#![feature(plugin, decl_macro, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;

--- a/core/lib/tests/local-request-content-type-issue-505.rs
+++ b/core/lib/tests/local-request-content-type-issue-505.rs
@@ -1,7 +1,7 @@
-#![feature(plugin, decl_macro)]
+#![feature(plugin, decl_macro, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 
-extern crate rocket;
+#[macro_use] extern crate rocket;
 
 use rocket::Outcome::*;
 use rocket::{Request, Data};

--- a/core/lib/tests/local_request_private_cookie-issue-368.rs
+++ b/core/lib/tests/local_request_private_cookie-issue-368.rs
@@ -1,7 +1,7 @@
-#![feature(plugin, decl_macro)]
+#![feature(plugin, decl_macro, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 
-extern crate rocket;
+#[macro_use] extern crate rocket;
 
 use rocket::http::Cookies;
 

--- a/core/lib/tests/nested-fairing-attaches.rs
+++ b/core/lib/tests/nested-fairing-attaches.rs
@@ -1,7 +1,7 @@
-#![feature(plugin, decl_macro)]
+#![feature(plugin, decl_macro, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 
-extern crate rocket;
+#[macro_use] extern crate rocket;
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 

--- a/core/lib/tests/precise-content-type-matching.rs
+++ b/core/lib/tests/precise-content-type-matching.rs
@@ -1,7 +1,7 @@
-#![feature(plugin, decl_macro)]
+#![feature(plugin, decl_macro, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 
-extern crate rocket;
+#[macro_use] extern crate rocket;
 
 #[post("/", format = "application/json")]
 fn specified() -> &'static str {

--- a/core/lib/tests/query-and-non-query-dont-collide.rs
+++ b/core/lib/tests/query-and-non-query-dont-collide.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro)]
+#![feature(plugin, decl_macro, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;

--- a/core/lib/tests/redirect_from_catcher-issue-113.rs
+++ b/core/lib/tests/redirect_from_catcher-issue-113.rs
@@ -1,7 +1,7 @@
-#![feature(plugin, decl_macro)]
+#![feature(plugin, decl_macro, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 
-extern crate rocket;
+#[macro_use] extern crate rocket;
 
 use rocket::response::Redirect;
 

--- a/core/lib/tests/route_guard.rs
+++ b/core/lib/tests/route_guard.rs
@@ -1,7 +1,7 @@
-#![feature(plugin, decl_macro)]
+#![feature(plugin, decl_macro, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 
-extern crate rocket;
+#[macro_use] extern crate rocket;
 
 use std::path::PathBuf;
 use rocket::Route;

--- a/core/lib/tests/segments-issues-41-86.rs
+++ b/core/lib/tests/segments-issues-41-86.rs
@@ -1,7 +1,7 @@
-#![feature(plugin, decl_macro)]
+#![feature(plugin, decl_macro, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 
-extern crate rocket;
+#[macro_use] extern crate rocket;
 
 use rocket::http::uri::Segments;
 

--- a/core/lib/tests/strict_and_lenient_forms.rs
+++ b/core/lib/tests/strict_and_lenient_forms.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro)]
+#![feature(plugin, decl_macro, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;

--- a/examples/config/tests/development.rs
+++ b/examples/config/tests/development.rs
@@ -1,7 +1,7 @@
-#![feature(plugin, decl_macro)]
+#![feature(plugin, decl_macro, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 
-extern crate rocket;
+#[macro_use] extern crate rocket;
 
 mod common;
 

--- a/examples/config/tests/production.rs
+++ b/examples/config/tests/production.rs
@@ -1,7 +1,7 @@
-#![feature(plugin, decl_macro)]
+#![feature(plugin, decl_macro, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 
-extern crate rocket;
+#[macro_use] extern crate rocket;
 
 mod common;
 

--- a/examples/config/tests/staging.rs
+++ b/examples/config/tests/staging.rs
@@ -1,7 +1,7 @@
-#![feature(plugin, decl_macro)]
+#![feature(plugin, decl_macro, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 
-extern crate rocket;
+#[macro_use] extern crate rocket;
 
 mod common;
 

--- a/examples/content_types/src/main.rs
+++ b/examples/content_types/src/main.rs
@@ -1,6 +1,7 @@
-#![feature(plugin, decl_macro)]
+#![feature(plugin, decl_macro, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 
+#[macro_use]
 extern crate rocket;
 extern crate serde_json;
 #[macro_use]

--- a/examples/cookies/src/main.rs
+++ b/examples/cookies/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro)]
+#![feature(plugin, decl_macro, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 
 extern crate rocket_contrib;

--- a/examples/errors/src/main.rs
+++ b/examples/errors/src/main.rs
@@ -1,7 +1,7 @@
-#![feature(plugin, decl_macro)]
+#![feature(plugin, decl_macro, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 
-extern crate rocket;
+#[macro_use] extern crate rocket;
 
 #[cfg(test)] mod tests;
 

--- a/examples/fairings/src/main.rs
+++ b/examples/fairings/src/main.rs
@@ -1,7 +1,7 @@
-#![feature(plugin, decl_macro)]
+#![feature(plugin, decl_macro, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 
-extern crate rocket;
+#[macro_use] extern crate rocket;
 
 use std::io::Cursor;
 use std::sync::atomic::{AtomicUsize, Ordering};

--- a/examples/form_kitchen_sink/src/main.rs
+++ b/examples/form_kitchen_sink/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro)]
+#![feature(plugin, decl_macro, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;

--- a/examples/form_validation/src/main.rs
+++ b/examples/form_validation/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro)]
+#![feature(plugin, decl_macro, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;

--- a/examples/handlebars_templates/src/main.rs
+++ b/examples/handlebars_templates/src/main.rs
@@ -1,8 +1,8 @@
-#![feature(plugin, decl_macro)]
+#![feature(plugin, decl_macro, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 
 extern crate rocket_contrib;
-extern crate rocket;
+#[macro_use] extern crate rocket;
 #[macro_use] extern crate serde_derive;
 
 #[cfg(test)] mod tests;

--- a/examples/hello_2018/Cargo.toml
+++ b/examples/hello_2018/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition"]
-
 [package]
 name = "hello_2018"
 version = "0.0.0"

--- a/examples/hello_2018/Cargo.toml
+++ b/examples/hello_2018/Cargo.toml
@@ -1,0 +1,12 @@
+cargo-features = ["edition"]
+
+[package]
+name = "hello_2018"
+version = "0.0.0"
+workspace = "../../"
+publish = false
+edition = "2018"
+
+[dependencies]
+rocket = { path = "../../core/lib" }
+rocket_codegen = { path = "../../core/codegen" }

--- a/examples/hello_2018/src/main.rs
+++ b/examples/hello_2018/src/main.rs
@@ -1,0 +1,16 @@
+#![feature(plugin, decl_macro, proc_macro_non_items)]
+#![plugin(rocket_codegen)]
+
+use rocket;
+use rocket::routes;
+
+#[cfg(test)] mod tests;
+
+#[get("/")]
+fn hello() -> &'static str {
+    "Hello, Rust 2018!"
+}
+
+fn main() {
+    rocket::ignite().mount("/", routes![hello]).launch();
+}

--- a/examples/hello_2018/src/tests.rs
+++ b/examples/hello_2018/src/tests.rs
@@ -1,0 +1,11 @@
+use rocket;
+use rocket::routes;
+use rocket::local::Client;
+
+#[test]
+fn hello_world() {
+    let rocket = rocket::ignite().mount("/", routes![super::hello]);
+    let client = Client::new(rocket).unwrap();
+    let mut response = client.get("/").dispatch();
+    assert_eq!(response.body_string(), Some("Hello, Rust 2018!".into()));
+}

--- a/examples/hello_person/src/main.rs
+++ b/examples/hello_person/src/main.rs
@@ -1,7 +1,7 @@
-#![feature(plugin, decl_macro)]
+#![feature(plugin, decl_macro, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 
-extern crate rocket;
+#[macro_use] extern crate rocket;
 
 #[cfg(test)] mod tests;
 

--- a/examples/hello_world/src/main.rs
+++ b/examples/hello_world/src/main.rs
@@ -1,7 +1,7 @@
-#![feature(plugin, decl_macro)]
+#![feature(plugin, decl_macro, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 
-extern crate rocket;
+#[macro_use] extern crate rocket;
 
 #[cfg(test)] mod tests;
 

--- a/examples/json/src/main.rs
+++ b/examples/json/src/main.rs
@@ -1,7 +1,7 @@
-#![feature(plugin, decl_macro)]
+#![feature(plugin, decl_macro, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 
-extern crate rocket;
+#[macro_use] extern crate rocket;
 #[macro_use] extern crate rocket_contrib;
 #[macro_use] extern crate serde_derive;
 

--- a/examples/managed_queue/src/main.rs
+++ b/examples/managed_queue/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro)]
+#![feature(plugin, decl_macro, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 
 extern crate crossbeam;

--- a/examples/msgpack/src/main.rs
+++ b/examples/msgpack/src/main.rs
@@ -1,7 +1,7 @@
-#![feature(plugin, decl_macro)]
+#![feature(plugin, decl_macro, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 
-extern crate rocket;
+#[macro_use] extern crate rocket;
 extern crate rocket_contrib;
 #[macro_use] extern crate serde_derive;
 

--- a/examples/optional_redirect/src/main.rs
+++ b/examples/optional_redirect/src/main.rs
@@ -1,6 +1,7 @@
-#![feature(plugin, decl_macro)]
+#![feature(plugin, decl_macro, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
-extern crate rocket;
+
+#[macro_use] extern crate rocket;
 
 #[cfg(test)]
 mod tests;

--- a/examples/pastebin/src/main.rs
+++ b/examples/pastebin/src/main.rs
@@ -1,6 +1,7 @@
-#![feature(plugin, decl_macro)]
+#![feature(plugin, decl_macro, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 
+#[macro_use]
 extern crate rocket;
 extern crate rand;
 

--- a/examples/query_params/src/main.rs
+++ b/examples/query_params/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro)]
+#![feature(plugin, decl_macro, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;

--- a/examples/ranking/src/main.rs
+++ b/examples/ranking/src/main.rs
@@ -1,7 +1,7 @@
-#![feature(plugin, decl_macro)]
+#![feature(plugin, decl_macro, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 
-extern crate rocket;
+#[macro_use] extern crate rocket;
 
 use rocket::http::RawStr;
 

--- a/examples/raw_sqlite/src/main.rs
+++ b/examples/raw_sqlite/src/main.rs
@@ -1,7 +1,7 @@
-#![feature(plugin, decl_macro)]
+#![feature(plugin, decl_macro, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 
-extern crate rocket;
+#[macro_use] extern crate rocket;
 extern crate rusqlite;
 
 #[cfg(test)] mod tests;

--- a/examples/raw_upload/src/main.rs
+++ b/examples/raw_upload/src/main.rs
@@ -1,7 +1,7 @@
-#![feature(plugin, decl_macro)]
+#![feature(plugin, decl_macro, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 
-extern crate rocket;
+#[macro_use] extern crate rocket;
 
 #[cfg(test)] mod tests;
 

--- a/examples/redirect/src/main.rs
+++ b/examples/redirect/src/main.rs
@@ -1,7 +1,7 @@
-#![feature(plugin, decl_macro)]
+#![feature(plugin, decl_macro, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 
-extern crate rocket;
+#[macro_use] extern crate rocket;
 
 #[cfg(test)] mod tests;
 

--- a/examples/request_guard/src/main.rs
+++ b/examples/request_guard/src/main.rs
@@ -1,7 +1,7 @@
-#![feature(plugin, decl_macro, never_type)]
+#![feature(plugin, decl_macro, never_type, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 
-extern crate rocket;
+#[macro_use] extern crate rocket;
 
 use rocket::request::{self, Request, FromRequest};
 use rocket::outcome::Outcome::*;

--- a/examples/request_local_state/src/main.rs
+++ b/examples/request_local_state/src/main.rs
@@ -1,7 +1,7 @@
-#![feature(plugin, decl_macro, never_type)]
+#![feature(plugin, decl_macro, never_type, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 
-extern crate rocket;
+#[macro_use] extern crate rocket;
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 

--- a/examples/session/src/main.rs
+++ b/examples/session/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, never_type)]
+#![feature(plugin, decl_macro, never_type, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 
 extern crate rocket_contrib;

--- a/examples/state/src/main.rs
+++ b/examples/state/src/main.rs
@@ -1,7 +1,7 @@
-#![feature(plugin, decl_macro)]
+#![feature(plugin, decl_macro, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 
-extern crate rocket;
+#[macro_use] extern crate rocket;
 
 #[cfg(test)] mod tests;
 

--- a/examples/stream/src/main.rs
+++ b/examples/stream/src/main.rs
@@ -1,7 +1,7 @@
-#![feature(plugin, decl_macro)]
+#![feature(plugin, decl_macro, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 
-extern crate rocket;
+#[macro_use] extern crate rocket;
 
 #[cfg(test)] mod tests;
 

--- a/examples/tera_templates/src/main.rs
+++ b/examples/tera_templates/src/main.rs
@@ -1,8 +1,8 @@
-#![feature(plugin, decl_macro)]
+#![feature(plugin, decl_macro, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 
 extern crate rocket_contrib;
-extern crate rocket;
+#[macro_use] extern crate rocket;
 extern crate serde_json;
 #[macro_use] extern crate serde_derive;
 

--- a/examples/testing/src/main.rs
+++ b/examples/testing/src/main.rs
@@ -1,7 +1,7 @@
-#![feature(plugin, decl_macro)]
+#![feature(plugin, decl_macro, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 
-extern crate rocket;
+#[macro_use] extern crate rocket;
 
 #[get("/")]
 fn hello() -> &'static str {

--- a/examples/tls/src/main.rs
+++ b/examples/tls/src/main.rs
@@ -1,7 +1,7 @@
-#![feature(plugin, decl_macro)]
+#![feature(plugin, decl_macro, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 
-extern crate rocket;
+#[macro_use] extern crate rocket;
 
 #[cfg(test)] mod tests;
 

--- a/examples/todo/src/main.rs
+++ b/examples/todo/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, custom_derive)]
+#![feature(plugin, decl_macro, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;

--- a/examples/uuid/src/main.rs
+++ b/examples/uuid/src/main.rs
@@ -1,10 +1,10 @@
-#![feature(plugin, decl_macro)]
+#![feature(plugin, decl_macro, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 
 #[macro_use]
 extern crate lazy_static;
 extern crate uuid;
-extern crate rocket;
+#[macro_use] extern crate rocket;
 extern crate rocket_contrib;
 
 use std::collections::HashMap;


### PR DESCRIPTION
What the title says. Also adds compiletest to the codegen_next crate and updates all examples and tests to properly import the macros.

Unfortunately, at present `#![feature(proc_macro_non_items)]` is required on downstream crates. They are also imported with `use` like items are instead of with `#[macro_use]`, which makes for a noisy commit.

This branch does not currently move any of the associated documentation.