### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ expressibility, and speed. Here's an example of a complete Rocket application:
 ```rust
 #![feature(proc_macro_hygiene, decl_macro)]
 
-#[macro_use] extern crate rocket;
+extern crate rocket;
+use rocket::{get, routes};
 
 #[get("/<name>/<age>")]
 fn hello(name: String, age: u8) -> String {


### PR DESCRIPTION
Update examples to use Rust 2018 syntax for importing macros.