### PR TITLE
Eradicate bootstraps

### DIFF
--- a/examples/todo/bootstrap.sh
+++ b/examples/todo/bootstrap.sh
@@ -1,6 +1,0 @@
-#! /usr/bin/env bash
-
-SCRIPT_PATH=$(cd "$(dirname "$0")" ; pwd -P)
-DATABASE_URL="${SCRIPT_PATH}/db/db.sqlite"
-
-rm -f "${DATABASE_URL}"

--- a/examples/todo/src/main.rs
+++ b/examples/todo/src/main.rs
@@ -78,8 +78,8 @@ fn index(msg: Option<FlashMessage>, conn: DbConn) -> Template {
     })
 }
 
-fn rocket() -> (Rocket, Option<DbConn>) {
-    let rocket = rocket::ignite()
+fn rocket() -> Rocket {
+    rocket::ignite()
         .attach(DbConn::fairing())
         .attach(AdHoc::on_attach("Database Migrations", |rocket| {
             let conn = DbConn::get_one(&rocket).expect("database connection");
@@ -94,16 +94,9 @@ fn rocket() -> (Rocket, Option<DbConn>) {
         .mount("/", StaticFiles::from("static/"))
         .mount("/", routes![index])
         .mount("/todo", routes![new, toggle, delete])
-        .attach(Template::fairing());
-
-    let conn = match cfg!(test) {
-        true => DbConn::get_one(&rocket),
-        false => None,
-    };
-
-    (rocket, conn)
+        .attach(Template::fairing())
 }
 
 fn main() {
-    rocket().0.launch();
+    rocket().launch();
 }

--- a/examples/todo/src/task.rs
+++ b/examples/todo/src/task.rs
@@ -50,4 +50,8 @@ impl Task {
     pub fn delete_with_id(id: i32, conn: &SqliteConnection) -> bool {
         diesel::delete(all_tasks.find(id)).execute(conn).is_ok()
     }
+
+    pub fn delete_all(conn: &SqliteConnection) -> bool {
+        diesel::delete(all_tasks).execute(conn).is_ok()
+    }
 }

--- a/examples/todo/src/tests.rs
+++ b/examples/todo/src/tests.rs
@@ -16,9 +16,12 @@ static DB_LOCK: Mutex<()> = Mutex::new(());
 macro_rules! run_test {
     (|$client:ident, $conn:ident| $block:expr) => ({
         let _lock = DB_LOCK.lock();
-        let (rocket, db) = super::rocket();
+        let rocket = super::rocket();
+        let db = super::DbConn::get_one(&rocket);
         let $client = Client::new(rocket).expect("Rocket client");
         let $conn = db.expect("failed to get database connection for testing");
+        assert!(Task::delete_all(&$conn), "failed to delete all tasks for testing");
+
         $block
     })
 }

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -49,24 +49,6 @@ function ensure_trailing_whitespace_free() {
   fi
 }
 
-function bootstrap_examples() {
-  while read -r file; do
-    bootstrap_script="${file}/bootstrap.sh"
-    if [ -x "${bootstrap_script}" ]; then
-      echo "    Bootstrapping ${file}..."
-
-      env_vars=$(bash "${bootstrap_script}")
-      bootstrap_result=$?
-      if [ $bootstrap_result -ne 0 ]; then
-        echo "    Running bootstrap script (${bootstrap_script}) failed!"
-        exit 1
-      else
-        eval $env_vars
-      fi
-    fi
-  done < <(find "${EXAMPLES_DIR}" -maxdepth 1 -type d)
-}
-
 echo ":: Ensuring all crate versions match..."
 check_versions_match "${ALL_PROJECT_DIRS[@]}"
 
@@ -127,9 +109,6 @@ elif [ "$1" = "--core" ]; then
 
   popd > /dev/null 2>&1
 else
-  echo ":: Bootstrapping examples..."
-  bootstrap_examples
-
   echo ":: Building and testing libraries..."
   CARGO_INCREMENTAL=0 cargo test --all-features --all $@
 fi


### PR DESCRIPTION
Removes the only test bootstrap by using temporary files and removes the code that runs test bootstraps. I'm not entirely sold on using `temp_dir()`, but I think I'm otherwise mostly happy with the way I ended up doing this. Hopefully the CI agrees.