### PR TITLE
Update compiler tests for 2018-12-28 nightly.

### DIFF
--- a/core/codegen/tests/ui-fail/catch.rs
+++ b/core/codegen/tests/ui-fail/catch.rs
@@ -41,3 +41,5 @@ fn f3(_request: &Request, other: bool) {
     //~^ ERROR invalid number of arguments
     //~^^ HELP optionally take an argument
 }
+
+fn main() { }

--- a/core/codegen/tests/ui-fail/from_form.rs
+++ b/core/codegen/tests/ui-fail/from_form.rs
@@ -1,5 +1,7 @@
 #[macro_use] extern crate rocket;
 
+use rocket::http::RawStr;
+
 #[derive(FromForm)]
 enum Thing { }
 //~^ ERROR not supported
@@ -162,3 +164,5 @@ struct BadName3 {
     //~^ ERROR invalid form field name
     field: String,
 }
+
+fn main() { }

--- a/core/codegen/tests/ui-fail/from_form.stderr
+++ b/core/codegen/tests/ui-fail/from_form.stderr
@@ -1,305 +1,305 @@
 error: enums are not supported
- --> $DIR/from_form.rs:4:1
+ --> $DIR/from_form.rs:6:1
   |
-4 | enum Thing { }
+6 | enum Thing { }
   | ^^^^^^^^^^^^^^
   |
 note: error occurred while deriving `FromForm`
- --> $DIR/from_form.rs:3:10
+ --> $DIR/from_form.rs:5:10
   |
-3 | #[derive(FromForm)]
+5 | #[derive(FromForm)]
   |          ^^^^^^^^
 
 error: tuple structs are not supported
- --> $DIR/from_form.rs:8:1
-  |
-8 | struct Foo1;
-  | ^^^^^^^^^^^^
-  |
+  --> $DIR/from_form.rs:10:1
+   |
+10 | struct Foo1;
+   | ^^^^^^^^^^^^
+   |
 note: error occurred while deriving `FromForm`
- --> $DIR/from_form.rs:7:10
-  |
-7 | #[derive(FromForm)]
-  |          ^^^^^^^^
+  --> $DIR/from_form.rs:9:10
+   |
+9  | #[derive(FromForm)]
+   |          ^^^^^^^^
 
 error: at least one field is required
-  --> $DIR/from_form.rs:12:1
+  --> $DIR/from_form.rs:14:1
    |
-12 | struct Foo2 {  }
+14 | struct Foo2 {  }
    | ^^^^^^^^^^^^^^^^
    |
 note: error occurred while deriving `FromForm`
-  --> $DIR/from_form.rs:11:10
+  --> $DIR/from_form.rs:13:10
    |
-11 | #[derive(FromForm)]
+13 | #[derive(FromForm)]
    |          ^^^^^^^^
 
 error: tuple structs are not supported
-  --> $DIR/from_form.rs:16:1
+  --> $DIR/from_form.rs:18:1
    |
-16 | struct Foo3(usize);
+18 | struct Foo3(usize);
    | ^^^^^^^^^^^^^^^^^^^
    |
 note: error occurred while deriving `FromForm`
-  --> $DIR/from_form.rs:15:10
+  --> $DIR/from_form.rs:17:10
    |
-15 | #[derive(FromForm)]
+17 | #[derive(FromForm)]
    |          ^^^^^^^^
 
 error: only one lifetime is supported
-  --> $DIR/from_form.rs:20:20
+  --> $DIR/from_form.rs:22:20
    |
