### PR TITLE
Added JsonResult for lenient routing

### DIFF
--- a/contrib/lib/src/lib.rs
+++ b/contrib/lib/src/lib.rs
@@ -65,7 +65,7 @@ pub extern crate tera;
 pub mod json;
 
 #[cfg(feature = "json")]
-pub use json::{Json, SerdeError, JsonValue};
+pub use json::{Json, JsonResult, SerdeError, JsonValue};
 
 #[cfg(feature = "msgpack")]
 #[doc(hidden)]


### PR DESCRIPTION
When receiving a webhook or other types of API requests, often times the contract is unclear, or the deviation from the contract can be hard to diagnose without the raw JSON body which was actually sent.

I considered various ways of logging the json body in this situation, but this one seemed to be the simplest, most intuitive, and involved no copying of the underlying json body string.