### PR TITLE
Make `proc_macro` feature gates more granular

### DIFF
--- a/core/codegen_next/src/lib.rs
+++ b/core/codegen_next/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro, core_intrinsics, decl_macro)]
+#![feature(proc_macro_diagnostic, proc_macro_span, core_intrinsics, decl_macro)]
 #![recursion_limit="256"]
 
 extern crate syn;


### PR DESCRIPTION
Just a one-line update in `codegen_next`. `pear` is still broken but should be fixed soon.

Gotta love these proc_macro changes coming down the pike.