### PR TITLE
Update 'contains_template' documentation.

### DIFF
--- a/contrib/lib/src/templates/metadata.rs
+++ b/contrib/lib/src/templates/metadata.rs
@@ -40,8 +40,8 @@ use templates::ContextManager;
 pub struct Metadata<'a>(&'a ContextManager);
 
 impl<'a> Metadata<'a> {
-    /// Returns `true` if the template with name `name` was loaded at start-up
-    /// time. Otherwise, returns `false`.
+    /// Returns `true` if the template with the given `name` is currently
+    /// loaded.  Otherwise, returns `false`.
     ///
     /// # Example
     ///


### PR DESCRIPTION
With template reloading active, the set of loaded templates can change. Since `contains_template` is "live" with respect to the list of templates, this text is more accurate.