### PR TITLE
Allow "." but disallow ".." in segments

### DIFF
--- a/core/lib/src/request/param.rs
+++ b/core/lib/src/request/param.rs
@@ -336,7 +336,7 @@ impl<'a> FromSegments<'a> for PathBuf {
 
             if decoded == ".." {
                 buf.pop();
-            } else if decoded.starts_with('.') {
+            } else if decoded.contains("..") {
                 return Err(SegmentError::BadStart('.'))
             } else if decoded.starts_with('*') {
                 return Err(SegmentError::BadStart('*'))


### PR DESCRIPTION
Hello,

You may want to allow `.` in your paths (for example `.hidden`) and the `starts_with('.')` prevents this.

I'm not sure that this is the best fix, maybe that we should check that the segment equals `.` instead?