### PR TITLE
Fix All The Databases™

### DIFF
--- a/contrib/codegen/Cargo.toml
+++ b/contrib/codegen/Cargo.toml
@@ -24,3 +24,8 @@ quote = "0.6"
 [build-dependencies]
 yansi = "0.5"
 version_check = "0.1.3"
+
+[dev-dependencies]
+compiletest_rs = { version = "0.3", features = ["stable"] }
+rocket = { version = "0.4.0", path = "../../core/lib" }
+rocket_contrib = { version = "0.4.0", path = "../lib", features = ["diesel_sqlite_pool"] }

--- a/contrib/codegen/src/database.rs
+++ b/contrib/codegen/src/database.rs
@@ -20,8 +20,8 @@ const EXAMPLE: &str = "example: `struct MyDatabase(diesel::SqliteConnection);`";
 const ONLY_ON_STRUCTS_MSG: &str = "`database` attribute can only be used on structs";
 const ONLY_UNNAMED_FIELDS: &str = "`database` attribute can only be applied to \
     structs with exactly one unnamed field";
-const NO_GENERIC_STRUCTS: &str = "`database` attribute cannot be applied to a struct \
-    with a generic type";
+const NO_GENERIC_STRUCTS: &str = "`database` attribute cannot be applied to structs \
+    with generics";
 
 fn parse_invocation(attr: TokenStream, input: TokenStream) -> Result<DatabaseInvocation> {
     let attr_stream2 = ::proc_macro2::TokenStream::from(attr);
@@ -31,7 +31,7 @@ fn parse_invocation(attr: TokenStream, input: TokenStream) -> Result<DatabaseInv
 
     let input = ::syn::parse::<DeriveInput>(input).unwrap();
     if !input.generics.params.is_empty() {
-        return Err(input.span().error(NO_GENERIC_STRUCTS));
+        return Err(input.generics.span().error(NO_GENERIC_STRUCTS));
     }
 
     let structure = match input.data {
@@ -56,34 +56,37 @@ fn parse_invocation(attr: TokenStream, input: TokenStream) -> Result<DatabaseInv
     })
 }
 
