### PR TITLE
Support usage of rocket macros in 2018 edition crates.

### DIFF
--- a/core/codegen/src/attribute/route.rs
+++ b/core/codegen/src/attribute/route.rs
@@ -318,6 +318,8 @@ fn generate_internal_uri_macro(route: &Route) -> TokenStream2 {
 
     quote! {
         pub macro #generated_macro_name($($token:tt)*) {{
+            extern crate rocket;
+            extern crate std;
             rocket::rocket_internal_uri!(#route_uri, (#(#dynamic_args),*), $($token)*)
         }}
     }

--- a/core/codegen/src/attribute/route.rs
+++ b/core/codegen/src/attribute/route.rs
@@ -317,9 +317,9 @@ fn generate_internal_uri_macro(route: &Route) -> TokenStream2 {
     let route_uri = route.attribute.path.origin.0.to_string();
 
     quote! {
-        pub macro #generated_macro_name($($token:tt)*) {
-            rocket_internal_uri!(#route_uri, (#(#dynamic_args),*), $($token)*)
-        }
+        pub macro #generated_macro_name($($token:tt)*) {{
+            rocket::rocket_internal_uri!(#route_uri, (#(#dynamic_args),*), $($token)*)
+        }}
     }
 }
 

--- a/core/codegen/src/bang/uri.rs
+++ b/core/codegen/src/bang/uri.rs
@@ -159,9 +159,9 @@ crate fn _uri_internal_macro(input: TokenStream) -> Result<TokenStream> {
     let query = Optional(origin.query().map(|q| explode(q, arguments)));
 
     Ok(quote!({
-        ::rocket::http::uri::Origin::new::<
-            ::std::borrow::Cow<'static, str>,
-            ::std::borrow::Cow<'static, str>,
+        rocket::http::uri::Origin::new::<
+            std::borrow::Cow<'static, str>,
+            std::borrow::Cow<'static, str>,
         >(#path, #query)
     }).into())
 }

--- a/examples/hello_2018/src/main.rs
+++ b/examples/hello_2018/src/main.rs
@@ -1,12 +1,17 @@
 #![feature(proc_macro_hygiene, decl_macro)]
 
-#[macro_use] extern crate rocket;
+use rocket::{get, routes, uri};
 
 #[cfg(test)] mod tests;
 
 #[get("/")]
-fn hello() -> &'static str {
-    "Hello, Rust 2018!"
+fn hello() -> String {
+    format!("Hello! Try {}.", uri!(hello_name: "Rust 2018"))
+}
+
+#[rocket::get("/<name>")]
+fn hello_name(name: String) -> String {
+    format!("Hello, {}!", name)
 }
 
 fn main() {

--- a/examples/hello_2018/src/tests.rs
+++ b/examples/hello_2018/src/tests.rs
@@ -1,9 +1,19 @@
-use rocket::{self, routes, local::Client};
+use rocket::{self, routes, local::Client, Rocket};
+
+fn rocket() -> Rocket {
+    rocket::ignite().mount("/", routes![super::hello, super::hello_name])
+}
 
 #[test]
-fn hello_world() {
-    let rocket = rocket::ignite().mount("/", routes![super::hello]);
-    let client = Client::new(rocket).unwrap();
+fn hello() {
+    let client = Client::new(rocket()).unwrap();
     let mut response = client.get("/").dispatch();
+    assert_eq!(response.body_string(), Some("Hello! Try /Rust%202018.".into()));
+}
+
+#[test]
+fn hello_name() {
+    let client = Client::new(rocket()).unwrap();
+    let mut response = client.get("/Rust%202018").dispatch();
     assert_eq!(response.body_string(), Some("Hello, Rust 2018!".into()));
 }


### PR DESCRIPTION
This commit consists of 3 changes:

* Replace `::rocket::` and `::std::` with `rocket::` and `std::` in `rocket_internal_uri`. This only became necessary quite recently, and I want to track down which commit in rust caused it and file a bug report if it's unintentional. **This change appears to be necessary for 2018-edition crates to be able to call `uri!`, regardless of import method!**
* Change the `hello_2018` example to not use `extern crate rocket;` and `use rocket::{macros...};` instead. This is idiomatic for the 2018 edition and the original motivation for adding the example.
* Change the `#[route]`-generated macro to call `rocket::rocket_internal_uri` instead of `rocket_internal_uri`. This probably requires 'rocket' to be not-renamed and at the crate root, but this is already required by most of the codegen. Without this change, `use rocket::uri;` without `#[macro_use]` must always be accompanied by `use rocket::rocket_internal_uri;`.

The first change may be due to a regression in rustc, but it might also be intentional and only exposed because we define `decl_macro`s from inside a `proc_macro`. We could hold off on it while I track the cause down, but in the meantime no 2018 edition crate can use the type-safe URI generation.

The second and third change align Rocket's macros better with 2018 usage style and demonstrate that it works.