### PR TITLE
Fix build errors with latest Rust nightly

### DIFF
--- a/contrib/lib/tests/templates.rs
+++ b/contrib/lib/tests/templates.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, proc_macro_non_items)]
+#![feature(plugin, decl_macro, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;

--- a/core/codegen/tests/complete-decorator.rs
+++ b/core/codegen/tests/complete-decorator.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, proc_macro_non_items)]
+#![feature(plugin, decl_macro, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;

--- a/core/codegen/tests/dynamic-paths.rs
+++ b/core/codegen/tests/dynamic-paths.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, proc_macro_non_items)]
+#![feature(plugin, decl_macro, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 #![allow(dead_code, unused_variables)]
 

--- a/core/codegen/tests/instanced-mounting.rs
+++ b/core/codegen/tests/instanced-mounting.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, proc_macro_non_items)]
+#![feature(plugin, decl_macro, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 #![allow(dead_code, unused_variables)]
 

--- a/core/codegen/tests/issue-1-colliding-names.rs
+++ b/core/codegen/tests/issue-1-colliding-names.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, proc_macro_non_items)]
+#![feature(plugin, decl_macro, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;

--- a/core/codegen/tests/refactored_rocket_no_lint_errors.rs
+++ b/core/codegen/tests/refactored_rocket_no_lint_errors.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, proc_macro_non_items)]
+#![feature(plugin, decl_macro, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 #![allow(dead_code, unused_variables)]
 

--- a/core/codegen/tests/type-alias-lints.rs
+++ b/core/codegen/tests/type-alias-lints.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, proc_macro_non_items)]
+#![feature(plugin, decl_macro, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 #![allow(dead_code, unused_variables)]
 

--- a/core/codegen_next/tests/ui-fail/catchers.rs
+++ b/core/codegen_next/tests/ui-fail/catchers.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_non_items)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/core/codegen_next/tests/ui-fail/routes.rs
+++ b/core/codegen_next/tests/ui-fail/routes.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_non_items)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/core/http/Cargo.toml
+++ b/core/http/Cargo.toml
@@ -25,7 +25,7 @@ indexmap = "1.0"
 rustls = { version = "0.13", optional = true }
 state = "0.4"
 cookie = { version = "0.11", features = ["percent-encode", "secure"] }
-pear = { git = "http://github.com/SergioBenitez/Pear", rev = "b475140" }
+pear = { git = "http://github.com/SergioBenitez/Pear", rev = "d221e16" }
 
 [dependencies.hyper-sync-rustls]
 version = "=0.3.0-rc.3"

--- a/core/http/src/lib.rs
+++ b/core/http/src/lib.rs
@@ -1,5 +1,5 @@
 #![feature(specialization)]
-#![feature(proc_macro_non_items)]
+#![feature(proc_macro_hygiene)]
 #![feature(try_from)]
 #![feature(crate_visibility_modifier)]
 #![recursion_limit="512"]

--- a/core/lib/Cargo.toml
+++ b/core/lib/Cargo.toml
@@ -28,7 +28,7 @@ state = "0.4.1"
 time = "0.1"
 memchr = "2" # TODO: Use pear instead.
 base64 = "0.9"
-pear = { git = "http://github.com/SergioBenitez/Pear", rev = "b475140" }
+pear = { git = "http://github.com/SergioBenitez/Pear", rev = "d221e16" }
 isatty = "0.1"
 
 [dev-dependencies]

--- a/core/lib/src/catcher.rs
+++ b/core/lib/src/catcher.rs
@@ -33,7 +33,7 @@ use yansi::Color::*;
 /// declared using the `catch` decorator, as follows:
 ///
 /// ```rust
-/// #![feature(plugin, decl_macro, proc_macro_non_items)]
+/// #![feature(plugin, decl_macro, proc_macro_hygiene)]
 /// #![plugin(rocket_codegen)]
 ///
 /// #[macro_use] extern crate rocket;

--- a/core/lib/src/handler.rs
+++ b/core/lib/src/handler.rs
@@ -86,7 +86,7 @@ pub type Outcome<'r> = outcome::Outcome<Response<'r>, Status, Data>;
 /// managed state and a static route, as follows:
 ///
 /// ```rust
-/// # #![feature(plugin, decl_macro, proc_macro_non_items)]
+/// # #![feature(plugin, decl_macro, proc_macro_hygiene)]
 /// # #![plugin(rocket_codegen)]
 /// # #[macro_use] extern crate rocket;
 /// #

