### PR TITLE
Allows read for certificates and their keys

### DIFF
--- a/core/http/Cargo.toml
+++ b/core/http/Cargo.toml
@@ -32,6 +32,8 @@ rev = "f191ca50"
 features = ["percent-encode", "secure"]
 
 [dependencies.hyper-sync-rustls]
+git = "https://github.com/mettke/hyper-sync-rustls"
+branch = "feature/tls_via_read"
 version = "=0.3.0-rc.3"
 features = ["server"]
 optional = true


### PR DESCRIPTION
This PR addresses #704 and requires https://github.com/SergioBenitez/hyper-sync-rustls/pull/5

With the PR it is possible to use custom Files, Arrays, String and pretty much everything else that implements `Read` or can be used in conjunction with `Cursor` for SSL certificates.

### Example for custom file

```rust
let mut config = Config::active().unwrap();
let certfile = fs::File::open("certs/server.crt").unwrap();
let keyfile = fs::File::open("certs/server.key").unwrap();
config.set_tls_from_read(certfile, keyfile);
```

### Example for byte vector

```rust
let mut config = Config::active().unwrap();
let certfile_bytes = Cursor::new(include_bytes!("certs/server.crt").to_vec());
let keyfile_bytes = Cursor::new(include_bytes!("certs/server.key").to_vec());
config.set_tls_from_read(certfile, keyfile);
```

### Example for string

```rust
let mut config = Config::active().unwrap();
let certfile = fs::File::open("certs/server.crt").unwrap();
let keyfile = fs::File::open("certs/server.key").unwrap();
let mut certfile_str = String::new();
let mut keyfile_str = String::new();
certfile.read_to_string(&mut certfile_str);
keyfile.read_to_string(&mut keyfile_str);
config.set_tls_from_read(Cursor::new(certfile_str), Cursor::new(keyfile_str));
```
