### PR TITLE
Embed the diesel database migrations in the `todo` example.

### DIFF
--- a/examples/todo/Cargo.toml
+++ b/examples/todo/Cargo.toml
@@ -11,6 +11,8 @@ serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
 diesel = { version = "1.3", features = ["sqlite", "r2d2"] }
+diesel_migrations = { version = "1.3" }
+log = "0.4"
 
 [dev-dependencies]
 parking_lot = { version = "0.6", features = ["nightly"] }

--- a/examples/todo/README.md
+++ b/examples/todo/README.md
@@ -6,23 +6,3 @@ a result, you'll need to have `sqlite3` and its headers installed:
   * **OS X:** `brew install sqlite`
   * **Debian/Ubuntu:** `apt-get install libsqlite3-dev`
   * **Arch:** `pacman -S sqlite`
-
-## Running
-
-**Before running, building, or testing this example, you'll need to ensure that
-a SQLite database file with the proper schema is present.**
-
-On a Unix machine or with bash installed, you can simply run the `boostrap.sh`
-script to create the database. The script installs the `diesel_cli` tools if
-they're not already installed and runs the migrations.
-
-You can also install the Diesel CLI and run the migrations manually with the
-following commands:
-
-```sh
-# install Diesel CLI tools
-cargo install diesel_cli --version '<= 1.2' --no-default-features --features=sqlite
-
-# create db/db.sqlite
-diesel migration run --database-url="db/db.sqlite"
-```

--- a/examples/todo/bootstrap.sh
+++ b/examples/todo/bootstrap.sh
@@ -3,15 +3,4 @@
 SCRIPT_PATH=$(cd "$(dirname "$0")" ; pwd -P)
 DATABASE_URL="${SCRIPT_PATH}/db/db.sqlite"
 
-pushd "${SCRIPT_PATH}" > /dev/null
-  # clear an existing database
-  rm -f "${DATABASE_URL}"
-
-  # install the diesel CLI tools if they're not installed
-  if ! command -v diesel >/dev/null 2>&1; then
-    cargo install diesel_cli --version '<= 1.2' --no-default-features --features=sqlite > /dev/null
-  fi
-
-  # create db/db.sqlite
-  diesel migration --database-url="${DATABASE_URL}" run > /dev/null
-popd > /dev/null
+rm -f "${DATABASE_URL}"

--- a/examples/todo/src/main.rs
+++ b/examples/todo/src/main.rs
@@ -20,6 +20,9 @@ use diesel::SqliteConnection;
 
 use task::{Task, Todo};
 
+// This macro from `diesel_migrations` defines an `embedded_migrations` module
+// containing a function named `run`. This allows the example to be run and
+// tested without any outside setup of the database.
 embed_migrations!();
 
 #[database("sqlite_database")]

--- a/examples/todo/src/main.rs
+++ b/examples/todo/src/main.rs
@@ -3,6 +3,8 @@
 
 #[macro_use] extern crate rocket;
 #[macro_use] extern crate diesel;
+#[macro_use] extern crate diesel_migrations;
+#[macro_use] extern crate log;
 #[macro_use] extern crate serde_derive;
 extern crate rocket_contrib;
 
@@ -10,12 +12,15 @@ mod task;
 #[cfg(test)] mod tests;
 
 use rocket::Rocket;
+use rocket::fairing::AdHoc;
 use rocket::request::{Form, FlashMessage};
 use rocket::response::{Flash, Redirect};
 use rocket_contrib::{Template, databases::database, static_files::StaticFiles};
 use diesel::SqliteConnection;
 
 use task::{Task, Todo};
+
+embed_migrations!();
 
 #[database("sqlite_database")]
 pub struct DbConn(SqliteConnection);
@@ -74,6 +79,16 @@ fn index(msg: Option<FlashMessage>, conn: DbConn) -> Template {
 fn rocket() -> (Rocket, Option<DbConn>) {
     let rocket = rocket::ignite()
         .attach(DbConn::fairing())
+        .attach(AdHoc::on_attach("Database Migrations", |rocket| {
+            let conn = DbConn::get_one(&rocket).expect("database connection");
+            match embedded_migrations::run(&*conn) {
+                Ok(()) => Ok(rocket),
+                Err(e) => {
+                    error!("Failed to run database migrations: {:?}", e);
+                    Err(rocket)
+                },
+            }
+        }))
         .mount("/", StaticFiles::from("static/"))
         .mount("/", routes![index])
         .mount("/todo", routes![new, toggle, delete])


### PR DESCRIPTION
With this change, `diesel_cli` will no longer be needed in order to prepare or run the example or tests, making the example easier to work with (and possibly reducing the time taken for CI builds?). It will still be necessary to install `diesel_cli` manually in order to add migrations or regenerate the schema.