+#[allow(non_snake_case)]
 pub fn database_attr(attr: TokenStream, input: TokenStream) -> Result<TokenStream> {
     let invocation = parse_invocation(attr, input)?;
 
     // Store everything we're going to need to generate code.
-    let connection_type = &invocation.connection_type;
+    let conn_type = &invocation.connection_type;
     let name = &invocation.db_name;
-    let request_guard_type = &invocation.type_name;
+    let guard_type = &invocation.type_name;
     let vis = &invocation.visibility;
-    let pool_type = Ident::new(&format!("{}Pool", request_guard_type), request_guard_type.span());
+    let pool_type = Ident::new(&format!("{}Pool", guard_type), guard_type.span());
     let fairing_name = format!("'{}' Database Pool", name);
+    let span = conn_type.span().into();
 
     // A few useful paths.
-    let databases = quote!(::rocket_contrib::databases);
-    let r2d2 = quote!(#databases::r2d2);
+    let databases = quote_spanned!(span => ::rocket_contrib::databases);
+    let Poolable = quote_spanned!(span => #databases::Poolable);
+    let r2d2 = quote_spanned!(span => #databases::r2d2);
     let request = quote!(::rocket::request);
 
-    Ok(quote! {
+    let generated_types = quote_spanned! { span =>
         /// The request guard type.
-        #vis struct #request_guard_type(
-            pub #r2d2::PooledConnection<<#connection_type as #databases::Poolable>::Manager>
-        );
+        #vis struct #guard_type(pub #r2d2::PooledConnection<<#conn_type as #Poolable>::Manager>);
 
         /// The pool type.
-        #vis struct #pool_type(
-            #r2d2::Pool<<#connection_type as #databases::Poolable>::Manager>
-        );
+        #vis struct #pool_type(#r2d2::Pool<<#conn_type as #Poolable>::Manager>);
+    };
 
-        impl #request_guard_type {
+    Ok(quote! {
+        #generated_types
+
+        impl #guard_type {
             /// Returns a fairing that initializes the associated database
             /// connection pool.
             pub fn fairing() -> impl ::rocket::fairing::Fairing {
@@ -91,7 +94,7 @@ pub fn database_attr(attr: TokenStream, input: TokenStream) -> Result<TokenStrea
 
                 ::rocket::fairing::AdHoc::on_attach(#fairing_name, |rocket| {
                     let pool = #databases::database_config(#name, rocket.config())
-                        .map(<#connection_type>::pool);
+                        .map(<#conn_type>::pool);
 
                     match pool {
                         Ok(Ok(p)) => Ok(rocket.manage(#pool_type(p))),
@@ -117,12 +120,12 @@ pub fn database_attr(attr: TokenStream, input: TokenStream) -> Result<TokenStrea
             pub fn get_one(rocket: &::rocket::Rocket) -> Option<Self> {
                 rocket.state::<#pool_type>()
                     .and_then(|pool| pool.0.get().ok())
-                    .map(#request_guard_type)
+                    .map(#guard_type)
             }
         }
 
-        impl ::std::ops::Deref for #request_guard_type {
-            type Target = #connection_type;
+        impl ::std::ops::Deref for #guard_type {
+            type Target = #conn_type;
 
             #[inline(always)]
             fn deref(&self) -> &Self::Target {
@@ -130,14 +133,14 @@ pub fn database_attr(attr: TokenStream, input: TokenStream) -> Result<TokenStrea
             }
         }
 
-        impl ::std::ops::DerefMut for #request_guard_type {
+        impl ::std::ops::DerefMut for #guard_type {
             #[inline(always)]
             fn deref_mut(&mut self) -> &mut Self::Target {
                 &mut self.0
             }
         }
 
-        impl<'a, 'r> #request::FromRequest<'a, 'r> for #request_guard_type {
+        impl<'a, 'r> #request::FromRequest<'a, 'r> for #guard_type {
             type Error = ();
 
             fn from_request(request: &'a #request::Request<'r>) -> #request::Outcome<Self, ()> {
@@ -145,7 +148,7 @@ pub fn database_attr(attr: TokenStream, input: TokenStream) -> Result<TokenStrea
                 let pool = request.guard::<::rocket::State<#pool_type>>()?;
 
                 match pool.0.get() {
-                    Ok(conn) => Outcome::Success(#request_guard_type(conn)),
+                    Ok(conn) => Outcome::Success(#guard_type(conn)),
                     Err(_) => Outcome::Failure((Status::ServiceUnavailable, ())),
                 }
             }

--- a/contrib/codegen/src/database.rs
+++ b/contrib/codegen/src/database.rs
@@ -91,7 +91,7 @@ pub fn database_attr(attr: TokenStream, input: TokenStream) -> Result<TokenStrea
 
                 ::rocket::fairing::AdHoc::on_attach(#fairing_name, |rocket| {
                     let pool = #databases::database_config(#name, rocket.config())
-                        .map(#connection_type::pool);
+                        .map(<#connection_type>::pool);
 
                     match pool {
                         Ok(Ok(p)) => Ok(rocket.manage(#pool_type(p))),
@@ -127,6 +127,13 @@ pub fn database_attr(attr: TokenStream, input: TokenStream) -> Result<TokenStrea
             #[inline(always)]
             fn deref(&self) -> &Self::Target {
                 &self.0
+            }
+        }
+
+        impl ::std::ops::DerefMut for #request_guard_type {
+            #[inline(always)]
+            fn deref_mut(&mut self) -> &mut Self::Target {
+                &mut self.0
             }
         }
 

--- a/contrib/codegen/tests/compile-test.rs
+++ b/contrib/codegen/tests/compile-test.rs
@@ -1,0 +1,102 @@
+extern crate compiletest_rs as compiletest;
+
+use std::path::{Path, PathBuf};
+use std::{io, fs::Metadata, time::SystemTime};
+
+#[derive(Copy, Clone)]
+enum Kind {
+    #[allow(dead_code)]
+    Dynamic,
+    Static
+}
+
+impl Kind {
+    fn extension(self) -> &'static str {
+        match self {
+            #[cfg(windows)] Kind::Dynamic => ".dll",
+            #[cfg(all(unix, target_os = "macos"))] Kind::Dynamic => ".dylib",
+            #[cfg(all(unix, not(target_os = "macos")))] Kind::Dynamic => ".so",
+            Kind::Static => ".rlib"
+        }
+    }
+}
+
+fn target_path() -> PathBuf {
+    #[cfg(debug_assertions)] const ENVIRONMENT: &str = "debug";
+    #[cfg(not(debug_assertions))] const ENVIRONMENT: &str = "release";
+
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent().unwrap().parent().unwrap()
+        .join("target")
+        .join(ENVIRONMENT)
+}
+
+fn link_flag(flag: &str, lib: &str, rel_path: &[&str]) -> String {
+    let mut path = target_path();
+    for component in rel_path {
+        path = path.join(component);
+    }
+
+    format!("{} {}={}", flag, lib, path.display())
+}
+
+fn best_time_for(metadata: &Metadata) -> SystemTime {
+    metadata.created()
+        .or_else(|_| metadata.modified())
+        .or_else(|_| metadata.accessed())
+        .unwrap_or_else(|_| SystemTime::now())
+}
+
+fn extern_dep(name: &str, kind: Kind) -> io::Result<String> {
+    let deps_root = target_path().join("deps");
+    let dep_name = format!("lib{}", name);
+
+    let mut dep_path: Option<PathBuf> = None;
+    for entry in deps_root.read_dir().expect("read_dir call failed") {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(_) => continue
+        };
+
+        let filename = entry.file_name();
+        let filename = filename.to_string_lossy();
+        let lib_name = filename.split('.').next().unwrap().split('-').next().unwrap();
+
+        if lib_name == dep_name && filename.ends_with(kind.extension()) {
+            if let Some(ref mut existing) = dep_path {
+                if best_time_for(&entry.metadata()?) > best_time_for(&existing.metadata()?) {
+                    *existing = entry.path().into();
+                }
+            } else {
+                dep_path = Some(entry.path().into());
+            }
+        }
+    }
+
+    let dep = dep_path.ok_or_else(|| io::Error::from(io::ErrorKind::NotFound))?;
+    let filename = dep.file_name().ok_or_else(|| io::Error::from(io::ErrorKind::InvalidData))?;
+    Ok(link_flag("--extern", name, &["deps", &filename.to_string_lossy()]))
+}
+
+fn run_mode(mode: &'static str, path: &'static str) {
+    let mut config = compiletest::Config::default();
+    config.mode = mode.parse().expect("invalid mode");
+    config.src_base = format!("tests/{}", path).into();
+    config.clean_rmeta();
+
+    config.target_rustcflags = Some([
+        link_flag("-L", "crate", &[]),
+        link_flag("-L", "dependency", &["deps"]),
+        extern_dep("rocket_http", Kind::Static).expect("find http dep"),
+        extern_dep("rocket", Kind::Static).expect("find core dep"),
+        extern_dep("rocket_contrib", Kind::Static).expect("find contrib dep"),
+    ].join(" "));
+
+    compiletest::run_tests(&config);
+}
+
+#[test]
+fn compile_test() {
+    run_mode("ui", "ui-fail");
+    run_mode("compile-fail", "ui-fail");
+}

--- a/contrib/codegen/tests/ui-fail/database-syntax.rs
+++ b/contrib/codegen/tests/ui-fail/database-syntax.rs
@@ -1,0 +1,41 @@
+#[macro_use] extern crate rocket_contrib;
+
+use rocket_contrib::databases::diesel;
+
+#[database]
+//~^ ERROR expected string literal
+struct A(diesel::SqliteConnection);
+
+#[database(1)]
+//~^ ERROR expected string literal
+struct B(diesel::SqliteConnection);
+
+#[database(123)]
+//~^ ERROR expected string literal
+struct C(diesel::SqliteConnection);
+
+#[database("hello" "hi")]
+//~^ ERROR expected string literal
+struct D(diesel::SqliteConnection);
+
+#[database("test")]
+enum Foo {  }
+//~^ ERROR on structs
+
+#[database("test")]
+struct Bar(diesel::SqliteConnection, diesel::SqliteConnection);
+//~^ ERROR one unnamed field
+
+#[database("test")]
+union Baz {  }
+//~^ ERROR on structs
+
+#[database("test")]
+struct E<'r>(&'r str);
+//~^ ERROR generics
+
+#[database("test")]
+struct F<T>(T);
+//~^ ERROR generics
+
+fn main() {  }

--- a/contrib/codegen/tests/ui-fail/database-syntax.stderr
+++ b/contrib/codegen/tests/ui-fail/database-syntax.stderr
@@ -1,0 +1,58 @@
+error: expected string literal
+ --> $DIR/database-syntax.rs:5:1
+  |
+5 | #[database]
+  | ^^^^^^^^^^^
+
+error: expected string literal
+ --> $DIR/database-syntax.rs:9:12
+  |
+9 | #[database(1)]
+  |            ^
+
+error: expected string literal
+  --> $DIR/database-syntax.rs:13:12
+   |
+13 | #[database(123)]
+   |            ^^^
+
+error: expected string literal
+  --> $DIR/database-syntax.rs:17:12
+   |
+17 | #[database("hello" "hi")]
+   |            ^^^^^^^^^^^^
+
+error: `database` attribute can only be used on structs
+  --> $DIR/database-syntax.rs:22:1
+   |
+22 | enum Foo {  }
+   | ^^^^^^^^^^^^^
+
+error: `database` attribute can only be applied to structs with exactly one unnamed field
+  --> $DIR/database-syntax.rs:26:11
+   |
+26 | struct Bar(diesel::SqliteConnection, diesel::SqliteConnection);
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: example: `struct MyDatabase(diesel::SqliteConnection);`
+
+error: `database` attribute can only be used on structs
+  --> $DIR/database-syntax.rs:30:1
+   |
+30 | union Baz {  }
+   | ^^^^^^^^^^^^^^
+
+error: `database` attribute cannot be applied to structs with generics
+  --> $DIR/database-syntax.rs:34:9
+   |
+34 | struct E<'r>(&'r str);
+   |         ^^^^
+
+error: `database` attribute cannot be applied to structs with generics
+  --> $DIR/database-syntax.rs:38:9
+   |
+38 | struct F<T>(T);
+   |         ^^^
+
+error: aborting due to 9 previous errors
+

--- a/contrib/codegen/tests/ui-fail/database-types.rs
+++ b/contrib/codegen/tests/ui-fail/database-types.rs
@@ -7,4 +7,8 @@ struct Unknown;
 struct A(Unknown);
 //~^ ERROR Unknown: rocket_contrib::databases::Poolable
 
+#[database("foo")]
+struct B(Vec<i32>);
+//~^ ERROR Vec<i32>: rocket_contrib::databases::Poolable
+
 fn main() {  }

--- a/contrib/codegen/tests/ui-fail/database-types.rs
+++ b/contrib/codegen/tests/ui-fail/database-types.rs
@@ -1,0 +1,10 @@
+extern crate rocket;
+#[macro_use] extern crate rocket_contrib;
+
+struct Unknown;
+
+#[database("foo")]
+struct A(Unknown);
+//~^ ERROR Unknown: rocket_contrib::databases::Poolable
+
+fn main() {  }

--- a/contrib/codegen/tests/ui-fail/database-types.stderr
+++ b/contrib/codegen/tests/ui-fail/database-types.stderr
@@ -1,0 +1,9 @@
+error[E0277]: the trait bound `Unknown: rocket_contrib::databases::Poolable` is not satisfied
+ --> $DIR/database-types.rs:7:10
+  |
+7 | struct A(Unknown);
+  |          ^^^^^^^ the trait `rocket_contrib::databases::Poolable` is not implemented for `Unknown`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/contrib/codegen/tests/ui-fail/database-types.stderr
+++ b/contrib/codegen/tests/ui-fail/database-types.stderr
@@ -4,6 +4,12 @@ error[E0277]: the trait bound `Unknown: rocket_contrib::databases::Poolable` is 
 7 | struct A(Unknown);
   |          ^^^^^^^ the trait `rocket_contrib::databases::Poolable` is not implemented for `Unknown`
 
-error: aborting due to previous error
+error[E0277]: the trait bound `std::vec::Vec<i32>: rocket_contrib::databases::Poolable` is not satisfied
+  --> $DIR/database-types.rs:11:10
+   |
+11 | struct B(Vec<i32>);
+   |          ^^^^^^^^ the trait `rocket_contrib::databases::Poolable` is not implemented for `std::vec::Vec<i32>`
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/contrib/codegen/tests/ui-fail/update-references.sh
+++ b/contrib/codegen/tests/ui-fail/update-references.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution and at
+# http://rust-lang.org/COPYRIGHT.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+# A script to update the references for particular tests. The idea is
+# that you do a run, which will generate files in the build directory
+# containing the (normalized) actual output of the compiler. This
+# script will then copy that output and replace the "expected output"
+# files. You can then commit the changes.
+#
+# If you find yourself manually editing a foo.stderr file, you're
+# doing it wrong.
+
+if [[ "$1" == "--help" || "$1" == "-h" || "$1" == "" || "$2" == "" ]]; then
+    echo "usage: $0 <build-directory> <relative-path-to-rs-files>"
+    echo ""
+    echo "For example:"
+    echo "   $0 ../../../build/x86_64-apple-darwin/test/ui *.rs */*.rs"
+fi
+
+MYDIR=$(dirname $0)
+
+BUILD_DIR="$1"
+shift
+
+shopt -s nullglob
+
+while [[ "$1" != "" ]]; do
+    for EXT in "stderr" "fixed"; do
+        for OUT_NAME in $BUILD_DIR/${1%.rs}.*$EXT; do
+            OUT_DIR=`dirname "$1"`
+            OUT_BASE=`basename "$OUT_NAME"`
+            if ! (diff $OUT_NAME $MYDIR/$OUT_DIR/$OUT_BASE >& /dev/null); then
+                echo updating $MYDIR/$OUT_DIR/$OUT_BASE
+                cp $OUT_NAME $MYDIR/$OUT_DIR
+            fi
+        done
+    done
+    shift
+done

--- a/contrib/lib/Cargo.toml
+++ b/contrib/lib/Cargo.toml
@@ -61,8 +61,8 @@ r2d2 = { version = "0.8", optional = true }
 r2d2_postgres = { version = "0.14", optional = true }
 mysql = { version = "14", optional = true }
 r2d2_mysql = { version = "9", optional = true }
-rusqlite = { version = "0.14.0", optional = true }
-r2d2_sqlite = { version = "0.6", optional = true }
+rusqlite = { version = "0.15.0", optional = true }
+r2d2_sqlite = { version = "0.7", optional = true }
 rusted_cypher = { version = "1", optional = true }
 r2d2_cypher = { version = "0.4", optional = true }
 redis = { version = "0.9", optional = true }

--- a/contrib/lib/Cargo.toml
+++ b/contrib/lib/Cargo.toml
@@ -61,8 +61,8 @@ r2d2 = { version = "0.8", optional = true }
 r2d2_postgres = { version = "0.14", optional = true }
 mysql = { version = "14", optional = true }
 r2d2_mysql = { version = "9", optional = true }
-rusqlite = { version = "0.15.0", optional = true }
-r2d2_sqlite = { version = "0.7", optional = true }
+rusqlite = { version = "0.14.0", optional = true }
+r2d2_sqlite = { version = "0.6", optional = true }
 rusted_cypher = { version = "1", optional = true }
 r2d2_cypher = { version = "0.4", optional = true }
 redis = { version = "0.9", optional = true }

--- a/contrib/lib/src/databases.rs
+++ b/contrib/lib/src/databases.rs
@@ -338,7 +338,7 @@
 //! [Diesel]: https://diesel.rs
 //! [`redis::Connection`]: https://docs.rs/redis/0.9.0/redis/struct.Connection.html
 //! [`rusted_cypher::GraphClient`]: https://docs.rs/rusted_cypher/1.1.0/rusted_cypher/graph/struct.GraphClient.html
-//! [`rusqlite::Connection`]: https://docs.rs/rusqlite/0.13.0/rusqlite/struct.Connection.html
+//! [`rusqlite::Connection`]: https://docs.rs/rusqlite/0.14.0/rusqlite/struct.Connection.html
 //! [`diesel::SqliteConnection`]: http://docs.diesel.rs/diesel/prelude/struct.SqliteConnection.html
 //! [`postgres::Connection`]: https://docs.rs/postgres/0.15.2/postgres/struct.Connection.html
 //! [`diesel::PgConnection`]: http://docs.diesel.rs/diesel/pg/struct.PgConnection.html

--- a/contrib/lib/src/databases.rs
+++ b/contrib/lib/src/databases.rs
@@ -338,7 +338,7 @@
 //! [Diesel]: https://diesel.rs
 //! [`redis::Connection`]: https://docs.rs/redis/0.9.0/redis/struct.Connection.html
 //! [`rusted_cypher::GraphClient`]: https://docs.rs/rusted_cypher/1.1.0/rusted_cypher/graph/struct.GraphClient.html
-//! [`rusqlite::Connection`]: https://docs.rs/rusqlite/0.13.0/rusqlite/struct.Connection.html
+//! [`rusqlite::Connection`]: https://docs.rs/rusqlite/0.15.0/rusqlite/struct.Connection.html
 //! [`diesel::SqliteConnection`]: http://docs.diesel.rs/diesel/prelude/struct.SqliteConnection.html
 //! [`postgres::Connection`]: https://docs.rs/postgres/0.15.2/postgres/struct.Connection.html
 //! [`diesel::PgConnection`]: http://docs.diesel.rs/diesel/pg/struct.PgConnection.html

--- a/contrib/lib/src/databases.rs
+++ b/contrib/lib/src/databases.rs
@@ -338,7 +338,7 @@
 //! [Diesel]: https://diesel.rs
 //! [`redis::Connection`]: https://docs.rs/redis/0.9.0/redis/struct.Connection.html
 //! [`rusted_cypher::GraphClient`]: https://docs.rs/rusted_cypher/1.1.0/rusted_cypher/graph/struct.GraphClient.html
-//! [`rusqlite::Connection`]: https://docs.rs/rusqlite/0.15.0/rusqlite/struct.Connection.html
+//! [`rusqlite::Connection`]: https://docs.rs/rusqlite/0.13.0/rusqlite/struct.Connection.html
 //! [`diesel::SqliteConnection`]: http://docs.diesel.rs/diesel/prelude/struct.SqliteConnection.html
 //! [`postgres::Connection`]: https://docs.rs/postgres/0.15.2/postgres/struct.Connection.html
 //! [`diesel::PgConnection`]: http://docs.diesel.rs/diesel/pg/struct.PgConnection.html

--- a/contrib/lib/tests/databases.rs
+++ b/contrib/lib/tests/databases.rs
@@ -11,3 +11,37 @@ mod databases_tests {
     #[database("bar")]
     struct PrimaryDb(diesel::PgConnection);
 }
+
+#[cfg(test)]
+mod db_integration_tests {
+    use std::collections::BTreeMap;
+    use rocket::config::{Config, Environment, Value};
+    use rocket_contrib::databases::rusqlite::{self, Result, NO_PARAMS};
+    use rocket_contrib::database;
+
+    #[database("test_db")]
+    struct SqliteDb(pub rusqlite::Connection);
+
+    #[test]
+    fn deref_mut_impl_present() {
+        let mut test_db: BTreeMap<String, Value> = BTreeMap::new();
+        let mut test_db_opts: BTreeMap<String, Value> = BTreeMap::new();
+        test_db_opts.insert("url".into(), Value::String(":memory:".into()));
+        test_db.insert("test_db".into(), Value::Table(test_db_opts));
+        let config = Config::build(Environment::Development)
+            .extra("databases", Value::Table(test_db))
+            .finalize()
+            .unwrap();
+
+        let rocket = rocket::custom(config).attach(SqliteDb::fairing());
+        let connection = SqliteDb::get_one(&rocket);
+
+        assert!(connection.is_some());
+
+        let result: Result<i32> = connection.unwrap().query_row("SELECT 1", NO_PARAMS, |row| row.get(0));
+
+        println!("{:#?}", result);
+
+        assert!(result.is_ok());
+    }
+}

--- a/contrib/lib/tests/databases.rs
+++ b/contrib/lib/tests/databases.rs
@@ -35,14 +35,14 @@ mod rusqlite_integration_test {
             .unwrap();
 
         let rocket = rocket::custom(config).attach(SqliteDb::fairing());
-        let connection = SqliteDb::get_one(&rocket);
+        let mut conn = SqliteDb::get_one(&rocket).unwrap();
 
-        assert!(connection.is_some());
+        let tx = conn.transaction().unwrap();
 
-        let result: rusqlite::Result<i32> = connection.unwrap().query_row("SELECT 1", &[], |row| row.get(0));
-
-        println!("{:#?}", result);
+        let result: rusqlite::Result<i32> = tx.query_row("SELECT 1", &[], |row| row.get(0));
 
         assert!(result.is_ok());
+
+        tx.commit().unwrap();
     }
 }

--- a/contrib/lib/tests/databases.rs
+++ b/contrib/lib/tests/databases.rs
@@ -12,11 +12,12 @@ mod databases_tests {
     struct PrimaryDb(diesel::PgConnection);
 }
 
+#[cfg(all(feature = "databases", feature = "sqlite_pool"))]
 #[cfg(test)]
-mod db_integration_tests {
+mod rusqlite_integration_test {
     use std::collections::BTreeMap;
     use rocket::config::{Config, Environment, Value};
-    use rocket_contrib::databases::rusqlite::{self, Result, NO_PARAMS};
+    use rocket_contrib::databases::rusqlite;
     use rocket_contrib::database;
 
     #[database("test_db")]
@@ -38,7 +39,7 @@ mod db_integration_tests {
 
         assert!(connection.is_some());
 
-        let result: Result<i32> = connection.unwrap().query_row("SELECT 1", NO_PARAMS, |row| row.get(0));
+        let result: rusqlite::Result<i32> = connection.unwrap().query_row("SELECT 1", &[], |row| row.get(0));
 
         println!("{:#?}", result);
 

--- a/site/guide/6-state.md
+++ b/site/guide/6-state.md
@@ -193,7 +193,7 @@ Presently, Rocket provides built-in support for the following databases:
 [Diesel]: https://diesel.rs
 [`redis::Connection`]: https://docs.rs/redis/0.9.0/redis/struct.Connection.html
 [`rusted_cypher::GraphClient`]: https://docs.rs/rusted_cypher/1.1.0/rusted_cypher/graph/struct.GraphClient.html
-[`rusqlite::Connection`]: https://docs.rs/rusqlite/0.13.0/rusqlite/struct.Connection.html
+[`rusqlite::Connection`]: https://docs.rs/rusqlite/0.14.0/rusqlite/struct.Connection.html
 [`diesel::SqliteConnection`]: http://docs.diesel.rs/diesel/prelude/struct.SqliteConnection.html
 [`postgres::Connection`]: https://docs.rs/postgres/0.15.2/postgres/struct.Connection.html
 [`diesel::PgConnection`]: http://docs.diesel.rs/diesel/pg/struct.PgConnection.html

--- a/site/guide/6-state.md
+++ b/site/guide/6-state.md
@@ -193,7 +193,7 @@ Presently, Rocket provides built-in support for the following databases:
 [Diesel]: https://diesel.rs
 [`redis::Connection`]: https://docs.rs/redis/0.9.0/redis/struct.Connection.html
 [`rusted_cypher::GraphClient`]: https://docs.rs/rusted_cypher/1.1.0/rusted_cypher/graph/struct.GraphClient.html
-[`rusqlite::Connection`]: https://docs.rs/rusqlite/0.13.0/rusqlite/struct.Connection.html
+[`rusqlite::Connection`]: https://docs.rs/rusqlite/0.15.0/rusqlite/struct.Connection.html
 [`diesel::SqliteConnection`]: http://docs.diesel.rs/diesel/prelude/struct.SqliteConnection.html
 [`postgres::Connection`]: https://docs.rs/postgres/0.15.2/postgres/struct.Connection.html
 [`diesel::PgConnection`]: http://docs.diesel.rs/diesel/pg/struct.PgConnection.html

--- a/site/guide/6-state.md
+++ b/site/guide/6-state.md
@@ -193,7 +193,7 @@ Presently, Rocket provides built-in support for the following databases:
 [Diesel]: https://diesel.rs
 [`redis::Connection`]: https://docs.rs/redis/0.9.0/redis/struct.Connection.html
 [`rusted_cypher::GraphClient`]: https://docs.rs/rusted_cypher/1.1.0/rusted_cypher/graph/struct.GraphClient.html
-[`rusqlite::Connection`]: https://docs.rs/rusqlite/0.15.0/rusqlite/struct.Connection.html
+[`rusqlite::Connection`]: https://docs.rs/rusqlite/0.13.0/rusqlite/struct.Connection.html
 [`diesel::SqliteConnection`]: http://docs.diesel.rs/diesel/prelude/struct.SqliteConnection.html
 [`postgres::Connection`]: https://docs.rs/postgres/0.15.2/postgres/struct.Connection.html
 [`diesel::PgConnection`]: http://docs.diesel.rs/diesel/pg/struct.PgConnection.html


### PR DESCRIPTION
Fixes the highlighted issues in #854 and #862.

Things to do:

- [x] Add `<>` around the connection pooling type in `contrib/codegen`
- [x] Add UI/regression test for #854
- [x] implement DerefMut
- [x] Test DerefMut trait using Sqlite and `:memory:`
- [x] bump versions of Rusqlite and r2d2-sqlite in docs

### Original text below:

This commit trades the previous error message in #854 for the following:

Code:

```toml
[package]
name = "rocket-db-repro"
version = "0.1.0"
authors = ["Eric Dattore <eric.dattore@gmail.com>"]
edition = "2018"

[dependencies]
rocket = { path = "../rocket/core/lib", version = "0.4" }
rocket_contrib = { path = "../rocket/contrib/lib", version = "0.4", features = ["databases", "diesel_sqlite_pool"] }
```
```rust
use rocket_contrib::{
    database,
    databases::{diesel, r2d2_diesel}
};

#[database("sqlite")]
pub struct DbConn(pub r2d2_diesel::ConnectionManager<diesel::PgConnection>);

fn main() {}

```

Error:
```
error[E0432]: unresolved import `rocket_contrib::databases::r2d2_diesel`
 --> src/main.rs:3:25
  |
3 |     databases::{diesel, r2d2_diesel}
  |                         ^^^^^^^^^^^ no `r2d2_diesel` in `databases`

error[E0412]: cannot find type `PgConnection` in module `diesel`
 --> src/main.rs:7:62
  |
7 | pub struct DbConn(pub r2d2_diesel::ConnectionManager<diesel::PgConnection>);
  |                                                              ^^^^^^^^^^^^ did you mean `Connection`?

error: aborting due to 2 previous errors

Some errors occurred: E0412, E0432.
For more information about an error, try `rustc --explain E0412`.
error: Could not compile `rocket-db-repro`.
```