### PR TITLE
Remove uses of FnBox

### DIFF
--- a/core/lib/src/lib.rs
+++ b/core/lib/src/lib.rs
@@ -1,12 +1,12 @@
 #![feature(specialization)]
 #![feature(decl_macro)]
 #![feature(try_trait)]
-#![feature(fnbox)]
 #![feature(never_type)]
 #![feature(proc_macro_hygiene)]
 #![feature(crate_visibility_modifier)]
 #![feature(try_from)]
 #![feature(label_break_value)]
+#![feature(unsized_locals)]
 
 #![recursion_limit="256"]
 


### PR DESCRIPTION
`FnBox` is unlikely to be ever stabilized, as `unsized_locals` fixes `Box<dyn FnOnce()>` to work.