--- a/core/lib/src/lib.rs
+++ b/core/lib/src/lib.rs
@@ -3,7 +3,7 @@
 #![feature(try_trait)]
 #![feature(fnbox)]
 #![feature(never_type)]
-#![feature(proc_macro_non_items)]
+#![feature(proc_macro_hygiene)]
 #![feature(crate_visibility_modifier)]
 #![feature(try_from)]
 #![feature(label_break_value)]
@@ -68,7 +68,7 @@
 //! write Rocket applications. Here's a simple example to get you started:
 //!
 //! ```rust
-//! #![feature(plugin, decl_macro, proc_macro_non_items)]
+//! #![feature(plugin, decl_macro, proc_macro_hygiene)]
 //! #![plugin(rocket_codegen)]
 //!
 //! #[macro_use] extern crate rocket;

--- a/core/lib/src/request/state.rs
+++ b/core/lib/src/request/state.rs
@@ -21,7 +21,7 @@ use http::Status;
 /// following example does just this:
 ///
 /// ```rust
-/// # #![feature(plugin, decl_macro, proc_macro_non_items)]
+/// # #![feature(plugin, decl_macro, proc_macro_hygiene)]
 /// # #![plugin(rocket_codegen)]
 /// # #[macro_use] extern crate rocket;
 /// use rocket::State;

--- a/core/lib/src/response/flash.rs
+++ b/core/lib/src/response/flash.rs
@@ -47,7 +47,7 @@ const FLASH_COOKIE_NAME: &str = "_flash";
 /// message on both the request and response sides.
 ///
 /// ```rust
-/// # #![feature(plugin, decl_macro, proc_macro_non_items)]
+/// # #![feature(plugin, decl_macro, proc_macro_hygiene)]
 /// # #![plugin(rocket_codegen)]
 /// #
 /// # #[macro_use] extern crate rocket;

--- a/core/lib/src/rocket.rs
+++ b/core/lib/src/rocket.rs
@@ -455,7 +455,7 @@ impl Rocket {
     /// dispatched to the `hi` route.
     ///
     /// ```rust
-    /// # #![feature(plugin, decl_macro, proc_macro_non_items)]
+    /// # #![feature(plugin, decl_macro, proc_macro_hygiene)]
     /// # #![plugin(rocket_codegen)]
     /// # #[macro_use] extern crate rocket;
     /// #
@@ -542,7 +542,7 @@ impl Rocket {
     /// # Examples
     ///
     /// ```rust
-    /// #![feature(plugin, decl_macro, proc_macro_non_items)]
+    /// #![feature(plugin, decl_macro, proc_macro_hygiene)]
     /// #![plugin(rocket_codegen)]
     ///
     /// #[macro_use] extern crate rocket;
@@ -601,7 +601,7 @@ impl Rocket {
     /// # Example
     ///
     /// ```rust
-    /// # #![feature(plugin, decl_macro, proc_macro_non_items)]
+    /// # #![feature(plugin, decl_macro, proc_macro_hygiene)]
     /// # #![plugin(rocket_codegen)]
     /// # #[macro_use] extern crate rocket;
     /// use rocket::State;
@@ -756,7 +756,7 @@ impl Rocket {
     /// # Example
     ///
     /// ```rust
-    /// # #![feature(plugin, decl_macro, proc_macro_non_items)]
+    /// # #![feature(plugin, decl_macro, proc_macro_hygiene)]
     /// # #![plugin(rocket_codegen)]
     /// # #[macro_use] extern crate rocket;
     /// use rocket::Rocket;

--- a/core/lib/tests/absolute-uris-okay-issue-443.rs
+++ b/core/lib/tests/absolute-uris-okay-issue-443.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, proc_macro_non_items)]
+#![feature(plugin, decl_macro, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;

--- a/core/lib/tests/fairing_before_head_strip-issue-546.rs
+++ b/core/lib/tests/fairing_before_head_strip-issue-546.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, proc_macro_non_items)]
+#![feature(plugin, decl_macro, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;

--- a/core/lib/tests/flash-lazy-removes-issue-466.rs
+++ b/core/lib/tests/flash-lazy-removes-issue-466.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, proc_macro_non_items)]
+#![feature(plugin, decl_macro, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;

--- a/core/lib/tests/form_method-issue-45.rs
+++ b/core/lib/tests/form_method-issue-45.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, proc_macro_non_items)]
+#![feature(plugin, decl_macro, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;

