### PR TITLE
Use the 'dyn' keyword explicitly to be compatible with the 'bare_trait_objects' lint.

### DIFF
--- a/core/codegen/src/bang/uri.rs
+++ b/core/codegen/src/bang/uri.rs
@@ -119,7 +119,7 @@ fn explode<'a, I>(route_str: &str, items: I) -> TokenStream2
 
         // generating: arg tokens for format string
         fmt_exprs.push(quote_spanned! { span =>
-            &#ident as &rocket::http::uri::UriDisplay
+            &#ident as &dyn rocket::http::uri::UriDisplay
         });
     }
 


### PR DESCRIPTION
`bare_trait_objects` is part of the `rust_2018_idioms` lint group. I believe this will also allow `cargo fix` to upgrade crates that use the `uri!` macro. Currently, the compiler suggests adding the `dyn` keyword inside the macro invocation somewhere which never works.