### PR TITLE
Fix typo in responses guide: #[responder] -> #[response]

### DIFF
--- a/site/guide/5-responses.md
+++ b/site/guide/5-responses.md
@@ -136,7 +136,7 @@ For the example above, Rocket generates a `Responder` implementation that:
 
 Note that the _first_ field is used as the inner responder while all remaining
 fields (unless ignored with `#[response(ignore)]`) are added as headers to the
-response. The optional `#[responder]` attribute can be used to customize the
+response. The optional `#[response]` attribute can be used to customize the
 status and content-type of the response. Because `ContentType` and `Status` are
 themselves headers, you can also dynamically set the content-type and status by
 simply including fields of these types.


### PR DESCRIPTION
The [Custom Responders](https://rocket.rs/v0.4/guide/responses/#custom-responders) section of the Responses guide references an attribute that doesn't seem to be in use:

> The optional `#[responder]` attribute can be used to customize the status and content-type of the response.

Using `#[responder]` results in this error:

```
error[E0658]: The attribute `responder` is currently unknown to the compiler and may have meaning added to it in the future (see issue #29642)
 --> src/main.rs:6:3
  |
6 | #[responder(status = 202, content_type = "json")]
  |   ^^^^^^^^^
  |
  = help: add #![feature(custom_attribute)] to the crate attributes to enable
```

This change fixes the typo in the guide, changing `#[responder]` to `#[response]`.