### PR TITLE
Remove rocket_codegen from pastebin guide

### DIFF
--- a/site/guide/10-pastebin.md
+++ b/site/guide/10-pastebin.md
@@ -44,7 +44,6 @@ Then add the usual Rocket dependencies to the `Cargo.toml` file:
 ```toml
 [dependencies]
 rocket = "0.4.0"
-rocket_codegen = "0.4.0"
 ```
 
 And finally, create a skeleton Rocket application to work off of in


### PR DESCRIPTION
The [release notes for 0.4](https://github.com/SergioBenitez/Rocket/blob/master/CHANGELOG.md#codegen-rewrite) recommend not having rocket_codegen as a direct dependency.