### PR TITLE
Allow wildcards in content-type

### DIFF
--- a/core/http/src/known_media_types.rs
+++ b/core/http/src/known_media_types.rs
@@ -1,6 +1,15 @@
 macro_rules! known_media_types {
     ($cont:ident) => ($cont! {
         Any (is_any): "any media type", "*", "*",
+        Application (is_application): "any application type", "application", "*",
+        Audio (is_audio): "any audio type", "audio", "*",
+        Font (is_font): "any font type", "font", "*",
+        Image (is_image): "any image type", "image", "*",
+        Message (is_message): "any message type", "message", "*",
+        Model (is_model): "any model type", "model", "*",
+        Multipart (is_multipart): "any multipart type", "multipart", "*",
+        Text (is_text): "any text type", "text", "*",
+        Video (is_video): "any video type", "video", "*",
         Binary (is_binary): "binary data", "application", "octet-stream",
         HTML (is_html): "HTML", "text", "html" ; "charset" => "utf-8",
         Plain (is_plain): "plain text", "text", "plain" ; "charset" => "utf-8",

--- a/examples/form_kitchen_sink/src/main.rs
+++ b/examples/form_kitchen_sink/src/main.rs
@@ -28,7 +28,7 @@ struct FormInput<'r> {
     select: FormOption,
 }
 
-#[post("/", data = "<sink>")]
+#[post("/", data = "<sink>", format="image/*")]
 fn sink(sink: Result<Form<FormInput>, FormError>) -> String {
     match sink {
         Ok(form) => format!("{:?}", &*form),


### PR DESCRIPTION
Adds the top level media types (From the [iana](https://www.iana.org/assignments/media-types/media-types.xhtml) list) to the known media types.

This doesn't add any tests, I couldn't figure out where they had to go for compiletest to require no warnings.

Fixes #583