### PR TITLE
Small revamp of pastebin guide

### DIFF
--- a/site/guide/10-pastebin.md
+++ b/site/guide/10-pastebin.md
@@ -44,7 +44,6 @@ Then add the usual Rocket dependencies to the `Cargo.toml` file:
 ```toml
 [dependencies]
 rocket = "0.4.0"
-rocket_codegen = "0.4.0"
 ```
 
 And finally, create a skeleton Rocket application to work off of in

--- a/site/guide/10-pastebin.md
+++ b/site/guide/10-pastebin.md
@@ -178,7 +178,7 @@ Finally, add a dependency for the `rand` crate to the `Cargo.toml` file:
 ```toml
 [dependencies]
 # existing Rocket dependencies...
-rand = "0.3"
+rand = "0.6"
 ```
 
 Then, ensure that your application builds with the new code:

--- a/site/guide/10-pastebin.md
+++ b/site/guide/10-pastebin.md
@@ -303,6 +303,14 @@ fn retrieve(id: &RawStr) -> Option<File> {
 }
 ```
 
+Make sure that the route is mounted at the root path:
+
+```rust
+fn main() {
+    rocket::ignite().mount("/", routes![index, upload, retrieve]).launch();
+}
+```
+
 Unfortunately, there's a problem with this code. Can you spot the issue? The
 [`RawStr`](@api/rocket/http/struct.RawStr.html) type should tip you off!
 

--- a/site/guide/10-pastebin.md
+++ b/site/guide/10-pastebin.md
@@ -135,7 +135,7 @@ use std::borrow::Cow;
 use rand::{self, Rng};
 
 /// Table to retrieve base62 values from.
-const BASE62: &'static [u8] = b"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+const BASE62: &[u8] = b"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 
 /// A _probably_ unique paste ID.
 pub struct PasteID<'a>(Cow<'a, str>);


### PR DESCRIPTION
I went through the guide and tried to update things that were out of date or missing. I wasn't able to find any big changes for 0.4. I did look at if the URL building in `upload` could use the new `uri!` but 1) it doesn't seem to help for the case of absolute URLs and 2) it would make the code unbuildable in that intermediate time before `retrieve` exists.