### PR TITLE
spelling and grammar fixes in core and contrib crates

### DIFF
--- a/contrib/lib/src/json.rs
+++ b/contrib/lib/src/json.rs
@@ -307,7 +307,7 @@ impl<'a> Responder<'a> for JsonValue {
 /// ```
 ///
 /// Variables or expressions can be interpolated into the JSON literal. Any type
-/// interpolated into an array element or object value must implement Serde's
+/// interpolated into an array element or object value must implement serde's
 /// `Serialize` trait, while any type interpolated into a object key must
 /// implement `Into<String>`.
 ///

--- a/contrib/lib/src/msgpack.rs
+++ b/contrib/lib/src/msgpack.rs
@@ -53,7 +53,7 @@ pub use self::rmp_serde::decode::Error as MsgPackError;
 ///
 /// If you're responding with MessagePack data, return a `MsgPack<T>` type,
 /// where `T` implements `Serialize` from
-/// [Serde](https://github.com/serde-rs/serde). The content type of the response
+/// [serde](https://github.com/serde-rs/serde). The content type of the response
 /// is set to `application/msgpack` automatically.
 ///
 /// ```rust

--- a/contrib/lib/src/templates/mod.rs
+++ b/contrib/lib/src/templates/mod.rs
@@ -143,7 +143,7 @@ pub struct TemplateInfo {
 }
 
 impl Template {
-    /// Returns a fairing that intializes and maintains templating state.
+    /// Returns a fairing that initializes and maintains templating state.
     ///
     /// This fairing, or the one returned by [`Template::custom()`], _must_ be
     /// attached to any `Rocket` instance that wishes to render templates.
@@ -179,7 +179,7 @@ impl Template {
         Template::custom(|_| {})
     }
 
-    /// Returns a fairing that intializes and maintains templating state.
+    /// Returns a fairing that initializes and maintains templating state.
     ///
     /// Unlike [`Template::fairing()`], this method allows you to configure
     /// templating engines via the parameter `f`. Note that only the enabled

--- a/contrib/lib/src/uuid.rs
+++ b/contrib/lib/src/uuid.rs
@@ -9,7 +9,7 @@ use rocket::http::RawStr;
 
 pub use self::uuid_ext::ParseError as UuidParseError;
 
-/// Implements `FromParam` and `FormFormValue` for accepting Uuid values from
+/// Implements `FromParam` and `FormFormValue` for accepting UUID values from
 /// the [uuid](https://github.com/rust-lang-nursery/uuid) crate.
 ///
 /// # Usage
@@ -49,7 +49,7 @@ pub use self::uuid_ext::ParseError as UuidParseError;
 pub struct Uuid(uuid_ext::Uuid);
 
 impl Uuid {
-    /// Consumes the Uuid wrapper returning the underlying `Uuid` type.
+    /// Consumes the Uuid wrapper, returning the underlying `Uuid` type.
     ///
     /// # Example
     /// ```rust

--- a/core/http/src/content_type.rs
+++ b/core/http/src/content_type.rs
@@ -11,7 +11,7 @@ use hyper::mime::Mime;
 ///
 /// # Usage
 ///
-/// `ContentTypes` should rarely be created directly. Instead, an associated
+/// `ContentType`s should rarely be created directly. Instead, an associated
 /// constant should be used; one is declared for most commonly used content
 /// types.
 ///
@@ -279,7 +279,7 @@ impl<T: Borrow<Mime>> From<T> for ContentType {
 impl From<Mime> for ContentType {
     #[inline]
     fn from(mime: Mime) -> ContentType {
-        // soooo inneficient.
+        // soooo inefficient.
         let params = mime.2.into_iter()
             .map(|(attr, value)| (attr.to_string(), value.to_string()))
             .collect::<Vec<_>>();

--- a/core/http/src/cookies.rs
+++ b/core/http/src/cookies.rs
@@ -260,7 +260,8 @@ impl<'a> Cookies<'a> {
     }
 
     /// For each property mentioned below, this method checks
-    /// if there is provided value and if there is none, set default value.
+    /// if there is a provided value and if there is none, sets
+    /// a default value.
     /// Default values are:
     ///
     ///    * `path`: `"/"`
@@ -289,7 +290,7 @@ impl<'a> Cookies<'a> {
     /// Removes `cookie` from this collection and generates a "removal" cookies
     /// to send to the client on response. For correctness, `cookie` must
     /// contain the same `path` and `domain` as the cookie that was initially
-    /// set. Failure to provide the initual `path` and `domain` will result in
+    /// set. Failure to provide the initial `path` and `domain` will result in
     /// cookies that are not properly removed.
     ///
     /// A "removal" cookie is a cookie that has the same name as the original

--- a/core/http/src/header.rs
+++ b/core/http/src/header.rs
@@ -126,7 +126,7 @@ pub struct HeaderMap<'h> {
 }
 
 impl<'h> HeaderMap<'h> {
-    /// Returns an empty collection.
+    /// Returns an empty header collection.
     ///
     /// # Example
     ///
@@ -620,7 +620,7 @@ impl<'h> HeaderMap<'h> {
     }
 
     /// Consumes `self` and returns an iterator over all of the headers stored
-    /// in the map in the way they are stored. This is a low-level machinism and
+    /// in the map in the way they are stored. This is a low-level mechanism and
     /// should likely not be used.
     /// WARNING: This is unstable! Do not use this method outside of Rocket!
     #[doc(hidden)]

--- a/core/http/src/media_type.rs
+++ b/core/http/src/media_type.rs
@@ -421,7 +421,7 @@ impl MediaType {
     }
 
     /// Compares `self` with `other` and returns `true` if `self` and `other`
-    /// are exactly equal to eachother, including with respect to their
+    /// are exactly equal to each other, including with respect to their
     /// parameters.
     ///
     /// This is different from the `PartialEq` implementation in that it

--- a/core/http/src/raw_str.rs
+++ b/core/http/src/raw_str.rs
@@ -39,7 +39,7 @@ use uncased::UncasedStr;
 ///
 /// A `RawStr` is a dynamically sized type (just like `str`). It is always used
 /// through a reference an as `&RawStr` (just like &str). You'll likely
-/// encounted an `&RawStr` as a parameter via [`FromParam`] or as a form value
+/// encounter an `&RawStr` as a parameter via [`FromParam`] or as a form value
 /// via [`FromFormValue`].
 ///
 /// [`FromParam`]: /rocket/request/trait.FromParam.html
@@ -240,7 +240,7 @@ impl RawStr {
             //    allocated. No characters are pushed to `allocated` prior to
             //    this branch running since the `escaped` flag isn't set. To
             //    enter this branch, the current byte must be a valid ASCII
-            //    character. This implies that every byte preceeding forms a
+            //    character. This implies that every byte preceding forms a
             //    valid UTF-8 string since ASCII characters in UTF-8 are never
             //    part of a multi-byte sequence. Thus, extending the `allocated`
             //    vector with these bytes results in a valid UTF-8 string in

--- a/core/http/src/status.rs
+++ b/core/http/src/status.rs
@@ -47,7 +47,7 @@ impl StatusClass {
 /// # Usage
 ///
 /// Status classes should rarely be created directly. Instead, an associated
-/// constant should be used; one is declared for every standard status defined
+/// constant should be used; one is declared for every status defined
 /// in the HTTP standard.
 ///
 /// ## Example
@@ -139,7 +139,7 @@ macro_rules! ctrs {
 }
 
 impl Status {
-    /// Creates a new `Status` with `code` and `reason`. This should be _only_
+    /// Creates a new `Status` with `code` and `reason`. This should be used _only_
     /// to construct non-standard HTTP statuses. Use an associated constant for
     /// standard statuses.
     ///

--- a/core/http/src/uncased.rs
+++ b/core/http/src/uncased.rs
@@ -1,7 +1,7 @@
 //! Contains types that encapsulate uncased ASCII strings.
 //!
 //! An 'uncased' ASCII string is case-preserving. That is, the string itself
-//! contains cased charaters, but comparison (including ordering, equaility, and
+//! contains cased characters, but comparison (including ordering, equality, and
 //! hashing) is case-insensitive.
 
 use std::ops::Deref;

--- a/core/http/src/uri/from_uri_param.rs
+++ b/core/http/src/uri/from_uri_param.rs
@@ -43,7 +43,7 @@ use {RawStr, uri::UriDisplay};
 ///
 /// This is typically only warranted for owned-value types with
 /// corresponding reference types: `String` and `&str`, for instance. In this
-/// case, it's desireable to allow an `&str` to be used in place of a `String`.
+/// case, it's desirable to allow an `&str` to be used in place of a `String`.
 ///
 /// When implementing `FromUriParam`, be aware that Rocket will use the
 /// [`UriDisplay`] implementation of `Target`, _not_ of the source type.

--- a/core/http/src/uri/uri.rs
+++ b/core/http/src/uri/uri.rs
@@ -192,7 +192,7 @@ impl<'a> Uri<'a> {
         self.query.map(|(i, j)| &self.uri[i..j])
     }
 
-    /// Returns the fargment part of this URI without the hash mark, if there is
+    /// Returns the fragment part of this URI without the hash mark, if there is
     /// any.
     ///
     /// ### Examples

--- a/core/lib/src/config/builder.rs
+++ b/core/lib/src/config/builder.rs
@@ -131,7 +131,7 @@ impl ConfigBuilder {
         self
     }
 
-    /// Set the keep-alive timeout to `timeout` seconds. If `timeout` is `None`,
+    /// Sets the keep-alive timeout to `timeout` seconds. If `timeout` is `None`,
     /// keep-alive is disabled.
     ///
     /// # Example

--- a/core/lib/src/config/config.rs
+++ b/core/lib/src/config/config.rs
@@ -34,7 +34,7 @@ use http::Key;
 /// ## General Configuration
 ///
 /// For more information about Rocket's configuration, see the [`config`] module
-/// documentaiton.
+/// documentation.
 ///
 /// [`config`]: /rocket/config/index.html
 #[derive(Clone)]
@@ -425,7 +425,7 @@ impl Config {
         self.workers = workers;
     }
 
-    /// Set the keep-alive timeout to `timeout` seconds. If `timeout` is `None`,
+    /// Sets the keep-alive timeout to `timeout` seconds. If `timeout` is `None`,
     /// keep-alive is disabled.
     ///
     /// # Example
@@ -509,7 +509,7 @@ impl Config {
         self.log_level = log_level;
     }
 
-    /// Set the receive limits in `self` to `limits`.
+    /// Sets the receive limits in `self` to `limits`.
     ///
     /// # Example
     ///

--- a/core/lib/src/config/environment.rs
+++ b/core/lib/src/config/environment.rs
@@ -39,7 +39,7 @@ impl Environment {
         }
     }
 
-    /// Returns a string with a comma-seperated list of valid environments.
+    /// Returns a string with a comma-separated list of valid environments.
     pub(crate) fn valid() -> &'static str {
         "development, staging, production"
     }

--- a/core/lib/src/config/mod.rs
+++ b/core/lib/src/config/mod.rs
@@ -255,7 +255,7 @@ impl RocketConfig {
         let active_env = config.environment;
 
         // None of these unwraps should fail since the filename is coming from
-        // an existing connfig.
+        // an existing config.
         let mut configs = HashMap::new();
         configs.insert(Development, Config::default(Development, &f).unwrap());
         configs.insert(Staging, Config::default(Staging, &f).unwrap());
@@ -271,7 +271,7 @@ impl RocketConfig {
     /// Read the configuration from the `Rocket.toml` file. The file is search
     /// for recursively up the tree, starting from the CWD.
     pub fn read() -> Result<RocketConfig> {
-        // Find the config file, starting from the `cwd` and working backwords.
+        // Find the config file, starting from the `cwd` and working backwards.
         let file = RocketConfig::find()?;
 
         // Try to open the config file for reading.
@@ -337,7 +337,7 @@ impl RocketConfig {
     /// Set the configuration for the environment `env` to be the configuration
     /// derived from the TOML table `kvs`. The environment must already exist in
     /// `self`, otherwise this function panics. Any existing values are
-    /// overriden by those in `kvs`.
+    /// overridden by those in `kvs`.
     fn set_from_table(&mut self, env: Environment, kvs: &Table) -> Result<()> {
         for (key, value) in kvs {
             self.get_mut(env).set_raw(key, value)?;
@@ -462,7 +462,7 @@ impl RocketConfig {
 /// Initializes the global RocketConfig by reading the Rocket config file from
 /// the current directory or any of its parents. Returns the active
 /// configuration, which is determined by the config env variable. If there as a
-/// problem parsing the configuration, the error is printed and the progam is
+/// problem parsing the configuration, the error is printed and the program is
 /// aborted. If there an I/O issue reading the config file, a warning is printed
 /// and the default configuration is used. If there is no config file, the
 /// default configuration is used.

--- a/core/lib/src/data/data.rs
+++ b/core/lib/src/data/data.rs
@@ -146,8 +146,8 @@ impl Data {
     ///
     /// The peek buffer contains at most 512 bytes of the body of the request.
     /// The actual size of the returned buffer varies by web request. The
-    /// [`peek_complete`](#method.peek_complete) can be used to determine if
-    /// this buffer contains _all_ of the data in the body of the request.
+    /// [`peek_complete`](#method.peek_complete) method can be used to determine
+    /// if this buffer contains _all_ of the data in the body of the request.
     ///
     /// # Example
     ///

--- a/core/lib/src/data/from_data.rs
+++ b/core/lib/src/data/from_data.rs
@@ -48,8 +48,8 @@ impl<'a, S, E> IntoOutcome<S, (Status, E), Data> for Result<S, E> {
 ///
 /// In the example below, `var` is used as the argument name for the data guard
 /// type `T`. When the `submit` route matches, Rocket will call the `FromData`
-/// implemention for the type `T`. The handler will only be called if the guard
-/// returns succesfully.
+/// implementation for the type `T`. The handler will only be called if the guard
+/// returns successfully.
 ///
 /// ```rust,ignore
 /// #[post("/submit", data = "<var>")]
@@ -95,7 +95,7 @@ impl<'a, S, E> IntoOutcome<S, (Status, E), Data> for Result<S, E> {
 ///   * **Option&lt;T>** _where_ **T: FromData**
 ///
 ///     The type `T` is derived from the incoming data using `T`'s `FromData`
-///     implementation. If the derivation is a `Success`, the dervived value is
+///     implementation. If the derivation is a `Success`, the derived value is
 ///     returned in `Some`. Otherwise, a `None` is returned.
 ///
 ///     _This implementation always returns successfully._

--- a/core/lib/src/error.rs
+++ b/core/lib/src/error.rs
@@ -23,7 +23,7 @@ pub enum Error {
     NoKey,
 }
 
-/// The kind of launch error that occured.
+/// The kind of launch error that occurred.
 ///
 /// In almost every instance, a launch error occurs because of an I/O error;
 /// this is represented by the `Io` variant. A launch error may also occur
@@ -183,10 +183,10 @@ impl ::std::error::Error for LaunchError {
         self.mark_handled();
         match *self.kind() {
             LaunchErrorKind::Bind(_) => "failed to bind to given address/port",
-            LaunchErrorKind::Io(_) => "an I/O error occured during launch",
+            LaunchErrorKind::Io(_) => "an I/O error occurred during launch",
             LaunchErrorKind::Collision(_) => "route collisions were detected",
             LaunchErrorKind::FailedFairings(_) => "a launch fairing reported an error",
-            LaunchErrorKind::Unknown(_) => "an unknown error occured during launch"
+            LaunchErrorKind::Unknown(_) => "an unknown error occurred during launch"
         }
     }
 }

--- a/core/lib/src/fairing/fairings.rs
+++ b/core/lib/src/fairing/fairings.rs
@@ -45,7 +45,7 @@ impl Fairings {
         // We maintain these invariants by not exposing the references and never
         // deallocating `Box<Fairing>` structures. As such, the references will
         // always be valid. Note: `ptr` doesn't point into the `Vec`, so
-        // reallocations there are irrelvant. Instead, it points into the heap.
+        // reallocations there are irrelevant. Instead, it points into the heap.
         //
         // Also, we don't save attach fairings since we don't need them anymore.
         let kind = fairing.info().kind;

--- a/core/lib/src/fairing/mod.rs
+++ b/core/lib/src/fairing/mod.rs
@@ -30,7 +30,7 @@
 //!     .attach(res_fairing);
 //! ```
 //!
-//! Once a fairing is attached, Rocket will execute it at the appropiate time,
+//! Once a fairing is attached, Rocket will execute it at the appropriate time,
 //! which varies depending on the fairing implementation. See the [`Fairing`]
 //! trait documentation for more information on the dispatching of fairing
 //! methods.
@@ -150,7 +150,7 @@ pub use self::info_kind::{Info, Kind};
 ///     A response callback is called when a response is ready to be sent to the
 ///     client. At this point, Rocket has completed all routing, including to
 ///     error catchers, and has generated the would-be final response. A
-///     response callback can modify the response at will. For exammple, a
+///     response callback can modify the response at will. For example, a
 ///     response callback can provide a default response when the user fails to
 ///     handle the request by checking for 404 responses. Note that a given
 ///     `Request` may have changed between `on_request` and `on_response`
@@ -314,7 +314,7 @@ pub trait Fairing: Send + Sync + 'static {
     ///
     /// This method is called just prior to launching the application if
     /// `Kind::Launch` is in the `kind` field of the `Info` structure for this
-    /// fairing. The `&Rocket` parameter curresponds to the application that
+    /// fairing. The `&Rocket` parameter corresponds to the application that
     /// will be launched.
     ///
     /// ## Default Implementation

--- a/core/lib/src/handler.rs
+++ b/core/lib/src/handler.rs
@@ -19,9 +19,9 @@ pub type ErrorHandler = for<'r> fn(Error, &'r Request) -> response::Result<'r>;
 impl<'r> Outcome<'r> {
     /// Return the `Outcome` of response to `req` from `responder`.
     ///
-    /// If the responder responds with `Ok`, an outcome of `Success` is returns
-    /// with the response. If the outcomes reeturns `Err`, an outcome of
-    /// `Failure` is returned with the status code.
+    /// If the responder returns `Ok`, an outcome of `Success` is
+    /// returned with the response. If the responder returns `Err`, an
+    /// outcome of `Failure` is returned with the status code.
     ///
     /// # Example
     ///

--- a/core/lib/src/lib.rs
+++ b/core/lib/src/lib.rs
@@ -32,7 +32,7 @@
 //!
 //!   1. [Core](/rocket) - The core library. Needed by every Rocket application.
 //!   2. [Codegen](/rocket_codegen) - Core code generation plugin. Should always
-//!      be used alongsize `rocket`, though it's not necessary.
+//!      be used alongside `rocket`, though it's not necessary.
 //!   3. [Contrib](/rocket_contrib) - Provides useful functionality for many
 //!      Rocket applications. Completely optional.
 //!
@@ -94,7 +94,7 @@
 //! ## Testing
 //!
 //! The [local](/rocket/local) module contains structures that facilitate unit
-//! and itegration testing of a Rocket application. The [top-level `local`
+//! and integration testing of a Rocket application. The [top-level `local`
 //! module documentation](/rocket/local) and the [testing chapter of the
 //! guide](https://rocket.rs/guide/testing/#testing) include detailed examples.
 

--- a/core/lib/src/local/client.rs
+++ b/core/lib/src/local/client.rs
@@ -11,21 +11,21 @@ use std::cell::RefCell;
 /// A `Client` is constructed via the [`new`] or [`untracked`] methods from an
 /// already constructed `Rocket` instance. Once a value of `Client` has been
 /// constructed, the [`LocalRequest`] constructor methods ([`get`], [`put`],
-/// [`post`], and so on) can be used to create a `LocalRequest` for dispaching.
+/// [`post`], and so on) can be used to create a `LocalRequest` for dispatching.
 ///
 /// See the [top-level documentation](/rocket/local/index.html) for more usage
 /// information.
 ///
 /// ## Cookie Tracking
 ///
-/// A `Client` constructed using [`new`] propogates cookie changes made by
+/// A `Client` constructed using [`new`] propagates cookie changes made by
 /// responses to previously dispatched requests. In other words, if a previously
 /// dispatched request resulted in a response that adds a cookie, any future
 /// requests will contain that cookie. Similarly, cookies removed by a response
-/// won't be propogated further.
+/// won't be propagated further.
 ///
 /// This is typically the desired mode of operation for a `Client` as it removes
-/// the burder of manually tracking cookies. Under some circumstances, however,
+/// the burden of manually tracking cookies. Under some circumstances, however,
 /// disabling this tracking may be desired. In these cases, use the
 /// [`untracked`](Client::untracked()) constructor to create a `Client` that
 /// _will not_ track cookies.
@@ -33,7 +33,7 @@ use std::cell::RefCell;
 /// ## Example
 ///
 /// The following snippet creates a `Client` from a `Rocket` instance and
-/// dispathes a local request to `POST /` with a body of `Hello, world!`.
+/// dispatches a local request to `POST /` with a body of `Hello, world!`.
 ///
 /// ```rust
 /// use rocket::local::Client;
@@ -78,14 +78,14 @@ impl Client {
     ///
     /// # Cookie Tracking
     ///
-    /// By default, a `Client` propogates cookie changes made by responses to
+    /// By default, a `Client` propagates cookie changes made by responses to
     /// previously dispatched requests. In other words, if a previously
     /// dispatched request resulted in a response that adds a cookie, any future
     /// requests will contain the new cookies. Similarly, cookies removed by a
-    /// response won't be propogated further.
+    /// response won't be propagated further.
     ///
     /// This is typically the desired mode of operation for a `Client` as it
-    /// removes the burder of manually tracking cookies. Under some
+    /// removes the burden of manually tracking cookies. Under some
     /// circumstances, however, disabling this tracking may be desired. The
     /// [`untracked()`](Client::untracked()) method creates a `Client` that
     /// _will not_ track cookies.
@@ -113,7 +113,7 @@ impl Client {
     /// # Cookie Tracking
     ///
     /// Unlike the [`new()`](Client::new()) constructor, a `Client` returned
-    /// from this method _does not_ automatically propogate cookie changes.
+    /// from this method _does not_ automatically propagate cookie changes.
     ///
     /// # Errors
     ///

--- a/core/lib/src/local/request.rs
+++ b/core/lib/src/local/request.rs
@@ -81,11 +81,11 @@ pub struct LocalRequest<'c> {
     // Because both a `LocalRequest` and a `LocalResponse` can hold an `Rc` to
     // the same `Request`, _and_ the `LocalRequest` can mutate the request, we
     // must ensure that 1) neither `LocalRequest` not `LocalResponse` are `Sync`
-    // or `Send` and 2) mutatations carried out in `LocalRequest` are _stable_:
+    // or `Send` and 2) mutations carried out in `LocalRequest` are _stable_:
     // they never _remove_ data, and any reallocations (say, for vectors or
     // hashmaps) result in object pointers remaining the same. This means that
     // even if the `Request` is mutated by a `LocalRequest`, those mutations are
-    // not observeable by `LocalResponse`.
+    // not observable by `LocalResponse`.
     //
     // The first is ensured by the embedding of the `Rc` type which is neither
     // `Send` nor `Sync`. The second is more difficult to argue. First, observe
@@ -130,7 +130,7 @@ impl<'c> LocalRequest<'c> {
         unsafe { &mut *self.ptr }
     }
 
-    // This method should _never_ be publically exposed!
+    // This method should _never_ be publicly exposed!
     #[inline(always)]
     fn long_lived_request<'a>(&mut self) -> &'a mut Request<'c> {
         // See the comments in the structure for the argument of correctness.

--- a/core/lib/src/request/form/form.rs
+++ b/core/lib/src/request/form/form.rs
@@ -131,7 +131,7 @@ use request::form::{FromForm, FormItems};
 /// Whether you should use a `&RawStr` or `String` in your `FromForm` type
 /// depends on your use case. The primary question to answer is: _Can the input
 /// contain characters that must be URL encoded?_ Note that this includes
-/// commmon characters such as spaces. If so, then you must use `String`, whose
+/// common characters such as spaces. If so, then you must use `String`, whose
 /// `FromFormValue` implementation automatically URL decodes strings. Because
 /// the `&RawStr` references will refer directly to the underlying form data,
 /// they will be raw and URL encoded.
@@ -236,7 +236,7 @@ impl<'f, T: FromForm<'f> + 'f> Form<'f, T> {
     // that they don't outlive this structure. So we would really like
     // something like `self` and then to transmute to that. But this doesn't
     // exist. So we do the next best: we use the first lifetime supplied by the
-    // caller via `get()` and contrain everything to that lifetime. This is, in
+    // caller via `get()` and constrain everything to that lifetime. This is, in
     // reality a little coarser than necessary, but the user can simply move the
     // call to right after the creation of a Form object to get the same effect.
     pub(crate) fn new(string: String, strict: bool) -> FormResult<Self, T::Error> {

--- a/core/lib/src/request/form/from_form.rs
+++ b/core/lib/src/request/form/from_form.rs
@@ -9,7 +9,7 @@ use request::FormItems;
 /// [rocket_codegen](/rocket_codegen) plugin. When deriving `FromForm`, every
 /// field in the structure must implement
 /// [FromFormValue](trait.FromFormValue.html). Rocket validates each field in
-/// the structure by calling its `FromFormValue` implemention. You may wish to
+/// the structure by calling its `FromFormValue` implementation. You may wish to
 /// implement `FromFormValue` for your own types for custom, automatic
 /// validation.
 ///
@@ -50,10 +50,10 @@ use request::FormItems;
 ///
 /// # Implementing
 ///
-/// Implementing `FromForm` should be a rare occurence. Prefer instead to use
+/// Implementing `FromForm` should be a rare occurrence. Prefer instead to use
 /// Rocket's built-in derivation.
 ///
-/// When implementing `FromForm`, use use the [FormItems](struct.FormItems.html)
+/// When implementing `FromForm`, use the [FormItems](struct.FormItems.html)
 /// iterator to iterate through the raw form key/value pairs. Be aware that form
 /// fields that are typically hidden from your application, such as `_method`,
 /// will be present while iterating. Ensure that you adhere to the properties of

--- a/core/lib/src/request/from_request.rs
+++ b/core/lib/src/request/from_request.rs
@@ -144,7 +144,7 @@ impl<S, E> IntoOutcome<S, (Status, E), ()> for Result<S, E> {
 ///
 ///     The type `T` is derived from the incoming request using `T`'s
 ///     `FromRequest` implementation. If the derivation is a `Success`, the
-///     dervived value is returned in `Some`. Otherwise, a `None` is returned.
+///     derived value is returned in `Some`. Otherwise, a `None` is returned.
 ///
 ///     _This implementation always returns successfully._
 ///
@@ -164,7 +164,7 @@ impl<S, E> IntoOutcome<S, (Status, E), ()> for Result<S, E> {
 /// unless there is an API key in the request and the key is valid. The
 /// following example implements this using an `ApiKey` type and a `FromRequest`
 /// implementation for that type. The `ApiKey` type is then used in the
-/// `senstive` handler.
+/// `sensitive` handler.
 ///
 /// ```rust
 /// # #![feature(plugin, decl_macro)]

--- a/core/lib/src/request/request.rs
+++ b/core/lib/src/request/request.rs
@@ -528,7 +528,7 @@ impl<'r> Request<'r> {
         self.state.route.get()
     }
 
-    /// Invokes the request guard implemention for `T`, returning its outcome.
+    /// Invokes the request guard implementation for `T`, returning its outcome.
     ///
     /// # Example
     ///

--- a/core/lib/src/request/state.rs
+++ b/core/lib/src/request/state.rs
@@ -85,7 +85,7 @@ use http::Status;
 pub struct State<'r, T: Send + Sync + 'static>(&'r T);
 
 impl<'r, T: Send + Sync + 'static> State<'r, T> {
-    /// Retrieve a borrow to the underyling value with a lifetime of `'r`.
+    /// Retrieve a borrow to the underlying value with a lifetime of `'r`.
     ///
     /// Using this method is typically unnecessary as `State` implements `Deref`
     /// with a `Target` of `T`. This means Rocket will automatically coerce a

--- a/core/lib/src/response/content.rs
+++ b/core/lib/src/response/content.rs
@@ -28,7 +28,7 @@ use http::{Status, ContentType};
 
 /// Sets the Content-Type of a `Responder` to a chosen value.
 ///
-/// Delagates the remainder of the response to the wrapped responder.
+/// Delegates the remainder of the response to the wrapped responder.
 ///
 /// # Example
 ///
@@ -65,7 +65,7 @@ macro_rules! ctrs {
             #[doc=$ct_str]
             #[doc="</i>."]
             ///
-            /// Delagates the remainder of the response to the wrapped responder.
+            /// Delegates the remainder of the response to the wrapped responder.
             #[derive(Debug, Clone, PartialEq)]
             pub struct $name<R>(pub R);
 

--- a/core/lib/src/response/flash.rs
+++ b/core/lib/src/response/flash.rs
@@ -12,7 +12,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 const FLASH_COOKIE_NAME: &'static str = "_flash";
 
 /// Sets a "flash" cookie that will be removed when it is accessed. The
-/// anologous request type is
+/// analogous request type is
 /// [FlashMessage](/rocket/request/type.FlashMessage.html).
 ///
 /// This type makes it easy to send messages across requests. It is typically
@@ -38,7 +38,7 @@ const FLASH_COOKIE_NAME: &'static str = "_flash";
 ///
 /// The `Responder` implementation for `Flash` sets the message cookie and then
 /// uses the passed in responder `res` to complete the response. In other words,
-/// it simply sets a cookie and delagates the rest of the response handling to
+/// it simply sets a cookie and delegates the rest of the response handling to
 /// the wrapped responder.
 ///
 /// # Example
@@ -99,7 +99,7 @@ pub struct Flash<R> {
 ///
 /// A `FlashMessage` holds the parsed contents of the flash cookie. As long as
 /// there is a flash cookie present (set by the `Flash` `Responder`), a
-/// `FlashMessage` reuqest guard will succeed.
+/// `FlashMessage` request guard will succeed.
 ///
 /// The flash cookie is cleared if either the [`name()`] or [`msg()`] method is
 /// called. If neither method is called, the flash cookie is not cleared.
@@ -196,7 +196,7 @@ impl<'r, R: Responder<'r>> Flash<R> {
 }
 
 /// Sets the message cookie and then uses the wrapped responder to complete the
-/// response. In other words, simply sets a cookie and delagates the rest of the
+/// response. In other words, simply sets a cookie and delegates the rest of the
 /// response handling to the wrapped responder. As a result, the `Outcome` of
 /// the response is the `Outcome` of the wrapped `Responder`.
 impl<'r, R: Responder<'r>> Responder<'r> for Flash<R> {
@@ -250,7 +250,7 @@ impl<'a, 'r> FromRequest<'a, 'r> for Flash<&'a Request<'r>> {
     type Error = ();
 
     fn from_request(req: &'a Request<'r>) -> request::Outcome<Self, Self::Error> {
-        trace_!("Flash: attemping to retrieve message.");
+        trace_!("Flash: attempting to retrieve message.");
         req.cookies().get(FLASH_COOKIE_NAME).ok_or(()).and_then(|cookie| {
             trace_!("Flash: retrieving message: {:?}", cookie);
 

--- a/core/lib/src/response/responder.rs
+++ b/core/lib/src/response/responder.rs
@@ -109,9 +109,9 @@ use request::Request;
 ///
 /// A `Responder` has access to the request it is responding to. Even so, you
 /// should avoid using the `Request` value as much as possible. This is because
-/// using the `Request` object makes your responder _inpure_, and so the use of
+/// using the `Request` object makes your responder _impure_, and so the use of
 /// the type as a `Responder` has less intrinsic meaning associated with it. If
-/// the `Responder` were pure, however, it always respond in the same manner,
+/// the `Responder` were pure, however, it would always respond in the same manner,
 /// regardless of the incoming request. Thus, knowing the type is sufficient to
 /// fully determine its functionality.
 ///

--- a/core/lib/src/response/response.rs
+++ b/core/lib/src/response/response.rs
@@ -60,7 +60,7 @@ impl<T> Body<T> {
 }
 
 impl<T: io::Read> Body<T> {
-    /// Attepts to read `self` into a `Vec` and returns it. If reading fails,
+    /// Attempts to read `self` into a `Vec` and returns it. If reading fails,
     /// returns `None`.
     pub fn into_bytes(self) -> Option<Vec<u8>> {
         let mut vec = Vec::new();
@@ -73,7 +73,7 @@ impl<T: io::Read> Body<T> {
         Some(vec)
     }
 
-    /// Attepts to read `self` into a `String` and returns it. If reading or
+    /// Attempts to read `self` into a `String` and returns it. If reading or
     /// conversion fails, returns `None`.
     pub fn into_string(self) -> Option<String> {
         self.into_bytes()
@@ -99,7 +99,7 @@ impl<T> fmt::Debug for Body<T> {
 /// Type for easily building `Response`s.
 ///
 /// Building a [Response](struct.Response.html) can be a low-level ordeal; this
-/// structure presents a higher-level API that simplified building `Response`s.
+/// structure presents a higher-level API that simplifies building `Response`s.
 ///
 /// # Usage
 ///
@@ -118,7 +118,7 @@ impl<T> fmt::Debug for Body<T> {
 /// the default behavior (using `header(..)`) is to _replace_. When a header is
 /// _replaced_, any existing values for headers with the same name are removed,
 /// and the new value is set. If no header exists, the header is simply added.
-/// On the other hand, when a header is `adjoined`, all existing values will
+/// On the other hand, when a header is _adjoined_, all existing values will
 /// remain, and the `value` of the adjoined header will be added to the set of
 /// existing values, if any. Adjoining maintains order: headers adjoined first
 /// will appear first in the `Response`.
@@ -250,7 +250,7 @@ impl<'r> ResponseBuilder<'r> {
 
     /// Adds `header` to the `Response` by adjoining the header with any
     /// existing headers with the same name that already exist in the
-    /// `Response`. This allow for multiple headers with the same name and
+    /// `Response`. This allows for multiple headers with the same name and
     /// potentially different values to be present in the `Response`.
     ///
     /// The type of `header` can be any type that implements `Into<Header>`.
@@ -279,7 +279,7 @@ impl<'r> ResponseBuilder<'r> {
         self
     }
 
-    /// Adds custom a header to the `Response` with the given name and value,
+    /// Adds a custom header to the `Response` with the given name and value,
     /// replacing any header with the same name that already exists in the
     /// response. If multiple headers with the same name exist, they are all
     /// removed, and only the new header and value will remain.
@@ -307,7 +307,7 @@ impl<'r> ResponseBuilder<'r> {
 
     /// Adds custom header to the `Response` with the given name and value,
     /// adjoining the header with any existing headers with the same name that
-    /// already exist in the `Response`. This allow for multiple headers with
+    /// already exist in the `Response`. This allows for multiple headers with
     /// the same name and potentially different values to be present in the
     /// `Response`.
     ///

--- a/core/lib/src/response/status.rs
+++ b/core/lib/src/response/status.rs
@@ -219,7 +219,7 @@ impl<'r, R: Responder<'r>> Responder<'r> for NotFound<R> {
     }
 }
 
-/// Creates a response with the given status code and underyling responder.
+/// Creates a response with the given status code and underlying responder.
 ///
 /// # Example
 ///

--- a/core/lib/src/rocket.rs
+++ b/core/lib/src/rocket.rs
@@ -300,7 +300,7 @@ impl Rocket {
     // Finds the error catcher for the status `status` and executes it for the
     // given request `req`. If a user has registers a catcher for `status`, the
     // catcher is called. If the catcher fails to return a good response, the
-    // 500 catcher is executed. if there is no registered catcher for `status`,
+    // 500 catcher is executed. If there is no registered catcher for `status`,
     // the default catcher is used.
     fn handle_error<'r>(&self, status: Status, req: &'r Request) -> Response<'r> {
         warn_!("Responding with {} catcher.", Paint::red(&status));

--- a/core/lib/src/router/route.rs
+++ b/core/lib/src/router/route.rs
@@ -45,9 +45,9 @@ impl Route {
     ///
     /// # Ranking
     ///
-    /// The route rank's is set so that routes with static paths are ranked
-    /// higher than route's with dynamic paths, and routes with query strings
-    /// are ranked higher than ranks without query strings. This default ranking
+    /// The route's rank is set so that routes with static paths are ranked
+    /// higher than routes with dynamic paths, and routes with query strings
+    /// are ranked higher than routes without query strings. This default ranking
     /// is summarized by the table below:
     ///
     /// | static path | query | rank |


### PR DESCRIPTION
Covers core and contrib only -- examples, tests, and codegen not included in this pass. Most changes should be non-controversial. A few more opinionated changes are in there somewhere, though.

Regarding functions that "set" or "add" a value, some of them are written in the style of "[this function] Sets the ..." or "[this function] Adds the..." and others in the imperative: "Set the..." or "Add the...". I noticed and changed a few of these to stay consistent with nearby functions, but it would be nice to have a consistent style at some point.