### PR TITLE
Fix the example code in README.md by applying the following compiler …

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Rocket is web framework for Rust (nightly) with a focus on ease-of-use,
 expressibility, and speed. Here's an example of a complete Rocket application:
 
 ```rust
-#![feature(plugin, decl_macro)]
+#![feature(plugin, decl_macro, proc_macro_non_items)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;


### PR DESCRIPTION
…suggestion:

error[E0658]: procedural macros cannot be expanded to expressions (see issue #38356)
  --> src/main.rs:12:38
   |
12 |     rocket::ignite().mount("/hello", routes![hello]).launch();
   |                                      ^^^^^^^^^^^^^^
   |
   = help: add #![feature(proc_macro_non_items)] to the crate attributes to enable