### PR TITLE
Update 'uuid' to 0.7.0

### DIFF
--- a/contrib/lib/Cargo.toml
+++ b/contrib/lib/Cargo.toml
@@ -39,7 +39,7 @@ rocket = { version = "0.4.0-dev", path = "../../core/lib/" }
 log = "0.4"
 
 # UUID dependencies.
-uuid = { version = ">= 0.5, <= 0.6", optional = true }
+uuid = { version = "0.7", optional = true }
 
 # Serialization and templating dependencies.
 serde = { version = "1.0", optional = true }

--- a/contrib/lib/src/uuid.rs
+++ b/contrib/lib/src/uuid.rs
@@ -7,7 +7,7 @@ use std::ops::Deref;
 use rocket::request::{FromParam, FromFormValue};
 use rocket::http::RawStr;
 
-pub use self::uuid_ext::ParseError as UuidParseError;
+pub use self::uuid_ext::parser::ParseError as UuidParseError;
 
 /// Implements `FromParam` and `FormFormValue` for accepting UUID values from
 /// the [uuid](https://github.com/rust-lang-nursery/uuid) crate.
@@ -125,7 +125,7 @@ impl PartialEq<uuid_ext::Uuid> for Uuid {
 #[cfg(test)]
 mod test {
     use super::uuid_ext;
-    use super::{Uuid, UuidParseError};
+    use super::Uuid;
     use super::FromParam;
     use super::FromStr;
 
@@ -161,9 +161,9 @@ mod test {
     }
 
     #[test]
+    #[should_panic(expected = "InvalidLength")]
     fn test_from_param_invalid() {
         let uuid_str = "c1aa1e3b-9614-4895-9ebd-705255fa5bc2p";
-        let uuid_result = Uuid::from_param(uuid_str.into());
-        assert_eq!(uuid_result, Err(UuidParseError::InvalidLength(37)));
+        Uuid::from_param(uuid_str.into()).unwrap();
     }
 }

--- a/examples/uuid/Cargo.toml
+++ b/examples/uuid/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 rocket = { path = "../../core/lib" }
 rocket_codegen = { path = "../../core/codegen" }
-uuid = ">= 0.5, <= 0.6"
+uuid = "0.7"
 lazy_static = "1.0"
 
 [dependencies.rocket_contrib]


### PR DESCRIPTION
There is a new release for the uuid crate. This pull request Bumps to the latest release.