--- a/core/lib/tests/form_value_decoding-issue-82.rs
+++ b/core/lib/tests/form_value_decoding-issue-82.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, proc_macro_non_items)]
+#![feature(plugin, decl_macro, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;

--- a/core/lib/tests/head_handling.rs
+++ b/core/lib/tests/head_handling.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, proc_macro_non_items)]
+#![feature(plugin, decl_macro, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;

--- a/core/lib/tests/limits.rs
+++ b/core/lib/tests/limits.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, proc_macro_non_items)]
+#![feature(plugin, decl_macro, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;

--- a/core/lib/tests/local-request-content-type-issue-505.rs
+++ b/core/lib/tests/local-request-content-type-issue-505.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, proc_macro_non_items)]
+#![feature(plugin, decl_macro, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;

--- a/core/lib/tests/local_request_private_cookie-issue-368.rs
+++ b/core/lib/tests/local_request_private_cookie-issue-368.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, proc_macro_non_items)]
+#![feature(plugin, decl_macro, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;

--- a/core/lib/tests/nested-fairing-attaches.rs
+++ b/core/lib/tests/nested-fairing-attaches.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, proc_macro_non_items)]
+#![feature(plugin, decl_macro, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;

--- a/core/lib/tests/precise-content-type-matching.rs
+++ b/core/lib/tests/precise-content-type-matching.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, proc_macro_non_items)]
+#![feature(plugin, decl_macro, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;

--- a/core/lib/tests/query-and-non-query-dont-collide.rs
+++ b/core/lib/tests/query-and-non-query-dont-collide.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, proc_macro_non_items)]
+#![feature(plugin, decl_macro, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;

--- a/core/lib/tests/redirect_from_catcher-issue-113.rs
+++ b/core/lib/tests/redirect_from_catcher-issue-113.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, proc_macro_non_items)]
+#![feature(plugin, decl_macro, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;

--- a/core/lib/tests/route_guard.rs
+++ b/core/lib/tests/route_guard.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, proc_macro_non_items)]
+#![feature(plugin, decl_macro, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;

--- a/core/lib/tests/segments-issues-41-86.rs
+++ b/core/lib/tests/segments-issues-41-86.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, proc_macro_non_items)]
+#![feature(plugin, decl_macro, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;

--- a/core/lib/tests/strict_and_lenient_forms.rs
+++ b/core/lib/tests/strict_and_lenient_forms.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, proc_macro_non_items)]
+#![feature(plugin, decl_macro, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;

--- a/examples/config/tests/development.rs
+++ b/examples/config/tests/development.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, proc_macro_non_items)]
+#![feature(plugin, decl_macro, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;

--- a/examples/config/tests/production.rs
+++ b/examples/config/tests/production.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, proc_macro_non_items)]
+#![feature(plugin, decl_macro, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;

--- a/examples/config/tests/staging.rs
+++ b/examples/config/tests/staging.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, proc_macro_non_items)]
+#![feature(plugin, decl_macro, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;

--- a/examples/content_types/src/main.rs
+++ b/examples/content_types/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, proc_macro_non_items)]
+#![feature(plugin, decl_macro, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;

--- a/examples/cookies/src/main.rs
+++ b/examples/cookies/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, proc_macro_non_items)]
+#![feature(plugin, decl_macro, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 
 extern crate rocket_contrib;

--- a/examples/errors/src/main.rs
+++ b/examples/errors/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, proc_macro_non_items)]
+#![feature(plugin, decl_macro, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;

--- a/examples/fairings/src/main.rs
+++ b/examples/fairings/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, proc_macro_non_items)]
+#![feature(plugin, decl_macro, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;

--- a/examples/form_kitchen_sink/src/main.rs
+++ b/examples/form_kitchen_sink/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, proc_macro_non_items)]
+#![feature(plugin, decl_macro, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;

--- a/examples/form_validation/src/main.rs
+++ b/examples/form_validation/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, proc_macro_non_items)]
+#![feature(plugin, decl_macro, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;

--- a/examples/handlebars_templates/src/main.rs
+++ b/examples/handlebars_templates/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, proc_macro_non_items)]
+#![feature(plugin, decl_macro, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 
 extern crate rocket_contrib;

--- a/examples/hello_2018/src/main.rs
+++ b/examples/hello_2018/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, proc_macro_non_items)]
+#![feature(plugin, decl_macro, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 
 use rocket::{self, routes};