-20 | struct NextTodoTask<'f, 'a> {
+22 | struct NextTodoTask<'f, 'a> {
    |                    ^^^^^^^^
    |
 note: error occurred while deriving `FromForm`
-  --> $DIR/from_form.rs:19:10
+  --> $DIR/from_form.rs:21:10
    |
-19 | #[derive(FromForm)]
+21 | #[derive(FromForm)]
    |          ^^^^^^^^
 
 error: invalid form field name
-  --> $DIR/from_form.rs:30:20
+  --> $DIR/from_form.rs:32:20
    |
-30 |     #[form(field = "isindex")]
+32 |     #[form(field = "isindex")]
    |                    ^^^^^^^^^
    |
 note: error occurred while deriving `FromForm`
-  --> $DIR/from_form.rs:28:10
+  --> $DIR/from_form.rs:30:10
    |
-28 | #[derive(FromForm)]
+30 | #[derive(FromForm)]
    |          ^^^^^^^^
 
 error: duplicate field name
-  --> $DIR/from_form.rs:39:5
+  --> $DIR/from_form.rs:41:5
    |
-39 |     foo: usize,
+41 |     foo: usize,
    |     ^^^
    |
 note: previous definition here
-  --> $DIR/from_form.rs:37:20
+  --> $DIR/from_form.rs:39:20
    |
-37 |     #[form(field = "foo")]
+39 |     #[form(field = "foo")]
    |                    ^^^^^
 note: error occurred while deriving `FromForm`
-  --> $DIR/from_form.rs:35:10
+  --> $DIR/from_form.rs:37:10
    |
-35 | #[derive(FromForm)]
+37 | #[derive(FromForm)]
    |          ^^^^^^^^
 
 error: duplicate field name
+  --> $DIR/from_form.rs:49:20
+   |
+49 |     #[form(field = "hello")]
+   |                    ^^^^^^^
+   |
+note: previous definition here
   --> $DIR/from_form.rs:47:20
    |
 47 |     #[form(field = "hello")]
    |                    ^^^^^^^
-   |
-note: previous definition here
-  --> $DIR/from_form.rs:45:20
-   |
-45 |     #[form(field = "hello")]
-   |                    ^^^^^^^
 note: error occurred while deriving `FromForm`
-  --> $DIR/from_form.rs:43:10
+  --> $DIR/from_form.rs:45:10
    |
-43 | #[derive(FromForm)]
+45 | #[derive(FromForm)]
    |          ^^^^^^^^
 
 error: duplicate field name
-  --> $DIR/from_form.rs:55:20
+  --> $DIR/from_form.rs:57:20
    |
-55 |     #[form(field = "first")]
+57 |     #[form(field = "first")]
    |                    ^^^^^^^
    |
 note: previous definition here
-  --> $DIR/from_form.rs:54:5
+  --> $DIR/from_form.rs:56:5
    |
-54 |     first: String,
+56 |     first: String,
    |     ^^^^^
 note: error occurred while deriving `FromForm`
-  --> $DIR/from_form.rs:52:10
+  --> $DIR/from_form.rs:54:10
    |
-52 | #[derive(FromForm)]
+54 | #[derive(FromForm)]
    |          ^^^^^^^^
 
 error: duplicate attribute parameter: field
-  --> $DIR/from_form.rs:62:28
+  --> $DIR/from_form.rs:64:28
    |
-62 |     #[form(field = "blah", field = "bloo")]
+64 |     #[form(field = "blah", field = "bloo")]
    |                            ^^^^^^^^^^^^^^
    |
 note: error occurred while deriving `FromForm`
-  --> $DIR/from_form.rs:60:10
+  --> $DIR/from_form.rs:62:10
    |
-60 | #[derive(FromForm)]
+62 | #[derive(FromForm)]
    |          ^^^^^^^^
 
 error: malformed attribute: expected list
-  --> $DIR/from_form.rs:69:7
+  --> $DIR/from_form.rs:71:7
    |
-69 |     #[form]
+71 |     #[form]
    |       ^^^^
    |
    = help: expected syntax: #[form(key = value, ..)]
 note: error occurred while deriving `FromForm`
-  --> $DIR/from_form.rs:67:10
+  --> $DIR/from_form.rs:69:10
    |
-67 | #[derive(FromForm)]
+69 | #[derive(FromForm)]
    |          ^^^^^^^^
 
 error: expected key/value pair
-  --> $DIR/from_form.rs:76:12
+  --> $DIR/from_form.rs:78:12
    |
-76 |     #[form("blah")]
+78 |     #[form("blah")]
    |            ^^^^^^
    |
 note: error occurred while deriving `FromForm`
-  --> $DIR/from_form.rs:74:10
+  --> $DIR/from_form.rs:76:10
    |
-74 | #[derive(FromForm)]
+76 | #[derive(FromForm)]
    |          ^^^^^^^^
 
 error: expected key/value pair
-  --> $DIR/from_form.rs:83:12
+  --> $DIR/from_form.rs:85:12
    |
-83 |     #[form(123)]
+85 |     #[form(123)]
    |            ^^^
    |
 note: error occurred while deriving `FromForm`
-  --> $DIR/from_form.rs:81:10
+  --> $DIR/from_form.rs:83:10
    |
-81 | #[derive(FromForm)]
+83 | #[derive(FromForm)]
    |          ^^^^^^^^
 
 error: unexpected attribute parameter: `beep`
-  --> $DIR/from_form.rs:90:12
+  --> $DIR/from_form.rs:92:12
    |
-90 |     #[form(beep = "bop")]
+92 |     #[form(beep = "bop")]
    |            ^^^^^^^^^^^^
    |
 note: error occurred while deriving `FromForm`
-  --> $DIR/from_form.rs:88:10
+  --> $DIR/from_form.rs:90:10
    |
-88 | #[derive(FromForm)]
+90 | #[derive(FromForm)]
    |          ^^^^^^^^
 
 error: duplicate invocation of `form` attribute
-  --> $DIR/from_form.rs:98:5
-   |
-98 |     #[form(field = "bleh")]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^
-   |
+   --> $DIR/from_form.rs:100:5
+    |
+100 |     #[form(field = "bleh")]
+    |     ^^^^^^^^^^^^^^^^^^^^^^^
+    |
 note: error occurred while deriving `FromForm`
-  --> $DIR/from_form.rs:95:10
-   |
-95 | #[derive(FromForm)]
-   |          ^^^^^^^^
+   --> $DIR/from_form.rs:97:10
+    |
+97  | #[derive(FromForm)]
+    |          ^^^^^^^^
 
 error: invalid value: expected string literal
-   --> $DIR/from_form.rs:105:20
+   --> $DIR/from_form.rs:107:20
     |
-105 |     #[form(field = true)]
+107 |     #[form(field = true)]
     |                    ^^^^
     |
 note: error occurred while deriving `FromForm`
-   --> $DIR/from_form.rs:103:10
+   --> $DIR/from_form.rs:105:10
     |
-103 | #[derive(FromForm)]
+105 | #[derive(FromForm)]
     |          ^^^^^^^^
 
 error: expected literal or key/value pair
-   --> $DIR/from_form.rs:112:12
+   --> $DIR/from_form.rs:114:12
     |
-112 |     #[form(field)]
+114 |     #[form(field)]
     |            ^^^^^
     |
 note: error occurred while deriving `FromForm`
-   --> $DIR/from_form.rs:110:10
+   --> $DIR/from_form.rs:112:10
     |
-110 | #[derive(FromForm)]
+112 | #[derive(FromForm)]
     |          ^^^^^^^^
 
 error: invalid value: expected string literal
-   --> $DIR/from_form.rs:119:20
+   --> $DIR/from_form.rs:121:20
     |
-119 |     #[form(field = 123)]
+121 |     #[form(field = 123)]
     |                    ^^^
     |
 note: error occurred while deriving `FromForm`
-   --> $DIR/from_form.rs:117:10
+   --> $DIR/from_form.rs:119:10
     |
-117 | #[derive(FromForm)]
+119 | #[derive(FromForm)]
     |          ^^^^^^^^
 
 error: invalid form field name
-   --> $DIR/from_form.rs:126:20
+   --> $DIR/from_form.rs:128:20
     |
-126 |     #[form(field = "hello&world")]
+128 |     #[form(field = "hello&world")]
     |                    ^^^^^^^^^^^^^
     |
 note: error occurred while deriving `FromForm`
-   --> $DIR/from_form.rs:124:10
+   --> $DIR/from_form.rs:126:10
     |
-124 | #[derive(FromForm)]
+126 | #[derive(FromForm)]
     |          ^^^^^^^^
 
 error: invalid form field name
-   --> $DIR/from_form.rs:133:20
+   --> $DIR/from_form.rs:135:20
     |
-133 |     #[form(field = "!@#$%^&*()_")]
+135 |     #[form(field = "!@#$%^&*()_")]
     |                    ^^^^^^^^^^^^^
     |
 note: error occurred while deriving `FromForm`
-   --> $DIR/from_form.rs:131:10
+   --> $DIR/from_form.rs:133:10
     |
-131 | #[derive(FromForm)]
+133 | #[derive(FromForm)]
     |          ^^^^^^^^
 
 error: invalid form field name
-   --> $DIR/from_form.rs:140:20
+   --> $DIR/from_form.rs:142:20
     |
-140 |     #[form(field = "?")]
+142 |     #[form(field = "?")]
     |                    ^^^
     |
 note: error occurred while deriving `FromForm`
-   --> $DIR/from_form.rs:138:10
+   --> $DIR/from_form.rs:140:10
     |
-138 | #[derive(FromForm)]
+140 | #[derive(FromForm)]
     |          ^^^^^^^^
 
 error: invalid form field name
-   --> $DIR/from_form.rs:147:20
+   --> $DIR/from_form.rs:149:20
     |
-147 |     #[form(field = "")]
+149 |     #[form(field = "")]
     |                    ^^
     |
 note: error occurred while deriving `FromForm`
-   --> $DIR/from_form.rs:145:10
+   --> $DIR/from_form.rs:147:10
     |
-145 | #[derive(FromForm)]
+147 | #[derive(FromForm)]
     |          ^^^^^^^^
 
 error: invalid form field name
-   --> $DIR/from_form.rs:154:20
+   --> $DIR/from_form.rs:156:20
     |
-154 |     #[form(field = "a&b")]
+156 |     #[form(field = "a&b")]
     |                    ^^^^^
     |
 note: error occurred while deriving `FromForm`
-   --> $DIR/from_form.rs:152:10
+   --> $DIR/from_form.rs:154:10
     |
-152 | #[derive(FromForm)]
+154 | #[derive(FromForm)]
     |          ^^^^^^^^
 
 error: invalid form field name
-   --> $DIR/from_form.rs:161:20
+   --> $DIR/from_form.rs:163:20
     |
-161 |     #[form(field = "a=")]
+163 |     #[form(field = "a=")]
     |                    ^^^^
     |
 note: error occurred while deriving `FromForm`
-   --> $DIR/from_form.rs:159:10
+   --> $DIR/from_form.rs:161:10
     |
-159 | #[derive(FromForm)]
+161 | #[derive(FromForm)]
     |          ^^^^^^^^
 
 error: aborting due to 24 previous errors

--- a/core/codegen/tests/ui-fail/from_form_value.rs
+++ b/core/codegen/tests/ui-fail/from_form_value.rs
@@ -43,3 +43,5 @@ enum Bar2 {
     //~^ ERROR expected literal or key/value
     A,
 }
+
+fn main() { }

--- a/core/codegen/tests/ui-fail/uri_display.rs
+++ b/core/codegen/tests/ui-fail/uri_display.rs
@@ -1,28 +1,46 @@
 #[macro_use] extern crate rocket;
 
 #[derive(UriDisplayQuery)]
+//~^ ERROR Foo1: rocket::http::uri::UriDisplay<rocket::http::uri::Query>
+//~| ERROR Foo1: rocket::http::uri::UriDisplay<rocket::http::uri::Query>
+//~| ERROR Foo1: rocket::http::uri::UriDisplay<rocket::http::uri::Query>
 struct Foo1;
 //~^ ERROR not supported
 
 #[derive(UriDisplayQuery)]
+//~^ ERROR Foo2: rocket::http::uri::UriDisplay<rocket::http::uri::Query>
+//~| ERROR Foo2: rocket::http::uri::UriDisplay<rocket::http::uri::Query>
+//~| ERROR Foo2: rocket::http::uri::UriDisplay<rocket::http::uri::Query>
 struct Foo2();
 //~^ ERROR not supported
 
 #[derive(UriDisplayQuery)]
+//~^ ERROR Foo3: rocket::http::uri::UriDisplay<rocket::http::uri::Query>
+//~| ERROR Foo3: rocket::http::uri::UriDisplay<rocket::http::uri::Query>
+//~| ERROR Foo3: rocket::http::uri::UriDisplay<rocket::http::uri::Query>
 enum Foo3 { }
 //~^ ERROR not supported
 
 #[derive(UriDisplayQuery)]
+//~^ ERROR Foo4: rocket::http::uri::UriDisplay<rocket::http::uri::Query>
+//~| ERROR Foo4: rocket::http::uri::UriDisplay<rocket::http::uri::Query>
+//~| ERROR Foo4: rocket::http::uri::UriDisplay<rocket::http::uri::Query>
 enum Foo4 {
     Variant,
     //~^ ERROR not supported
 }
 
 #[derive(UriDisplayQuery)]
+//~^ ERROR Foo5: rocket::http::uri::UriDisplay<rocket::http::uri::Query>
+//~| ERROR Foo5: rocket::http::uri::UriDisplay<rocket::http::uri::Query>
+//~| ERROR Foo5: rocket::http::uri::UriDisplay<rocket::http::uri::Query>
 struct Foo5(String, String);
 //~^ ERROR exactly one
 
 #[derive(UriDisplayQuery)]
+//~^ ERROR Foo6: rocket::http::uri::UriDisplay<rocket::http::uri::Query>
+//~| ERROR Foo6: rocket::http::uri::UriDisplay<rocket::http::uri::Query>
+//~| ERROR Foo6: rocket::http::uri::UriDisplay<rocket::http::uri::Query>
 struct Foo6 {
     #[form(field = 123)]
     //~^ ERROR invalid value: expected string
@@ -30,19 +48,29 @@ struct Foo6 {
 }
 
 #[derive(UriDisplayPath)]
+//~^ ERROR Foo7: rocket::http::uri::UriDisplay<rocket::http::uri::Path>
+//~| ERROR Foo7: rocket::http::uri::UriDisplay<rocket::http::uri::Path>
 struct Foo7(String, usize);
 //~^ ERROR exactly one
 
 #[derive(UriDisplayPath)]
+//~^ ERROR Foo8: rocket::http::uri::UriDisplay<rocket::http::uri::Path>
+//~| ERROR Foo8: rocket::http::uri::UriDisplay<rocket::http::uri::Path>
 struct Foo8;
 //~^ ERROR exactly one
 
 #[derive(UriDisplayPath)]
+//~^ ERROR Foo9: rocket::http::uri::UriDisplay<rocket::http::uri::Path>
+//~| ERROR Foo9: rocket::http::uri::UriDisplay<rocket::http::uri::Path>
 enum Foo9 {  }
 //~^ ERROR not supported
 
 #[derive(UriDisplayPath)]
+//~^ ERROR Foo10: rocket::http::uri::UriDisplay<rocket::http::uri::Path>
+//~| ERROR Foo10: rocket::http::uri::UriDisplay<rocket::http::uri::Path>
 struct Foo10 {
 //~^ ERROR not supported
     named: usize
 }
+
+fn main() { }

--- a/core/codegen/tests/ui-fail/uri_display.stderr
+++ b/core/codegen/tests/ui-fail/uri_display.stderr
@@ -1,7 +1,7 @@
 error: fieldless structs or variants are not supported
- --> $DIR/uri_display.rs:4:1
+ --> $DIR/uri_display.rs:7:1
   |
-4 | struct Foo1;
+7 | struct Foo1;
   | ^^^^^^^^^^^^
   |
 note: error occurred while deriving `UriDisplay`
@@ -11,115 +11,304 @@ note: error occurred while deriving `UriDisplay`
   |          ^^^^^^^^^^^^^^^
 
 error: fieldless structs or variants are not supported
- --> $DIR/uri_display.rs:8:1
-  |
-8 | struct Foo2();
-  | ^^^^^^^^^^^^^^
-  |
+  --> $DIR/uri_display.rs:14:1
+   |
+14 | struct Foo2();
+   | ^^^^^^^^^^^^^^
+   |
 note: error occurred while deriving `UriDisplay`
- --> $DIR/uri_display.rs:7:10
-  |
-7 | #[derive(UriDisplayQuery)]
-  |          ^^^^^^^^^^^^^^^
+  --> $DIR/uri_display.rs:10:10
+   |
+10 | #[derive(UriDisplayQuery)]
+   |          ^^^^^^^^^^^^^^^
 
 error: empty enums are not supported
-  --> $DIR/uri_display.rs:12:1
+  --> $DIR/uri_display.rs:21:1
    |
-12 | enum Foo3 { }
+21 | enum Foo3 { }
    | ^^^^^^^^^^^^^
    |
 note: error occurred while deriving `UriDisplay`
-  --> $DIR/uri_display.rs:11:10
+  --> $DIR/uri_display.rs:17:10
    |
-11 | #[derive(UriDisplayQuery)]
+17 | #[derive(UriDisplayQuery)]
    |          ^^^^^^^^^^^^^^^
 
 error: fieldless structs or variants are not supported
-  --> $DIR/uri_display.rs:17:5
+  --> $DIR/uri_display.rs:29:5
    |
-17 |     Variant,
+29 |     Variant,
    |     ^^^^^^^
    |
 note: error occurred while deriving `UriDisplay`
-  --> $DIR/uri_display.rs:15:10
+  --> $DIR/uri_display.rs:24:10
    |
-15 | #[derive(UriDisplayQuery)]
+24 | #[derive(UriDisplayQuery)]
    |          ^^^^^^^^^^^^^^^
 
 error: tuple structs or variants must have exactly one field
-  --> $DIR/uri_display.rs:22:12
+  --> $DIR/uri_display.rs:37:12
    |
-22 | struct Foo5(String, String);
+37 | struct Foo5(String, String);
    |            ^^^^^^^^^^^^^^^^
    |
 note: error occurred while deriving `UriDisplay`
-  --> $DIR/uri_display.rs:21:10
+  --> $DIR/uri_display.rs:33:10
    |
-21 | #[derive(UriDisplayQuery)]
+33 | #[derive(UriDisplayQuery)]
    |          ^^^^^^^^^^^^^^^
 
 error: invalid value: expected string literal
-  --> $DIR/uri_display.rs:27:20
+  --> $DIR/uri_display.rs:45:20
    |
-27 |     #[form(field = 123)]
+45 |     #[form(field = 123)]
    |                    ^^^
-   |
-note: error occurred while deriving `UriDisplay`
-  --> $DIR/uri_display.rs:25:10
-   |
-25 | #[derive(UriDisplayQuery)]
-   |          ^^^^^^^^^^^^^^^
-
-error: struct must have exactly one field
-  --> $DIR/uri_display.rs:33:12
-   |
-33 | struct Foo7(String, usize);
-   |            ^^^^^^^^^^^^^^^
-   |
-note: error occurred while deriving `UriDisplay`
-  --> $DIR/uri_display.rs:32:10
-   |
-32 | #[derive(UriDisplayPath)]
-   |          ^^^^^^^^^^^^^^
-
-error: struct must have exactly one field
-  --> $DIR/uri_display.rs:37:1
-   |
-37 | struct Foo8;
-   | ^^^^^^^^^^^^
-   |
-note: error occurred while deriving `UriDisplay`
-  --> $DIR/uri_display.rs:36:10
-   |
-36 | #[derive(UriDisplayPath)]
-   |          ^^^^^^^^^^^^^^
-
-error: enums are not supported
-  --> $DIR/uri_display.rs:41:1
-   |
-41 | enum Foo9 {  }
-   | ^^^^^^^^^^^^^^
    |
 note: error occurred while deriving `UriDisplay`
   --> $DIR/uri_display.rs:40:10
    |
-40 | #[derive(UriDisplayPath)]
+40 | #[derive(UriDisplayQuery)]
+   |          ^^^^^^^^^^^^^^^
+
+error: struct must have exactly one field
+  --> $DIR/uri_display.rs:53:12
+   |
+53 | struct Foo7(String, usize);
+   |            ^^^^^^^^^^^^^^^
+   |
+note: error occurred while deriving `UriDisplay`
+  --> $DIR/uri_display.rs:50:10
+   |
+50 | #[derive(UriDisplayPath)]
+   |          ^^^^^^^^^^^^^^
+
+error: struct must have exactly one field
+  --> $DIR/uri_display.rs:59:1
+   |
+59 | struct Foo8;
+   | ^^^^^^^^^^^^
+   |
+note: error occurred while deriving `UriDisplay`
+  --> $DIR/uri_display.rs:56:10
+   |
+56 | #[derive(UriDisplayPath)]
+   |          ^^^^^^^^^^^^^^
+
+error: enums are not supported
+  --> $DIR/uri_display.rs:65:1
+   |
+65 | enum Foo9 {  }
+   | ^^^^^^^^^^^^^^
+   |
+note: error occurred while deriving `UriDisplay`
+  --> $DIR/uri_display.rs:62:10
+   |
+62 | #[derive(UriDisplayPath)]
    |          ^^^^^^^^^^^^^^
 
 error: named structs are not supported
-  --> $DIR/uri_display.rs:45:1
+  --> $DIR/uri_display.rs:71:1
    |
-45 | / struct Foo10 {
-46 | | //~^ ERROR not supported
-47 | |     named: usize
-48 | | }
+71 | / struct Foo10 {
+72 | | //~^ ERROR not supported
+73 | |     named: usize
+74 | | }
    | |_^
    |
 note: error occurred while deriving `UriDisplay`
-  --> $DIR/uri_display.rs:44:10
+  --> $DIR/uri_display.rs:68:10
    |
-44 | #[derive(UriDisplayPath)]
+68 | #[derive(UriDisplayPath)]
    |          ^^^^^^^^^^^^^^
 
-error: aborting due to 10 previous errors
+error[E0277]: the trait bound `Foo1: rocket::http::uri::UriDisplay<rocket::http::uri::Query>` is not satisfied
+ --> $DIR/uri_display.rs:3:10
+  |
+3 | #[derive(UriDisplayQuery)]
+  |          ^^^^^^^^^^^^^^^ the trait `rocket::http::uri::UriDisplay<rocket::http::uri::Query>` is not implemented for `Foo1`
 
+error[E0277]: the trait bound `Foo1: rocket::http::uri::UriDisplay<rocket::http::uri::Query>` is not satisfied
+ --> $DIR/uri_display.rs:3:10
+  |
+3 | #[derive(UriDisplayQuery)]
+  |          ^^^^^^^^^^^^^^^ the trait `rocket::http::uri::UriDisplay<rocket::http::uri::Query>` is not implemented for `Foo1`
+  |
+  = note: required because of the requirements on the impl of `rocket::http::uri::UriDisplay<rocket::http::uri::Query>` for `&Foo1`
+
+error[E0277]: the trait bound `Foo1: rocket::http::uri::UriDisplay<rocket::http::uri::Query>` is not satisfied
+ --> $DIR/uri_display.rs:3:10
+  |
+3 | #[derive(UriDisplayQuery)]
+  |          ^^^^^^^^^^^^^^^ the trait `rocket::http::uri::UriDisplay<rocket::http::uri::Query>` is not implemented for `Foo1`
+  |
+  = note: required because of the requirements on the impl of `rocket::http::uri::UriDisplay<rocket::http::uri::Query>` for `&mut Foo1`
+
+error[E0277]: the trait bound `Foo2: rocket::http::uri::UriDisplay<rocket::http::uri::Query>` is not satisfied
+  --> $DIR/uri_display.rs:10:10
+   |
+10 | #[derive(UriDisplayQuery)]
+   |          ^^^^^^^^^^^^^^^ the trait `rocket::http::uri::UriDisplay<rocket::http::uri::Query>` is not implemented for `Foo2`
+
+error[E0277]: the trait bound `Foo2: rocket::http::uri::UriDisplay<rocket::http::uri::Query>` is not satisfied
+  --> $DIR/uri_display.rs:10:10
+   |
+10 | #[derive(UriDisplayQuery)]
+   |          ^^^^^^^^^^^^^^^ the trait `rocket::http::uri::UriDisplay<rocket::http::uri::Query>` is not implemented for `Foo2`
+   |
+   = note: required because of the requirements on the impl of `rocket::http::uri::UriDisplay<rocket::http::uri::Query>` for `&Foo2`
+
+error[E0277]: the trait bound `Foo2: rocket::http::uri::UriDisplay<rocket::http::uri::Query>` is not satisfied
+  --> $DIR/uri_display.rs:10:10
+   |
+10 | #[derive(UriDisplayQuery)]
+   |          ^^^^^^^^^^^^^^^ the trait `rocket::http::uri::UriDisplay<rocket::http::uri::Query>` is not implemented for `Foo2`
+   |
+   = note: required because of the requirements on the impl of `rocket::http::uri::UriDisplay<rocket::http::uri::Query>` for `&mut Foo2`
+
+error[E0277]: the trait bound `Foo3: rocket::http::uri::UriDisplay<rocket::http::uri::Query>` is not satisfied
+  --> $DIR/uri_display.rs:17:10
+   |
+17 | #[derive(UriDisplayQuery)]
+   |          ^^^^^^^^^^^^^^^ the trait `rocket::http::uri::UriDisplay<rocket::http::uri::Query>` is not implemented for `Foo3`
+
+error[E0277]: the trait bound `Foo3: rocket::http::uri::UriDisplay<rocket::http::uri::Query>` is not satisfied
+  --> $DIR/uri_display.rs:17:10
+   |
+17 | #[derive(UriDisplayQuery)]
+   |          ^^^^^^^^^^^^^^^ the trait `rocket::http::uri::UriDisplay<rocket::http::uri::Query>` is not implemented for `Foo3`
+   |
+   = note: required because of the requirements on the impl of `rocket::http::uri::UriDisplay<rocket::http::uri::Query>` for `&Foo3`
+
+error[E0277]: the trait bound `Foo3: rocket::http::uri::UriDisplay<rocket::http::uri::Query>` is not satisfied
+  --> $DIR/uri_display.rs:17:10
+   |
+17 | #[derive(UriDisplayQuery)]
+   |          ^^^^^^^^^^^^^^^ the trait `rocket::http::uri::UriDisplay<rocket::http::uri::Query>` is not implemented for `Foo3`
+   |
+   = note: required because of the requirements on the impl of `rocket::http::uri::UriDisplay<rocket::http::uri::Query>` for `&mut Foo3`
+
+error[E0277]: the trait bound `Foo4: rocket::http::uri::UriDisplay<rocket::http::uri::Query>` is not satisfied
+  --> $DIR/uri_display.rs:24:10
+   |
+24 | #[derive(UriDisplayQuery)]
+   |          ^^^^^^^^^^^^^^^ the trait `rocket::http::uri::UriDisplay<rocket::http::uri::Query>` is not implemented for `Foo4`
+
+error[E0277]: the trait bound `Foo4: rocket::http::uri::UriDisplay<rocket::http::uri::Query>` is not satisfied
+  --> $DIR/uri_display.rs:24:10
+   |
+24 | #[derive(UriDisplayQuery)]
+   |          ^^^^^^^^^^^^^^^ the trait `rocket::http::uri::UriDisplay<rocket::http::uri::Query>` is not implemented for `Foo4`
+   |
+   = note: required because of the requirements on the impl of `rocket::http::uri::UriDisplay<rocket::http::uri::Query>` for `&Foo4`
+
+error[E0277]: the trait bound `Foo4: rocket::http::uri::UriDisplay<rocket::http::uri::Query>` is not satisfied
+  --> $DIR/uri_display.rs:24:10
+   |
+24 | #[derive(UriDisplayQuery)]
+   |          ^^^^^^^^^^^^^^^ the trait `rocket::http::uri::UriDisplay<rocket::http::uri::Query>` is not implemented for `Foo4`
+   |
+   = note: required because of the requirements on the impl of `rocket::http::uri::UriDisplay<rocket::http::uri::Query>` for `&mut Foo4`
+
+error[E0277]: the trait bound `Foo5: rocket::http::uri::UriDisplay<rocket::http::uri::Query>` is not satisfied
+  --> $DIR/uri_display.rs:33:10
+   |
+33 | #[derive(UriDisplayQuery)]
+   |          ^^^^^^^^^^^^^^^ the trait `rocket::http::uri::UriDisplay<rocket::http::uri::Query>` is not implemented for `Foo5`
+
+error[E0277]: the trait bound `Foo5: rocket::http::uri::UriDisplay<rocket::http::uri::Query>` is not satisfied
+  --> $DIR/uri_display.rs:33:10
+   |
+33 | #[derive(UriDisplayQuery)]
+   |          ^^^^^^^^^^^^^^^ the trait `rocket::http::uri::UriDisplay<rocket::http::uri::Query>` is not implemented for `Foo5`
+   |
+   = note: required because of the requirements on the impl of `rocket::http::uri::UriDisplay<rocket::http::uri::Query>` for `&Foo5`
+
+error[E0277]: the trait bound `Foo5: rocket::http::uri::UriDisplay<rocket::http::uri::Query>` is not satisfied
+  --> $DIR/uri_display.rs:33:10
+   |
+33 | #[derive(UriDisplayQuery)]
+   |          ^^^^^^^^^^^^^^^ the trait `rocket::http::uri::UriDisplay<rocket::http::uri::Query>` is not implemented for `Foo5`
+   |
+   = note: required because of the requirements on the impl of `rocket::http::uri::UriDisplay<rocket::http::uri::Query>` for `&mut Foo5`
+
+error[E0277]: the trait bound `Foo6: rocket::http::uri::UriDisplay<rocket::http::uri::Query>` is not satisfied
+  --> $DIR/uri_display.rs:40:10
+   |
+40 | #[derive(UriDisplayQuery)]
+   |          ^^^^^^^^^^^^^^^ the trait `rocket::http::uri::UriDisplay<rocket::http::uri::Query>` is not implemented for `Foo6`
+
+error[E0277]: the trait bound `Foo6: rocket::http::uri::UriDisplay<rocket::http::uri::Query>` is not satisfied
+  --> $DIR/uri_display.rs:40:10
+   |
+40 | #[derive(UriDisplayQuery)]
+   |          ^^^^^^^^^^^^^^^ the trait `rocket::http::uri::UriDisplay<rocket::http::uri::Query>` is not implemented for `Foo6`
+   |
+   = note: required because of the requirements on the impl of `rocket::http::uri::UriDisplay<rocket::http::uri::Query>` for `&Foo6`
+
+error[E0277]: the trait bound `Foo6: rocket::http::uri::UriDisplay<rocket::http::uri::Query>` is not satisfied
+  --> $DIR/uri_display.rs:40:10
+   |
+40 | #[derive(UriDisplayQuery)]
+   |          ^^^^^^^^^^^^^^^ the trait `rocket::http::uri::UriDisplay<rocket::http::uri::Query>` is not implemented for `Foo6`
+   |
+   = note: required because of the requirements on the impl of `rocket::http::uri::UriDisplay<rocket::http::uri::Query>` for `&mut Foo6`
+
+error[E0277]: the trait bound `Foo7: rocket::http::uri::UriDisplay<rocket::http::uri::Path>` is not satisfied
+  --> $DIR/uri_display.rs:50:10
+   |
+50 | #[derive(UriDisplayPath)]
+   |          ^^^^^^^^^^^^^^ the trait `rocket::http::uri::UriDisplay<rocket::http::uri::Path>` is not implemented for `Foo7`
+
+error[E0277]: the trait bound `Foo7: rocket::http::uri::UriDisplay<rocket::http::uri::Path>` is not satisfied
+  --> $DIR/uri_display.rs:50:10
+   |
+50 | #[derive(UriDisplayPath)]
+   |          ^^^^^^^^^^^^^^ the trait `rocket::http::uri::UriDisplay<rocket::http::uri::Path>` is not implemented for `Foo7`
+   |
+   = note: required because of the requirements on the impl of `rocket::http::uri::UriDisplay<rocket::http::uri::Path>` for `&Foo7`
+
+error[E0277]: the trait bound `Foo8: rocket::http::uri::UriDisplay<rocket::http::uri::Path>` is not satisfied
+  --> $DIR/uri_display.rs:56:10
+   |
+56 | #[derive(UriDisplayPath)]
+   |          ^^^^^^^^^^^^^^ the trait `rocket::http::uri::UriDisplay<rocket::http::uri::Path>` is not implemented for `Foo8`
+
+error[E0277]: the trait bound `Foo8: rocket::http::uri::UriDisplay<rocket::http::uri::Path>` is not satisfied
+  --> $DIR/uri_display.rs:56:10
+   |
+56 | #[derive(UriDisplayPath)]
+   |          ^^^^^^^^^^^^^^ the trait `rocket::http::uri::UriDisplay<rocket::http::uri::Path>` is not implemented for `Foo8`
+   |
+   = note: required because of the requirements on the impl of `rocket::http::uri::UriDisplay<rocket::http::uri::Path>` for `&Foo8`
+
+error[E0277]: the trait bound `Foo9: rocket::http::uri::UriDisplay<rocket::http::uri::Path>` is not satisfied
+  --> $DIR/uri_display.rs:62:10
+   |
+62 | #[derive(UriDisplayPath)]
+   |          ^^^^^^^^^^^^^^ the trait `rocket::http::uri::UriDisplay<rocket::http::uri::Path>` is not implemented for `Foo9`
+
+error[E0277]: the trait bound `Foo9: rocket::http::uri::UriDisplay<rocket::http::uri::Path>` is not satisfied
+  --> $DIR/uri_display.rs:62:10
+   |
+62 | #[derive(UriDisplayPath)]
+   |          ^^^^^^^^^^^^^^ the trait `rocket::http::uri::UriDisplay<rocket::http::uri::Path>` is not implemented for `Foo9`
+   |
+   = note: required because of the requirements on the impl of `rocket::http::uri::UriDisplay<rocket::http::uri::Path>` for `&Foo9`
+
+error[E0277]: the trait bound `Foo10: rocket::http::uri::UriDisplay<rocket::http::uri::Path>` is not satisfied
+  --> $DIR/uri_display.rs:68:10
+   |
+68 | #[derive(UriDisplayPath)]
+   |          ^^^^^^^^^^^^^^ the trait `rocket::http::uri::UriDisplay<rocket::http::uri::Path>` is not implemented for `Foo10`
+
+error[E0277]: the trait bound `Foo10: rocket::http::uri::UriDisplay<rocket::http::uri::Path>` is not satisfied
+  --> $DIR/uri_display.rs:68:10
+   |
+68 | #[derive(UriDisplayPath)]
+   |          ^^^^^^^^^^^^^^ the trait `rocket::http::uri::UriDisplay<rocket::http::uri::Path>` is not implemented for `Foo10`
+   |
+   = note: required because of the requirements on the impl of `rocket::http::uri::UriDisplay<rocket::http::uri::Path>` for `&Foo10`
+
+error: aborting due to 36 previous errors
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
The 2018-12-28 nightly (Probably [`fff01cc`](https://github.com/rust-lang/rust/pull/56999/commits/fff01ccfa805ccef67827bf1ea84e21d61d13e6f) in rust-lang/rust#56999) exposed some more errors in the compiler tests, two trivial:

* a few missing `fn main`
* a missing `use rocket::http::RawStr;`

And one annoying one:

The derives for `UriDisplay{Path,Query}` also derive `FromUriParam`. Since the 2018-12-28 nightly, `FooX: UriDisplay<Path>` failing to be implemented shows up again as unsatisfied trait bounds for the implementation of `FromUriParam`. I'm not thrilled with the current error output but wanted to at least ensure it passes the CI with this change.

One possible fix would be to add a trivial where constraint (`impl FromUriParam<...> for &Foo1 where Foo1: UriDisplay<...>`), but that feels inappropriate as a way to fix error messages and requires use of another unstable feature.