### PR TITLE
Construct `rocket_param_` idents from the function arguments

### DIFF
--- a/codegen/src/decorators/route.rs
+++ b/codegen/src/decorators/route.rs
@@ -142,16 +142,18 @@ impl RouteGenerateExt for RouteParams {
         let mut declared_set = HashSet::new();
         for (i, param) in self.path_params(ecx).enumerate() {
             declared_set.insert(param.ident().name);
-            let ty = match self.annotated_fn.find_input(&param.ident().name) {
-                Some(arg) => strip_ty_lifetimes(arg.ty.clone()),
+            let arg = match self.annotated_fn.find_input(&param.ident().name) {
+                Some(arg) => arg,
                 None => {
                     self.missing_declared_err(ecx, param.inner());
                     continue;
                 }
             };
 
+            let ty = strip_ty_lifetimes(arg.ty.clone());
+            let ident = arg.ident().expect("function argument ident").prepend(PARAM_PREFIX);
+
             // Note: the `None` case shouldn't happen if a route is matched.
-            let ident = param.ident().prepend(PARAM_PREFIX);
             let expr = match param {
                 Param::Single(_) => quote_expr!(ecx, match __req.get_param_str($i) {
                     Some(s) => <$ty as ::rocket::request::FromParam>::from_param(s),

--- a/codegen/tests/run-pass/route_ident_hygiene.rs
+++ b/codegen/tests/run-pass/route_ident_hygiene.rs
@@ -1,0 +1,22 @@
+#![feature(plugin)]
+#![plugin(rocket_codegen)]
+
+extern crate rocket;
+
+#[get("/easy/<id>")]
+fn easy(id: i32) -> String {
+    format!("id: {}", id)
+}
+
+macro_rules! make_handler {
+    () => {
+        #[get("/hard/<id>")]
+        fn hard(id: i32) -> String {
+            format!("id: {}", id)
+        }
+    }
+}
+
+make_handler!();
+
+fn main() { }


### PR DESCRIPTION
...instead of the route string. Should fix #635.

The included test fails in current v0.3 but passes with this change. The test might also be useful in the master branch, but the bug may no longer be present once `#[route]` is re-implemented for #693.