### PR TITLE
Fix notify dependency version.

### DIFF
--- a/contrib/lib/Cargo.toml
+++ b/contrib/lib/Cargo.toml
@@ -71,7 +71,7 @@ r2d2_redis = { version = "0.8", optional = true }
 time = { version = "0.1.40", optional = true }
 
 [target.'cfg(debug_assertions)'.dependencies]
-notify = { version = "^4.0" }
+notify = { version = "^4.0.6" }
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
We are using `impl From<std::io::Error> for notify::Error` at https://github.com/SergioBenitez/Rocket/blob/76c830a467920f818ca1ff7d9e92798c2755f6f8/contrib/lib/src/templates/fairing.rs#L58 , which was added in `notify` 4.0.6.

This was first reported by **groks** in IRC.