### PR TITLE
Put private cookies behind a feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
   - TEST_FLAGS=
   - TEST_FLAGS=--release
   - TEST_FLAGS=--contrib
+  - TEST_FLAGS=--core
 rust:
   - nightly
 script: ./scripts/test.sh $TEST_FLAGS

--- a/core/http/Cargo.toml
+++ b/core/http/Cargo.toml
@@ -15,6 +15,7 @@ categories = ["web-programming"]
 
 [features]
 tls = ["rustls", "hyper-sync-rustls"]
+private-cookies = ["cookie/secure"]
 
 [dependencies]
 smallvec = "0.6"
@@ -24,7 +25,7 @@ time = "0.1"
 indexmap = "1.0"
 rustls = { version = "0.14", optional = true }
 state = "0.4"
-cookie = { version = "0.11", features = ["percent-encode", "secure"] }
+cookie = { version = "0.11", features = ["percent-encode"] }
 pear = "0.1"
 unicode-xid = "0.1"
 

--- a/core/http/src/cookies.rs
+++ b/core/http/src/cookies.rs
@@ -177,6 +177,8 @@ impl<'a> Cookies<'a> {
     /// `Cookie` with the decrypted value. If the cookie cannot be found, or the
     /// cookie fails to authenticate or decrypt, `None` is returned.
     ///
+    /// This method is only available when the `private-cookies` feature is enabled.
+    ///
     /// # Example
     ///
     /// ```rust
@@ -237,6 +239,8 @@ impl<'a> Cookies<'a> {
     /// These defaults ensure maximum usability and security. For additional
     /// security, you may wish to set the `secure` flag.
     ///
+    /// This method is only available when the `private-cookies` feature is enabled.
+    ///
     /// # Example
     ///
     /// ```rust
@@ -275,6 +279,8 @@ impl<'a> Cookies<'a> {
     ///    * `SameSite`: `Strict`
     ///    * `HttpOnly`: `true`
     ///    * `Expires`: 1 week from now
+    ///
+    /// This method is only available when the `private-cookies` feature is enabled.
     ///
     #[cfg(feature = "private-cookies")]
     fn set_private_defaults(cookie: &mut Cookie<'static>) {
@@ -326,6 +332,8 @@ impl<'a> Cookies<'a> {
     /// For correct removal, the passed in `cookie` must contain the same `path`
     /// and `domain` as the cookie that was initially set. If a path is not set
     /// on `cookie`, the `"/"` path will automatically be set.
+    ///
+    /// This method is only available when the `private-cookies` feature is enabled.
     ///
     /// # Example
     ///

--- a/core/http/src/cookies.rs
+++ b/core/http/src/cookies.rs
@@ -2,9 +2,15 @@ use std::fmt;
 use std::cell::RefMut;
 
 use cookie::Delta;
-pub use cookie::{Cookie, Key, CookieJar, SameSite};
+pub use cookie::{Cookie, CookieJar, SameSite};
+
+#[cfg(feature = "private-cookies")]
+pub use cookie::Key;
 
 use Header;
+
+#[cfg(not(feature = "private-cookies"))]
+type Key = ();
 
 /// Collection of one or more HTTP cookies.
 ///
@@ -181,6 +187,7 @@ impl<'a> Cookies<'a> {
     ///     let cookie = cookies.get_private("name");
     /// }
     /// ```
+    #[cfg(feature = "private-cookies")]
     pub fn get_private(&mut self, name: &str) -> Option<Cookie<'static>> {
         match *self {
             Cookies::Jarred(ref mut jar, key) => jar.private(key).get(name),
@@ -240,6 +247,7 @@ impl<'a> Cookies<'a> {
     ///     cookies.add_private(Cookie::new("name", "value"));
     /// }
     /// ```
+    #[cfg(feature = "private-cookies")]
     pub fn add_private(&mut self, mut cookie: Cookie<'static>) {
         if let Cookies::Jarred(ref mut jar, key) = *self {
             Cookies::set_private_defaults(&mut cookie);
@@ -249,6 +257,7 @@ impl<'a> Cookies<'a> {
 
     /// Adds an original, private `cookie` to the collection.
     /// WARNING: This is unstable! Do not use this method outside of Rocket!
+    #[cfg(feature = "private-cookies")]
     #[doc(hidden)]
     pub fn add_original_private(&mut self, mut cookie: Cookie<'static>) {
         if let Cookies::Jarred(ref mut jar, key) = *self {
@@ -267,6 +276,7 @@ impl<'a> Cookies<'a> {
     ///    * `HttpOnly`: `true`
     ///    * `Expires`: 1 week from now
     ///
+    #[cfg(feature = "private-cookies")]
     fn set_private_defaults(cookie: &mut Cookie<'static>) {
         if cookie.path().is_none() {
             cookie.set_path("/");
@@ -327,6 +337,7 @@ impl<'a> Cookies<'a> {
     ///     cookies.remove_private(Cookie::named("name"));
     /// }
     /// ```
+    #[cfg(feature = "private-cookies")]
     pub fn remove_private(&mut self, mut cookie: Cookie<'static>) {
         if let Cookies::Jarred(ref mut jar, key) = *self {
             if cookie.path().is_none() {

--- a/core/http/src/lib.rs
+++ b/core/http/src/lib.rs
@@ -59,7 +59,8 @@ pub mod uncased;
 #[doc(hidden)] pub use smallvec::{SmallVec, Array};
 
 // This one we need to expose for core.
-#[doc(hidden)] pub use cookies::{Key, CookieJar};
+#[doc(hidden)] pub use cookies::CookieJar;
+#[doc(hidden)] #[cfg(feature = "private-cookies")] pub use cookies::Key;
 
 pub use method::Method;
 pub use content_type::ContentType;

--- a/core/lib/Cargo.toml
+++ b/core/lib/Cargo.toml
@@ -16,6 +16,7 @@ categories = ["web-programming::http-server"]
 
 [features]
 tls = ["rocket_http/tls"]
+private-cookies = ["rocket_http/private-cookies"]
 
 [dependencies]
 rocket_codegen = { version = "0.4.0-rc.1", path = "../codegen" }

--- a/core/lib/src/config/custom_values.rs
+++ b/core/lib/src/config/custom_values.rs
@@ -3,14 +3,17 @@ use std::fmt;
 #[cfg(feature = "tls")] use http::tls::{Certificate, PrivateKey};
 
 use config::{Result, Config, Value, ConfigError, LoggingLevel};
-use http::Key;
 
+#[cfg(feature = "private-cookies")] use http::Key;
+
+#[cfg(feature = "private-cookies")]
 #[derive(Clone)]
 pub enum SecretKey {
     Generated(Key),
     Provided(Key)
 }
 
+#[cfg(feature = "private-cookies")]
 impl SecretKey {
     #[inline]
     crate fn inner(&self) -> &Key {
@@ -28,6 +31,7 @@ impl SecretKey {
     }
 }
 
+#[cfg(feature = "private-cookies")]
 impl fmt::Display for SecretKey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {

--- a/core/lib/src/local/request.rs
+++ b/core/lib/src/local/request.rs
@@ -280,6 +280,7 @@ impl<'c> LocalRequest<'c> {
     /// # #[allow(unused_variables)]
     /// let req = client.get("/").private_cookie(Cookie::new("user_id", "sb"));
     /// ```
+    #[cfg(feature = "private-cookies")]
     #[inline]
     pub fn private_cookie(self, cookie: Cookie<'static>) -> Self {
         self.request.cookies().add_original_private(cookie);

--- a/core/lib/src/local/request.rs
+++ b/core/lib/src/local/request.rs
@@ -268,6 +268,8 @@ impl<'c> LocalRequest<'c> {
     ///
     /// [private cookie]: ::http::Cookies::add_private()
     ///
+    /// This method is only available when the `private-cookies` feature is enabled.
+    ///
     /// # Examples
     ///
     /// Add `user_id` as a private cookie:

--- a/core/lib/src/request/request.rs
+++ b/core/lib/src/request/request.rs
@@ -290,7 +290,10 @@ impl<'r> Request<'r> {
     pub fn cookies(&self) -> Cookies {
         // FIXME: Can we do better? This is disappointing.
         match self.state.cookies.try_borrow_mut() {
+            #[cfg(feature = "private-cookies")]
             Ok(jar) => Cookies::new(jar, self.state.config.secret_key()),
+            #[cfg(not(feature = "private-cookies"))]
+            Ok(jar) => Cookies::new(jar, &()),
             Err(_) => {
                 error_!("Multiple `Cookies` instances are active at once.");
                 info_!("An instance of `Cookies` must be dropped before another \

--- a/core/lib/src/rocket.rs
+++ b/core/lib/src/rocket.rs
@@ -113,19 +113,6 @@ macro_rules! serve {
     })
 }
 
-#[cfg(feature = "private-cookies")]
-#[inline]
-fn check_secret_key_in_prod(config: &Config) {
-    if config.secret_key.is_generated() && config.environment.is_prod() {
-        warn!("environment is 'production', but no `secret_key` is configured");
-    }
-}
-
-#[cfg(not(feature = "private-cookies"))]
-#[inline]
-fn check_secret_key_in_prod(config: &Config) {
-}
-
 impl Rocket {
     #[inline]
     fn issue_response(&self, response: Response, hyp_res: hyper::FreshResponse) {
@@ -428,7 +415,11 @@ impl Rocket {
             launch_info_!("tls: {}", Paint::white("disabled"));
         }
 
-        check_secret_key_in_prod(&config);
+        #[cfg(feature = "private-cookies")] {
+            if config.secret_key.is_generated() && config.environment.is_prod() {
+                warn!("environment is 'production', but no `secret_key` is configured");
+            }
+        }
 
         for (name, value) in config.extras() {
             launch_info_!("{} {}: {}",

--- a/core/lib/tests/local_request_private_cookie-issue-368.rs
+++ b/core/lib/tests/local_request_private_cookie-issue-368.rs
@@ -4,6 +4,7 @@
 
 use rocket::http::Cookies;
 
+#[cfg(feature = "private-cookies")]
 #[get("/")]
 fn return_private_cookie(mut cookies: Cookies) -> Option<String> {
     match cookies.get_private("cookie_name") {
@@ -12,6 +13,7 @@ fn return_private_cookie(mut cookies: Cookies) -> Option<String> {
     }
 }
 
+#[cfg(feature = "private-cookies")]
 mod tests {
     use super::*;
     use rocket::local::Client;

--- a/examples/session/Cargo.toml
+++ b/examples/session/Cargo.toml
@@ -5,7 +5,7 @@ workspace = "../../"
 publish = false
 
 [dependencies]
-rocket = { path = "../../core/lib" }
+rocket = { path = "../../core/lib", features = ["private-cookies"] }
 
 [dependencies.rocket_contrib]
 path = "../../contrib/lib"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -107,6 +107,26 @@ if [ "$1" = "--contrib" ]; then
   done
 
   popd > /dev/null 2>&1
+elif [ "$1" = "--core" ]; then
+  FEATURES=(
+    private-cookies
+    tls
+  )
+
+  pushd "${CORE_ROOT}" > /dev/null 2>&1
+
+  echo ":: Building and testing core [no features]..."
+  CARGO_INCREMENTAL=0 cargo test --no-default-features
+
+  echo ":: Building and testing core [default]..."
+  CARGO_INCREMENTAL=0 cargo test
+
+  for feature in "${FEATURES[@]}"; do
+    echo ":: Building and testing core [${feature}]..."
+    CARGO_INCREMENTAL=0 cargo test --no-default-features --features "${feature}"
+  done
+
+  popd > /dev/null 2>&1
 else
   echo ":: Bootstrapping examples..."
   bootstrap_examples

--- a/site/guide/4-requests.md
+++ b/site/guide/4-requests.md
@@ -503,6 +503,15 @@ fn logout(mut cookies: Cookies) -> Flash<Redirect> {
 
 [`Cookies::add()`]: @api/rocket/http/enum.Cookies.html#method.add
 
+Private Cookies can be omitted at build time by excluding the feature
+`private-cookies`. You can do this by setting the `default-features`
+directive to `false` in your `Cargo.toml`:
+
+```toml
+[dependencies.rocket]
+default-features = false
+```
+
 ### Secret Key
 
 To encrypt private cookies, Rocket uses the 256-bit key specified in the


### PR DESCRIPTION
I'm quite new to both Rocket and Rust, so I've probably made a few mistakes. I'm very open to feedback though!

The motivation behind this is to be able to compile Rocket without `ring`, which currently doesn't ship assembly for the MIPS architecture.

todo:
- [x] The testing script needs to be updated so it tests with the feature and without it.
- [x] The documentation needs to be updated.
- [x] The guide should say that you can disable this functionality. 
- [x] Try and decrease the number of `#[cfg(...)]`s