### PR TITLE
Remove uses of the `const_fn` feature.

### DIFF
--- a/core/http/src/lib.rs
+++ b/core/http/src/lib.rs
@@ -1,6 +1,5 @@
 #![feature(specialization)]
 #![feature(proc_macro_non_items)]
-#![feature(const_fn)]
 #![feature(try_from)]
 #![feature(crate_visibility_modifier)]
 #![recursion_limit="256"]

--- a/core/http/src/status.rs
+++ b/core/http/src/status.rs
@@ -101,7 +101,7 @@ macro_rules! ctrs {
             #[doc=$reason]
             #[doc="</i>."]
             #[allow(non_upper_case_globals)]
-            pub const $name: Status = Status::new($code, $reason);
+            pub const $name: Status = Status { code: $code, reason: $reason };
          )+
 
         /// Returns a Status given a standard status code `code`. If `code` is
@@ -155,7 +155,7 @@ impl Status {
     /// assert_eq!(custom.to_string(), "299 Somewhat Successful".to_string());
     /// ```
     #[inline(always)]
-    pub const fn new(code: u16, reason: &'static str) -> Status {
+    pub fn new(code: u16, reason: &'static str) -> Status {
         Status { code, reason }
     }
 

--- a/core/lib/src/lib.rs
+++ b/core/lib/src/lib.rs
@@ -1,5 +1,4 @@
 #![feature(specialization)]
-#![feature(const_fn)]
 #![feature(plugin, decl_macro)]
 #![feature(try_trait)]
 #![feature(fnbox)]

--- a/examples/todo/src/main.rs
+++ b/examples/todo/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, custom_derive, const_fn)]
+#![feature(plugin, decl_macro, custom_derive)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;


### PR DESCRIPTION
This feature is currently only used in the `http` crate to make `Status::new` a const fn. A `Status` instance can already be constructed in a const using `Status { code, reason }` syntax, so this doesn't remove any capabilities but is a breaking change for anyone using `Status::new` in a const.