### PR TITLE
Nested form attributes. (Closes #313)

### DIFF
--- a/core/codegen_next/tests/from_form.rs
+++ b/core/codegen_next/tests/from_form.rs
@@ -317,3 +317,44 @@ fn form_errors() {
     let form: Result<WhoopsForm, _> = strict("complete=true");
     assert_eq!(form, Err(FormParseError::Missing("other".into())));
 }
+
+#[derive(Debug, PartialEq, FromForm)]
+struct User {
+    name: String,
+}
+
+#[derive(Debug, PartialEq, FromForm)]
+struct Business {
+    name: String,
+    profits: usize,
+}
+
+#[derive(Debug, PartialEq, FromForm)]
+struct NestedForm {
+    #[form(nested = true)]
+    user: User,
+    #[form(nested = true, field = "their_business")]
+    business: Business,
+    normal: usize,
+}
+
+#[test]
+fn nested() {
+    // Check that forms with nested attributes (fields that implement FromForm)
+    // parse correctly
+    let form: Result<NestedForm, _> =
+        strict("user_name=Alex&their_business_name=ACME&their_business_profits=0&normal=42");
+    assert_eq!(
+        form,
+        Ok(NestedForm {
+            user: User {
+                name: "Alex".into()
+            },
+            business: Business {
+                name: "ACME".into(),
+                profits: 0
+            },
+            normal: 42
+        })
+    );
+}


### PR DESCRIPTION
Not much to say; Creates a new `FormItems` instance for each child but this should be inconsequential as `FormItem` only stores references. If there are form errors in nested children they won't show the prefix however, so a nested `User` model will only show a missing `name`, not a missing `user_name`.