### PR TITLE
Fix HSTS application logic in SpaceHelmet.

### DIFF
--- a/contrib/lib/src/helmet/helmet.rs
+++ b/contrib/lib/src/helmet/helmet.rs
@@ -180,8 +180,12 @@ impl SpaceHelmet {
             response.set_header(policy.header());
         }
 
-        if !self.force_hsts.load(Ordering::Relaxed) {
-            response.set_header(Policy::header(&Hsts::default()));
+        if self.force_hsts.load(Ordering::Relaxed) {
+            let hsts = Hsts::default();
+
+            if !response.headers().contains(hsts.name().as_str()) {
+                response.set_header(SubPolicy::header(&hsts));
+            }
         }
     }
 }


### PR DESCRIPTION
The reorganization flipped the forcing logic and left out a check, so it now applies the forced HSTS header every time *except* when it should, overwriting any per-request HSTS headers.