--- a/examples/hello_person/src/main.rs
+++ b/examples/hello_person/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, proc_macro_non_items)]
+#![feature(plugin, decl_macro, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;

--- a/examples/hello_world/src/main.rs
+++ b/examples/hello_world/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, proc_macro_non_items)]
+#![feature(plugin, decl_macro, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;

--- a/examples/json/src/main.rs
+++ b/examples/json/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, proc_macro_non_items)]
+#![feature(plugin, decl_macro, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;

--- a/examples/managed_queue/src/main.rs
+++ b/examples/managed_queue/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, proc_macro_non_items)]
+#![feature(plugin, decl_macro, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 
 extern crate crossbeam;

--- a/examples/msgpack/src/main.rs
+++ b/examples/msgpack/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, proc_macro_non_items)]
+#![feature(plugin, decl_macro, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;

--- a/examples/optional_redirect/src/main.rs
+++ b/examples/optional_redirect/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, proc_macro_non_items)]
+#![feature(plugin, decl_macro, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;

--- a/examples/pastebin/src/main.rs
+++ b/examples/pastebin/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, proc_macro_non_items)]
+#![feature(plugin, decl_macro, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 
 #[macro_use]

--- a/examples/query_params/src/main.rs
+++ b/examples/query_params/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, proc_macro_non_items)]
+#![feature(plugin, decl_macro, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;

--- a/examples/ranking/src/main.rs
+++ b/examples/ranking/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, proc_macro_non_items)]
+#![feature(plugin, decl_macro, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;

--- a/examples/raw_sqlite/src/main.rs
+++ b/examples/raw_sqlite/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, proc_macro_non_items)]
+#![feature(plugin, decl_macro, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;

--- a/examples/raw_upload/src/main.rs
+++ b/examples/raw_upload/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, proc_macro_non_items)]
+#![feature(plugin, decl_macro, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;

--- a/examples/redirect/src/main.rs
+++ b/examples/redirect/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, proc_macro_non_items)]
+#![feature(plugin, decl_macro, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;

--- a/examples/request_guard/src/main.rs
+++ b/examples/request_guard/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, never_type, proc_macro_non_items)]
+#![feature(plugin, decl_macro, never_type, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;

--- a/examples/request_local_state/src/main.rs
+++ b/examples/request_local_state/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, never_type, proc_macro_non_items)]
+#![feature(plugin, decl_macro, never_type, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;

--- a/examples/session/src/main.rs
+++ b/examples/session/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, never_type, proc_macro_non_items)]
+#![feature(plugin, decl_macro, never_type, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 
 extern crate rocket_contrib;

--- a/examples/state/src/main.rs
+++ b/examples/state/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, proc_macro_non_items)]
+#![feature(plugin, decl_macro, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;

--- a/examples/stream/src/main.rs
+++ b/examples/stream/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, proc_macro_non_items)]
+#![feature(plugin, decl_macro, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;

--- a/examples/tera_templates/src/main.rs
+++ b/examples/tera_templates/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, proc_macro_non_items)]
+#![feature(plugin, decl_macro, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 
 extern crate rocket_contrib;

--- a/examples/testing/src/main.rs
+++ b/examples/testing/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, proc_macro_non_items)]
+#![feature(plugin, decl_macro, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;

--- a/examples/tls/src/main.rs
+++ b/examples/tls/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, proc_macro_non_items)]
+#![feature(plugin, decl_macro, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;

--- a/examples/todo/src/main.rs
+++ b/examples/todo/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, proc_macro_non_items)]
+#![feature(plugin, decl_macro, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 
 #[macro_use] extern crate rocket;

--- a/examples/uuid/src/main.rs
+++ b/examples/uuid/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, decl_macro, proc_macro_non_items)]
+#![feature(plugin, decl_macro, proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 
 #[macro_use]


### PR DESCRIPTION
This PR fixes build errors introduced in the latest few Rust nightly versions.

- The `proc_macro_non_items` feature has been changed to `proc_macro_hygiene`
- The git revision of the `pear` dependency has been updated as well to apply this change

Confirmed to work with `rustc 1.31.0-nightly (b2d6ea98b 2018-10-07)` and `cargo 1.31.0-nightly (ad6e5c003 2018-09-28)`.

Note: I would also like to apply these changes to the `v0.4-preview` branch along with some other fixes, but am not sure yet how to properly merge these into that branch.