### PR TITLE
Update doc for ConfigBuilder

### DIFF
--- a/core/lib/src/config/builder.rs
+++ b/core/lib/src/config/builder.rs
@@ -14,7 +14,7 @@ pub struct ConfigBuilder {
     pub port: u16,
     /// The number of workers to run in parallel.
     pub workers: u16,
-    /// Keep-alive timeout in seconds or None if disabled.
+    /// Keep-alive timeout in seconds or disabled if 0.
     pub keep_alive: u32,
     /// How much information to log.
     pub log_level: LoggingLevel,


### PR DESCRIPTION
Drive by PR, noticed that this docstring didn't keep up with the underlying type change.