### PR TITLE
Fix compatibility warnings and errors in examples.

### DIFF
--- a/examples/managed_queue/Cargo.toml
+++ b/examples/managed_queue/Cargo.toml
@@ -5,6 +5,6 @@ workspace = "../.."
 publish = false
 
 [dependencies]
-crossbeam = "*"
+crossbeam = "0.4"
 rocket = { path = "../../core/lib" }
 rocket_codegen = { path = "../../core/codegen" }

--- a/examples/managed_queue/src/main.rs
+++ b/examples/managed_queue/src/main.rs
@@ -6,7 +6,7 @@ extern crate rocket;
 
 #[cfg(test)] mod tests;
 
-use crossbeam::sync::MsQueue;
+use crossbeam::queue::MsQueue;
 use rocket::State;
 
 #[derive(FromForm, Debug)]

--- a/examples/todo/src/tests.rs
+++ b/examples/todo/src/tests.rs
@@ -3,7 +3,7 @@ extern crate rand;
 
 use super::task::Task;
 use self::parking_lot::Mutex;
-use self::rand::{Rng, thread_rng};
+use self::rand::{Rng, thread_rng, distributions::Alphanumeric};
 
 use rocket::local::Client;
 use rocket::http::{Status, ContentType};
@@ -90,7 +90,7 @@ fn test_many_insertions() {
 
         for i in 0..ITER {
             // Issue a request to insert a new task with a random description.
-            let desc: String = rng.gen_ascii_chars().take(12).collect();
+            let desc: String = rng.sample_iter(&Alphanumeric).take(12).collect();
             client.post("/todo")
                 .header(ContentType::Form)
                 .body(format!("description={}", desc))


### PR DESCRIPTION
- crossbeam: specify version and update for compatibility with 0.4 release
- rand: use `sample_iter` and `distributions::Alphanumeric` instead of `gen_ascii_chars`

The crossbeam changes would need to be applied to v0.3 as well. I believe rand was only updated to 0.5 in the master branch.