### PR TITLE
Correctly quote version number in sample Cargo.toml.

### DIFF
--- a/contrib/lib/src/templates/mod.rs
+++ b/contrib/lib/src/templates/mod.rs
@@ -9,7 +9,7 @@
 //!
 //!      ```toml
 //!      [dependencies.rocket_contrib]
-//!      version = 0.4.0
+//!      version = "0.4.0"
 //!      default-features = false
 //!      features = ["handlebars_templates", "tera_templates"]
 //!      ```


### PR DESCRIPTION
The version number needs to be quoted in `Cargo.toml`. This PR fixes an example in the docs that wasn't quoted.