### PR TITLE
Add MongoDB support in `rocket_contrib`

### DIFF
--- a/contrib/lib/Cargo.toml
+++ b/contrib/lib/Cargo.toml
@@ -33,6 +33,7 @@ mysql_pool = ["databases", "mysql", "r2d2_mysql"]
 sqlite_pool = ["databases", "rusqlite", "r2d2_sqlite"]
 cypher_pool = ["databases", "rusted_cypher", "r2d2_cypher"]
 redis_pool = ["databases", "redis", "r2d2_redis"]
+mongodb_pool = ["databases", "mongodb", "r2d2-mongodb"]
 
 [dependencies]
 # Global dependencies.
@@ -66,6 +67,8 @@ rusted_cypher = { version = "1", optional = true }
 r2d2_cypher = { version = "0.4", optional = true }
 redis = { version = "0.9", optional = true }
 r2d2_redis = { version = "0.8", optional = true }
+mongodb = { version = "0.3.12", optional = true }
+r2d2-mongodb = { version = "0.2.0", optional = true }
 
 # SpaceHelmet dependencies
 time = { version = "0.1.40", optional = true }

--- a/contrib/lib/src/databases.rs
+++ b/contrib/lib/src/databases.rs
@@ -333,6 +333,7 @@
 //! | Sqlite   | [Rustqlite]           | [`rusqlite::Connection`]       | `sqlite_pool`          |
 //! | Neo4j    | [`rusted_cypher`]     | [`rusted_cypher::GraphClient`] | `cypher_pool`          |
 //! | Redis    | [`redis-rs`]          | [`redis::Connection`]          | `redis_pool`           |
+//! | MongoDB  | [`mongodb`]           | [`mongodb::Client`]            | `mongodb_pool`         |
 //!
 //! [Diesel]: https://diesel.rs
 //! [`redis::Connection`]: https://docs.rs/redis/0.9.0/redis/struct.Connection.html
@@ -349,6 +350,8 @@
 //! [Rust-Postgres]: https://github.com/sfackler/rust-postgres
 //! [`rust-mysql-simple`]: https://github.com/blackbeam/rust-mysql-simple
 //! [`diesel::PgConnection`]: http://docs.diesel.rs/diesel/pg/struct.PgConnection.html
+//! [`mongodb`]: https://github.com/mongodb-labs/mongo-rust-driver-prototype
+//! [`mongodb::Client`]: https://docs.rs/mongodb/0.3.12/mongodb/trait.ThreadedClient.html
 //!
 //! The above table lists all the supported database adapters in this library.
 //! In order to use particular `Poolable` type that's included in this library,
@@ -398,6 +401,9 @@ use self::r2d2::ManageConnection;
 
 #[cfg(feature = "redis_pool")] pub extern crate redis;
 #[cfg(feature = "redis_pool")] pub extern crate r2d2_redis;
+
+#[cfg(feature = "mongodb_pool")] pub extern crate mongodb;
+#[cfg(feature = "mongodb_pool")] pub extern crate r2d2_mongodb;
 
 /// A structure representing a particular database configuration.
 ///
@@ -778,6 +784,17 @@ impl Poolable for redis::Connection {
         let manager = r2d2_redis::RedisConnectionManager::new(config.url).map_err(DbError::Custom)?;
         r2d2::Pool::builder().max_size(config.pool_size).build(manager)
             .map_err(DbError::PoolError)
+    }
+}
+
+#[cfg(feature = "mongodb_pool")]
+impl Poolable for mongodb::db::Database {
+    type Manager = r2d2_mongodb::MongodbConnectionManager;
+    type Error = DbError<mongodb::Error>;
+
+    fn pool(config: DatabaseConfig) -> Result<r2d2::Pool<Self::Manager>, Self::Error> {
+        let manager = r2d2_mongodb::MongodbConnectionManager::new_with_uri(config.url).map_err(DbError::Custom)?;
+        r2d2::Pool::builder().max_size(config.pool_size).build(manager).map_err(DbError::PoolError)
     }
 }
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -95,6 +95,7 @@ if [ "$1" = "--contrib" ]; then
     sqlite_pool
     cypher_pool
     redis_pool
+    mongodb_pool
   )
 
   pushd "${CONTRIB_LIB_ROOT}" > /dev/null 2>&1

--- a/site/guide/6-state.md
+++ b/site/guide/6-state.md
@@ -187,6 +187,7 @@ Presently, Rocket provides built-in support for the following databases:
 | Sqlite   | [`Rustqlite`]         | [`rusqlite::Connection`]       | `sqlite_pool`          |
 | Neo4j    | [`rusted_cypher`]     | [`rusted_cypher::GraphClient`] | `cypher_pool`          |
 | Redis    | [`redis-rs`]          | [`redis::Connection`]          | `redis_pool`           |
+| MongoDB  | [`mongodb`]           | [`mongodb::Client`]            | `mongodb_pool`         |
 
 [`r2d2`]: https://crates.io/crates/r2d2
 [Diesel]: https://diesel.rs
@@ -204,6 +205,8 @@ Presently, Rocket provides built-in support for the following databases:
 [Rust-Postgres]: https://github.com/sfackler/rust-postgres
 [`rust-mysql-simple`]: https://github.com/blackbeam/rust-mysql-simple
 [`diesel::PgConnection`]: http://docs.diesel.rs/diesel/pg/struct.PgConnection.html
+[`mongodb`]: https://github.com/mongodb-labs/mongo-rust-driver-prototype
+[`mongodb::Client`]: https://docs.rs/mongodb/0.3.12/mongodb/trait.ThreadedClient.html
 
 ### Usage
 


### PR DESCRIPTION
This addresses #831.

It's not the prettiest since I do the parsing in the trait `impl` instead of inside the connection manager, but I have a pending PR (https://gitlab.com/petoknm/r2d2-mongodb/merge_requests/1) on the r2d2 adapter that should simplify our code in `rocket_contrib`.

I've accordingly updated the module documentation and guide to list MongoDB support as included.

Let me know if you want me to make any changes or have any questions.