### PR TITLE
Fix some clippy warnings.

### DIFF
--- a/core/codegen/src/decorators/catch.rs
+++ b/core/codegen/src/decorators/catch.rs
@@ -8,8 +8,8 @@ use syntax::ext::base::{Annotatable, ExtCtxt};
 use syntax::tokenstream::TokenTree;
 use syntax::parse::token;
 
-const ERR_PARAM: &'static str = "__err";
-const REQ_PARAM: &'static str = "__req";
+const ERR_PARAM: &str = "__err";
+const REQ_PARAM: &str = "__req";
 
 trait CatchGenerateExt {
     fn generate_fn_arguments(&self, &ExtCtxt, Ident, Ident) -> Vec<TokenTree>;

--- a/core/codegen/src/decorators/derive_form.rs
+++ b/core/codegen/src/decorators/derive_form.rs
@@ -217,7 +217,7 @@ fn from_form_substructure(cx: &mut ExtCtxt, trait_span: Span, substr: &Substruct
         let (ident, name, span) = extract_field_ident_name(cx, field);
         let stripped_ty = strip_ty_lifetimes(field.ty.clone());
 
-        if let Some(sp) = names.get(&name).map(|sp| *sp) {
+        if let Some(sp) = names.get(&name).cloned() {
             cx.struct_span_err(span, "field with duplicate name")
                 .span_note(sp, "original was declared here")
                 .emit();

--- a/core/codegen/src/lib.rs
+++ b/core/codegen/src/lib.rs
@@ -238,19 +238,19 @@ use rustc_plugin::Registry;
 use syntax::ext::base::SyntaxExtension;
 use syntax::symbol::Symbol;
 
-const DEBUG_ENV_VAR: &'static str = "ROCKET_CODEGEN_DEBUG";
+const DEBUG_ENV_VAR: &str = "ROCKET_CODEGEN_DEBUG";
 
-const PARAM_PREFIX: &'static str = "rocket_param_";
-const ROUTE_STRUCT_PREFIX: &'static str = "static_rocket_route_info_for_";
-const CATCH_STRUCT_PREFIX: &'static str = "static_rocket_catch_info_for_";
-const ROUTE_FN_PREFIX: &'static str = "rocket_route_fn_";
-const CATCH_FN_PREFIX: &'static str = "rocket_catch_fn_";
-const URI_INFO_MACRO_PREFIX: &'static str = "rocket_uri_for_";
+const PARAM_PREFIX: &str = "rocket_param_";
+const ROUTE_STRUCT_PREFIX: &str = "static_rocket_route_info_for_";
+const CATCH_STRUCT_PREFIX: &str = "static_rocket_catch_info_for_";
+const ROUTE_FN_PREFIX: &str = "rocket_route_fn_";
+const CATCH_FN_PREFIX: &str = "rocket_catch_fn_";
+const URI_INFO_MACRO_PREFIX: &str = "rocket_uri_for_";
 
-const ROUTE_ATTR: &'static str = "rocket_route";
-const ROUTE_INFO_ATTR: &'static str = "rocket_route_info";
+const ROUTE_ATTR: &str = "rocket_route";
+const ROUTE_INFO_ATTR: &str = "rocket_route_info";
 
-const CATCHER_ATTR: &'static str = "rocket_catcher";
+const CATCHER_ATTR: &str = "rocket_catcher";
 
 macro_rules! register_decorators {
     ($registry:expr, $($name:expr => $func:ident),+) => (

--- a/core/codegen/src/macros/uri.rs
+++ b/core/codegen/src/macros/uri.rs
@@ -28,7 +28,7 @@ pub fn uri(
     // so that errors from the `internal` call show up on the user's code.
     let expr = parser.mk_mac_expr(sp,
         ast::Mac_ {
-            path: path,
+            path,
             delim: MacDelimiter::Parenthesis,
             tts: args.to_vec().into_iter().collect::<TokenStream>().into(),
         },

--- a/core/codegen/src/parser/catch.rs
+++ b/core/codegen/src/parser/catch.rs
@@ -34,7 +34,7 @@ impl CatchParams {
             ecx.span_fatal(sp, "malformed attribute");
         });
 
-        if meta_items.len() < 1 {
+        if meta_items.is_empty() {
             ecx.span_fatal(sp, "attribute requires the `code` parameter");
         } else if meta_items.len() > 1 {
             ecx.span_fatal(sp, "attribute can only have one `code` parameter");

--- a/core/codegen/src/parser/route.rs
+++ b/core/codegen/src/parser/route.rs
@@ -119,12 +119,9 @@ impl RouteParams {
         }
 
         RouteParams {
-            method,
-            uri,
+            method, uri, format, rank,
             data_param: data,
             query_param: query,
-            format,
-            rank,
             annotated_fn: function,
         }
     }

--- a/core/codegen/src/parser/route.rs
+++ b/core/codegen/src/parser/route.rs
@@ -52,7 +52,7 @@ impl RouteParams {
             ecx.span_fatal(sp, "malformed attribute");
         });
 
-        if meta_items.len() < 1 {
+        if meta_items.is_empty() {
             ecx.span_fatal(sp, "attribute requires at least 1 parameter");
         }
 
@@ -64,7 +64,7 @@ impl RouteParams {
             None => (parse_method(ecx, &meta_items[0]), &meta_items[1..])
         };
 
-        if attr_params.len() < 1 {
+        if attr_params.is_empty() {
             ecx.struct_span_err(sp, "attribute requires at least a path")
                 .help(r#"example: #[get("/my/path")] or #[get(path = "/hi")]"#)
                 .emit();
@@ -119,12 +119,12 @@ impl RouteParams {
         }
 
         RouteParams {
-            method: method,
-            uri: uri,
+            method,
+            uri,
             data_param: data,
             query_param: query,
-            format: format,
-            rank: rank,
+            format,
+            rank,
             annotated_fn: function,
         }
     }

--- a/core/codegen/src/parser/uri.rs
+++ b/core/codegen/src/parser/uri.rs
@@ -47,7 +47,7 @@ fn valid_segments(ecx: &ExtCtxt, uri: &Uri, sp: Span) -> bool {
         }
 
         // Check if this is a dynamic param. If so, check it's well-formedness.
-        if segment.starts_with("<") && segment.ends_with(">") {
+        if segment.starts_with('<') && segment.ends_with('>') {
             let mut param = &segment[1..(segment.len() - 1)];
             if segment.ends_with("..>") {
                 segments_span = Some(span);
@@ -69,8 +69,8 @@ fn valid_segments(ecx: &ExtCtxt, uri: &Uri, sp: Span) -> bool {
             }
 
             validated = false;
-        } else if segment.starts_with("<") {
-            if segment[1..].contains("<") || segment.contains(">") {
+        } else if segment.starts_with('<') {
+            if segment[1..].contains('<') || segment.contains('>') {
                 ecx.struct_span_err(span, "malformed parameter")
                     .help("parameters must be of the form '<param>'")
                     .emit();
@@ -82,7 +82,7 @@ fn valid_segments(ecx: &ExtCtxt, uri: &Uri, sp: Span) -> bool {
 
             validated = false;
         } else if Uri::percent_encode(segment) != segment {
-            if segment.contains("<") || segment.contains(">") {
+            if segment.contains('<') || segment.contains('>') {
                 ecx.struct_span_err(span, "malformed parameter")
                     .help("parameters must be of the form '<param>'")
                     .emit();

--- a/core/codegen/src/parser/uri_macro.rs
+++ b/core/codegen/src/parser/uri_macro.rs
@@ -146,7 +146,7 @@ impl UriParams {
 
         // Ensure that both types of arguments were not used at once.
         let (mut homogeneous_args, mut prev_named) = (true, None);
-        for arg in arguments.iter() {
+        for arg in &arguments {
             match prev_named {
                 Some(prev_named) => homogeneous_args = prev_named == arg.is_named(),
                 None => prev_named = Some(arg.is_named()),
@@ -237,7 +237,7 @@ impl InternalUriParams {
                 }
 
                 let (mut missing, mut exprs) = (vec![], vec![]);
-                for (name, expr) in params.into_iter() {
+                for (name, expr) in params {
                     match expr {
                         Some(expr) => exprs.push(expr),
                         None => missing.push(name)

--- a/core/codegen/src/utils/mod.rs
+++ b/core/codegen/src/utils/mod.rs
@@ -41,7 +41,7 @@ macro_rules! debug {
 }
 
 pub fn span<T>(t: T, span: Span) -> Spanned<T> {
-    Spanned { node: t, span: span }
+    Spanned { node: t, span }
 }
 
 pub fn sep_by_tok<T>(ecx: &ExtCtxt, things: &[T], token: Token) -> Vec<TokenTree>

--- a/core/codegen/src/utils/span_ext.rs
+++ b/core/codegen/src/utils/span_ext.rs
@@ -43,6 +43,6 @@ impl SpanExt for Span {
     }
 
     fn wrap<T>(self, node: T) -> Spanned<T> {
-        Spanned { node: node, span: self }
+        Spanned { node, span: self }
     }
 }

--- a/core/codegen_next/src/parser.rs
+++ b/core/codegen_next/src/parser.rs
@@ -10,6 +10,7 @@ pub use proc_macro2::Delimiter;
 
 pub type Result<T> = ::std::result::Result<T, Diagnostic>;
 
+#[derive(Copy, Clone)]
 pub enum Seperator {
     Comma,
     Pipe,
@@ -23,7 +24,7 @@ pub struct Parser {
 
 impl Parser {
     pub fn new(tokens: TokenStream) -> Parser {
-        let buffer = Box::new(TokenBuffer::new(tokens.into()));
+        let buffer = Box::new(TokenBuffer::new(tokens));
         // Our `Parser` is self-referential. We cast a pointer to the heap
         // allocation as `&'static` to allow the storage of the reference
         // along-side the allocation. This is safe as long as `buffer` is never
@@ -42,7 +43,7 @@ impl Parser {
     pub fn current_span(&self) -> Span {
         self.cursor.token_tree()
             .map(|_| self.cursor.span().unstable())
-            .unwrap_or_else(|| Span::call_site())
+            .unwrap_or_else(Span::call_site)
     }
 
     pub fn parse<T: Synom>(&mut self) -> Result<T> {

--- a/core/http/src/accept.rs
+++ b/core/http/src/accept.rs
@@ -252,24 +252,21 @@ impl Accept {
         let mut all = self.iter();
         let mut preferred = all.next().unwrap_or(&ANY);
         for media_type in all {
-            if media_type.weight().is_none() && preferred.weight().is_some() {
-                // Media types without a `q` parameter are preferred.
-                preferred = media_type;
-            } else if media_type.weight_or(0.0) > preferred.weight_or(1.0) {
+            // Prefer media types without a `q` parameter.
+            if (media_type.weight().is_none() && preferred.weight().is_some()) ||
                 // Prefer media types with a greater weight, but if one doesn't
                 // have a weight, prefer the one we already have.
-                preferred = media_type;
-            } else if media_type.specificity() > preferred.specificity() {
+                (media_type.weight_or(0.0) > preferred.weight_or(1.0)) ||
                 // Prefer more specific media types over less specific ones. IE:
                 // text/html over application/*.
-                preferred = media_type;
-            } else if media_type == preferred {
+                (media_type.specificity() > preferred.specificity()) ||
                 // Finally, all other things being equal, prefer a media type
                 // with more parameters over one with fewer. IE: text/html; a=b
                 // over text/html.
-                if media_type.params().count() > preferred.params().count() {
-                    preferred = media_type;
-                }
+                (media_type == preferred &&
+                    (media_type.params().count() > preferred.params().count()))
+            {
+                preferred = media_type;
             }
         }
 

--- a/core/http/src/accept.rs
+++ b/core/http/src/accept.rs
@@ -252,21 +252,24 @@ impl Accept {
         let mut all = self.iter();
         let mut preferred = all.next().unwrap_or(&ANY);
         for media_type in all {
-            // Prefer media types without a `q` parameter.
-            if (media_type.weight().is_none() && preferred.weight().is_some()) ||
+            if media_type.weight().is_none() && preferred.weight().is_some() {
+                // Media types without a `q` parameter are preferred.
+                preferred = media_type;
+            } else if media_type.weight_or(0.0) > preferred.weight_or(1.0) {
                 // Prefer media types with a greater weight, but if one doesn't
                 // have a weight, prefer the one we already have.
-                (media_type.weight_or(0.0) > preferred.weight_or(1.0)) ||
+                preferred = media_type;
+            } else if media_type.specificity() > preferred.specificity() {
                 // Prefer more specific media types over less specific ones. IE:
                 // text/html over application/*.
-                (media_type.specificity() > preferred.specificity()) ||
+                preferred = media_type;
+            } else if media_type == preferred {
                 // Finally, all other things being equal, prefer a media type
                 // with more parameters over one with fewer. IE: text/html; a=b
                 // over text/html.
-                (media_type == preferred &&
-                    (media_type.params().count() > preferred.params().count()))
-            {
-                preferred = media_type;
+                if media_type.params().count() > preferred.params().count() {
+                    preferred = media_type;
+                }
             }
         }
 

--- a/core/http/src/content_type.rs
+++ b/core/http/src/content_type.rs
@@ -332,7 +332,7 @@ impl FromStr for ContentType {
     /// ```
     #[inline(always)]
     fn from_str(raw: &str) -> Result<ContentType, String> {
-        MediaType::from_str(raw).map(|mt| ContentType(mt))
+        MediaType::from_str(raw).map(ContentType)
     }
 }
 

--- a/core/http/src/cookies.rs
+++ b/core/http/src/cookies.rs
@@ -352,7 +352,7 @@ impl<'a> Cookies<'a> {
     ///     }
     /// }
     /// ```
-    pub fn iter<'s>(&'s self) -> impl Iterator<Item=&'s Cookie<'static>> {
+    pub fn iter(&self) -> impl Iterator<Item=&Cookie<'static>> {
         match *self {
             Cookies::Jarred(ref jar, _) => jar.iter(),
             Cookies::Empty(ref jar) => jar.iter()

--- a/core/http/src/ext.rs
+++ b/core/http/src/ext.rs
@@ -28,8 +28,8 @@ impl<T> IntoCollection<T> for Vec<T> {
     }
 
     #[inline]
-    fn mapped<U, F: FnMut(T) -> U, A: Array<Item=U>>(self, mut f: F) -> SmallVec<A> {
-        self.into_iter().map(|item| f(item)).collect()
+    fn mapped<U, F: FnMut(T) -> U, A: Array<Item=U>>(self, f: F) -> SmallVec<A> {
+        self.into_iter().map(f).collect()
     }
 }
 
@@ -42,8 +42,10 @@ macro_rules! impl_for_slice {
             }
 
             #[inline]
-            fn mapped<U, F: FnMut(T) -> U, A: Array<Item=U>>(self, mut f: F) -> SmallVec<A> {
-                self.iter().cloned().map(|item| f(item)).collect()
+            fn mapped<U, F, A: Array<Item=U>>(self, f: F) -> SmallVec<A>
+                where F: FnMut(T) -> U
+            {
+                self.iter().cloned().map(f).collect()
             }
         }
     )

--- a/core/http/src/header.rs
+++ b/core/http/src/header.rs
@@ -267,7 +267,7 @@ impl<'h> HeaderMap<'h> {
     pub fn get_one<'a>(&'a self, name: &str) -> Option<&'a str> {
         self.headers.get(UncasedStr::new(name))
             .and_then(|values| {
-                if values.len() >= 1 { Some(values[0].borrow()) }
+                if !values.is_empty() { Some(values[0].borrow()) }
                 else { None }
             })
     }
@@ -561,7 +561,7 @@ impl<'h> HeaderMap<'h> {
     ///     }
     /// }
     /// ```
-    pub fn iter<'s>(&'s self) -> impl Iterator<Item=Header<'s>> {
+    pub fn iter(&self) -> impl Iterator<Item=Header> {
         self.headers.iter().flat_map(|(key, values)| {
             values.iter().map(move |val| {
                 Header::new(key.as_str(), &**val)
@@ -613,7 +613,7 @@ impl<'h> HeaderMap<'h> {
             value.into_iter().map(move |value| {
                 Header {
                     name: name.clone(),
-                    value: value
+                    value,
                 }
             })
         })

--- a/core/http/src/header.rs
+++ b/core/http/src/header.rs
@@ -611,10 +611,7 @@ impl<'h> HeaderMap<'h> {
     pub fn into_iter(self) -> impl Iterator<Item=Header<'h>> {
         self.headers.into_iter().flat_map(|(name, value)| {
             value.into_iter().map(move |value| {
-                Header {
-                    name: name.clone(),
-                    value,
-                }
+                Header { name: name.clone(), value }
             })
         })
     }

--- a/core/http/src/method.rs
+++ b/core/http/src/method.rs
@@ -52,8 +52,8 @@ impl Method {
     /// assert_eq!(Method::Post.supports_payload(), true);
     /// ```
     #[inline]
-    pub fn supports_payload(&self) -> bool {
-        match *self {
+    pub fn supports_payload(self) -> bool {
+        match self {
             Put | Post | Delete | Patch => true,
             Get | Head | Connect | Trace | Options => false,
         }
@@ -70,8 +70,8 @@ impl Method {
     /// assert_eq!(Method::Get.as_str(), "GET");
     /// ```
     #[inline]
-    pub fn as_str(&self) -> &'static str {
-        match *self {
+    pub fn as_str(self) -> &'static str {
+        match self {
             Get => "GET",
             Put => "PUT",
             Post => "POST",

--- a/core/http/src/raw_str.rs
+++ b/core/http/src/raw_str.rs
@@ -63,7 +63,7 @@ impl RawStr {
     /// let raw_str: &RawStr = "Hello, world!".into();
     /// ```
     #[inline(always)]
-    pub fn from_str<'a>(string: &'a str) -> &'a RawStr {
+    pub fn from_str(string: &str) -> &RawStr {
         string.into()
     }
 

--- a/core/http/src/status.rs
+++ b/core/http/src/status.rs
@@ -156,10 +156,7 @@ impl Status {
     /// ```
     #[inline(always)]
     pub const fn new(code: u16, reason: &'static str) -> Status {
-        Status {
-            code: code,
-            reason: reason
-        }
+        Status { code, reason }
     }
 
     /// Returns the class of a given status.

--- a/core/http/src/uri/uri.rs
+++ b/core/http/src/uri/uri.rs
@@ -39,13 +39,7 @@ impl<'a> Uri<'a> {
             (None, None) => ((0, end), None, None),
         };
 
-        Uri {
-            uri,
-            path,
-            query,
-            fragment,
-            segment_count: AtomicIsize::new(EMPTY),
-        }
+        Uri { uri, path, query, fragment, segment_count: AtomicIsize::new(EMPTY) }
     }
 
     /// Returns the number of segments in the URI. Empty segments, which are

--- a/core/http/src/uri/uri.rs
+++ b/core/http/src/uri/uri.rs
@@ -40,10 +40,10 @@ impl<'a> Uri<'a> {
         };
 
         Uri {
-            uri: uri,
-            path: path,
-            query: query,
-            fragment: fragment,
+            uri,
+            path,
+            query,
+            fragment,
             segment_count: AtomicIsize::new(EMPTY),
         }
     }

--- a/core/lib/src/config/mod.rs
+++ b/core/lib/src/config/mod.rs
@@ -225,10 +225,10 @@ use self::environment::CONFIG_ENV;
 use self::toml_ext::parse_simple_toml_value;
 use http::uncased::uncased_eq;
 
-const CONFIG_FILENAME: &'static str = "Rocket.toml";
-const GLOBAL_ENV_NAME: &'static str = "global";
-const ENV_VAR_PREFIX: &'static str = "ROCKET_";
-const PREHANDLED_VARS: [&'static str; 2] = ["ROCKET_CODEGEN_DEBUG", CONFIG_ENV];
+const CONFIG_FILENAME: &str = "Rocket.toml";
+const GLOBAL_ENV_NAME: &str = "global";
+const ENV_VAR_PREFIX: &str = "ROCKET_";
+const PREHANDLED_VARS: [&str; 2] = ["ROCKET_CODEGEN_DEBUG", CONFIG_ENV];
 
 /// Wraps `std::result` with the error type of
 /// [ConfigError](enum.ConfigError.html).

--- a/core/lib/src/lib.rs
+++ b/core/lib/src/lib.rs
@@ -98,7 +98,7 @@
 //! module documentation](/rocket/local) and the [testing chapter of the
 //! guide](https://rocket.rs/guide/testing/#testing) include detailed examples.
 
-#[allow(unused_imports)] #[macro_use] extern crate rocket_codegen_next;
+#![allow(unused_imports)] #[macro_use] extern crate rocket_codegen_next;
 #[doc(hidden)] pub use rocket_codegen_next::*;
 
 extern crate rocket_http;

--- a/core/lib/src/lib.rs
+++ b/core/lib/src/lib.rs
@@ -98,7 +98,7 @@
 //! module documentation](/rocket/local) and the [testing chapter of the
 //! guide](https://rocket.rs/guide/testing/#testing) include detailed examples.
 
-#![allow(unused_imports)] #[macro_use] extern crate rocket_codegen_next;
+#[allow(unused_imports)] #[macro_use] extern crate rocket_codegen_next;
 #[doc(hidden)] pub use rocket_codegen_next::*;
 
 extern crate rocket_http;

--- a/core/lib/src/local/request.rs
+++ b/core/lib/src/local/request.rs
@@ -336,11 +336,7 @@ impl<'c> LocalRequest<'c> {
         let req = self.long_lived_request();
         let response = self.client.rocket().dispatch(req, Data::local(self.data));
         self.client.update_cookies(&response);
-
-        LocalResponse {
-            _request: self.request,
-            response,
-        }
+        LocalResponse { _request: self.request, response }
     }
 
     /// Dispatches the request, returning the response.
@@ -400,11 +396,7 @@ impl<'c> LocalRequest<'c> {
         let req = self.long_lived_request();
         let response = self.client.rocket().dispatch(req, Data::local(data));
         self.client.update_cookies(&response);
-
-        LocalResponse {
-            _request: self.request.clone(),
-            response,
-        }
+        LocalResponse { _request: self.request.clone(), response }
     }
 }
 

--- a/core/lib/src/local/request.rs
+++ b/core/lib/src/local/request.rs
@@ -221,7 +221,7 @@ impl<'c> LocalRequest<'c> {
     ///     .cookie(Cookie::new("user_id", "12"));
     /// ```
     #[inline]
-    pub fn cookie<'a>(self, cookie: Cookie<'a>) -> Self {
+    pub fn cookie(self, cookie: Cookie) -> Self {
         self.request.cookies().add_original(cookie.into_owned());
         self
     }
@@ -242,7 +242,7 @@ impl<'c> LocalRequest<'c> {
     /// let req = client.get("/").cookies(cookies);
     /// ```
     #[inline]
-    pub fn cookies<'a>(self, cookies: Vec<Cookie<'a>>) -> Self {
+    pub fn cookies(self, cookies: Vec<Cookie>) -> Self {
         for cookie in cookies {
             self.request.cookies().add_original(cookie.into_owned());
         }
@@ -339,7 +339,7 @@ impl<'c> LocalRequest<'c> {
 
         LocalResponse {
             _request: self.request,
-            response: response
+            response,
         }
     }
 
@@ -403,7 +403,7 @@ impl<'c> LocalRequest<'c> {
 
         LocalResponse {
             _request: self.request.clone(),
-            response: response
+            response,
         }
     }
 }

--- a/core/lib/src/logger.rs
+++ b/core/lib/src/logger.rs
@@ -23,8 +23,8 @@ pub enum LoggingLevel {
 
 impl LoggingLevel {
     #[inline(always)]
-    fn to_level_filter(&self) -> log::LevelFilter {
-        match *self {
+    fn to_level_filter(self) -> log::LevelFilter {
+        match self {
             LoggingLevel::Critical => log::LevelFilter::Warn,
             LoggingLevel::Normal => log::LevelFilter::Info,
             LoggingLevel::Debug => log::LevelFilter::Trace,
@@ -103,10 +103,11 @@ impl log::Log for RocketLogger {
         }
 
         // In Rocket, we abuse targets with suffix "_" to indicate indentation.
-        if record.target().ends_with('_') {
-            if configged_level != LoggingLevel::Critical || record.target().starts_with("launch") {
-                print!("    {} ", Paint::white("=>"));
-            }
+        if (record.target().ends_with('_')) &&
+            (configged_level != LoggingLevel::Critical ||
+                record.target().starts_with("launch"))
+        {
+            print!("    {} ", Paint::white("=>"));
         }
 
         match record.level() {

--- a/core/lib/src/logger.rs
+++ b/core/lib/src/logger.rs
@@ -103,11 +103,10 @@ impl log::Log for RocketLogger {
         }
 
         // In Rocket, we abuse targets with suffix "_" to indicate indentation.
-        if (record.target().ends_with('_')) &&
-            (configged_level != LoggingLevel::Critical ||
-                record.target().starts_with("launch"))
-        {
-            print!("    {} ", Paint::white("=>"));
+        if record.target().ends_with('_') {
+            if configged_level != LoggingLevel::Critical || record.target().starts_with("launch") {
+                print!("    {} ", Paint::white("=>"));
+            }
         }
 
         match record.level() {

--- a/core/lib/src/request/param.rs
+++ b/core/lib/src/request/param.rs
@@ -332,7 +332,7 @@ impl<'a> FromSegments<'a> for PathBuf {
         let mut buf = PathBuf::new();
         for segment in segments {
             let decoded = Uri::percent_decode(segment.as_bytes())
-                .map_err(|e| SegmentError::Utf8(e))?;
+                .map_err(SegmentError::Utf8)?;
 
             if decoded == ".." {
                 buf.pop();

--- a/core/lib/src/request/request.rs
+++ b/core/lib/src/request/request.rs
@@ -490,7 +490,7 @@ impl<'r> Request<'r> {
             // where the client accepts the thing at all?
             self.accept()
                 .map(|accept| accept.preferred().media_type())
-                .or(Some(&ANY))
+                .or_else(|| Some(&ANY))
         }
     }
 
@@ -702,7 +702,7 @@ impl<'r> Request<'r> {
                     Err(_) => continue
                 };
 
-                for cookie_str in raw_str.split(";").map(|s| s.trim()) {
+                for cookie_str in raw_str.split(';').map(|s| s.trim()) {
                     if let Some(cookie) = Cookies::parse_cookie(cookie_str) {
                         cookie_jar.add_original(cookie);
                     }

--- a/core/lib/src/request/request.rs
+++ b/core/lib/src/request/request.rs
@@ -490,7 +490,7 @@ impl<'r> Request<'r> {
             // where the client accepts the thing at all?
             self.accept()
                 .map(|accept| accept.preferred().media_type())
-                .or_else(|| Some(&ANY))
+                .or(Some(&ANY))
         }
     }
 

--- a/core/lib/src/response/flash.rs
+++ b/core/lib/src/response/flash.rs
@@ -9,7 +9,7 @@ use http::{Status, Cookie};
 use std::sync::atomic::{AtomicBool, Ordering};
 
 // The name of the actual flash cookie.
-const FLASH_COOKIE_NAME: &'static str = "_flash";
+const FLASH_COOKIE_NAME: &str = "_flash";
 
 /// Sets a "flash" cookie that will be removed when it is accessed. The
 /// anologous request type is


### PR DESCRIPTION
Clippy has been recently landed in Nightly toward a path to stabilization. This patch fixes some of the warnings that it produces on the master branch.

If this change is accepted, my intention is to work through the rest of the clippy warnings in time for the v0.4 release (so, over the next week or so). There are quite a lot, but they're mostly small changes.