### PR TITLE
Add support for Range requests

### DIFF
--- a/core/lib/src/response/mod.rs
+++ b/core/lib/src/response/mod.rs
@@ -34,7 +34,7 @@ pub mod status;
 #[doc(hidden)] pub use rocket_codegen::Responder;
 
 pub use self::response::{Response, ResponseBuilder, Body, DEFAULT_CHUNK_SIZE};
-pub use self::responder::Responder;
+pub use self::responder::{RangeResponder, Responder};
 pub use self::redirect::Redirect;
 pub use self::flash::Flash;
 pub use self::named_file::NamedFile;

--- a/core/lib/src/response/responder.rs
+++ b/core/lib/src/response/responder.rs
@@ -272,6 +272,8 @@ impl<'r, B: io::Seek + io::Read + 'r> Responder<'r> for RangeResponder<B> {
 
                         let (start, end) = match ranges[0] {
                             ByteRangeSpec::FromTo(start, mut end) => {
+                                // make end exclusive
+                                end += 1;
                                 if end > size {
                                     end = size;
                                 }
@@ -304,7 +306,8 @@ impl<'r, B: io::Seek + io::Read + 'r> Responder<'r> for RangeResponder<B> {
                             .status(Status::PartialContent)
                             .header(AcceptRanges(vec![RangeUnit::Bytes]))
                             .header(ContentRange(ContentRangeSpec::Bytes {
-                                range: Some((start, end)),
+                                // make end inclusive again
+                                range: Some((start, end - 1)),
                                 instance_length: Some(size),
                             }))
                             .raw_body(Body::Sized(body, end - start))

--- a/core/lib/src/response/responder.rs
+++ b/core/lib/src/response/responder.rs
@@ -319,7 +319,11 @@ impl<'r> Responder<'r> for Vec<u8> {
 /// Returns a response with a sized body for the file. Always returns `Ok`.
 impl<'r> Responder<'r> for File {
     fn respond_to(self, req: &Request) -> response::Result<'r> {
-        RangeResponder(BufReader::new(self)).respond_to(req)
+        let (metadata, file) = (self.metadata(), BufReader::new(self));
+        match metadata {
+            Ok(_) => RangeResponder(file).respond_to(req),
+            Err(_) => Response::build().streamed_body(file).ok()
+        }        
     }
 }
 

--- a/core/lib/src/response/responder.rs
+++ b/core/lib/src/response/responder.rs
@@ -275,7 +275,7 @@ impl<'r, B: io::Seek + io::Read + 'r> Responder<'r> for RangeResponder<B> {
                             .header(AcceptRanges(vec![RangeUnit::Bytes]))
                             .header(ContentRange(ContentRangeSpec::Bytes {
                                 range: Some((start, end)),
-                                instance_length: Some(end - start),
+                                instance_length: Some(size),
                             }))
                             .raw_body(Body::Sized(body, end - start))
                             .ok()

--- a/core/lib/src/response/responder.rs
+++ b/core/lib/src/response/responder.rs
@@ -228,7 +228,7 @@ impl<'r, B: io::Seek + io::Read + 'r> Responder<'r> for RangeResponder<B> {
 
         let mut body = self.0; 
         //  A server MUST ignore a Range header field received with a request method other than GET.
-        if req.method() != Method::Get {
+        if req.method() == Method::Get {
             let range = req.headers().get_one("Range").and_then(|x| Range::from_str(x).ok());
             match range {
                 Some(Range::Bytes(ranges)) => {

--- a/core/lib/src/response/responder.rs
+++ b/core/lib/src/response/responder.rs
@@ -223,7 +223,6 @@ pub struct RangeResponder<B: io::Seek + io::Read>(pub B);
 
 impl<'r, B: io::Seek + io::Read + 'r> Responder<'r> for RangeResponder<B> {
     fn respond_to(self, req: &Request) -> response::Result<'r> {
-        use std::cmp;
         use http::hyper::header::{ContentRange, ByteRangeSpec, ContentRangeSpec};
 
         let mut body = self.0; 
@@ -263,7 +262,7 @@ impl<'r, B: io::Seek + io::Read + 'r> Responder<'r> for RangeResponder<B> {
                                 // but the RFC reads:
                                 //      If the selected representation is shorter than the specified
                                 //      suffix-length, the entire representation is used.
-                                let start = cmp::max(size - len, 0);
+                                let start = size.checked_sub(len).unwrap_or(0);
                                 (start, size - start)
                             }
                         };

--- a/core/lib/src/response/responder.rs
+++ b/core/lib/src/response/responder.rs
@@ -260,7 +260,7 @@ impl<'r, B: io::Seek + io::Read + 'r> Responder<'r> for RangeResponder<B> {
     fn respond_to(self, req: &Request) -> response::Result<'r> {
         use http::hyper::header::{ContentRange, ByteRangeSpec, ContentRangeSpec};
 
-        let mut body = self.0; 
+        let mut body = self.0;
         //  A server MUST ignore a Range header field received with a request method other than GET.
         if req.method() == Method::Get {
             let range = req.headers().get_one("Range").map(|x| Range::from_str(x));
@@ -269,7 +269,7 @@ impl<'r, B: io::Seek + io::Read + 'r> Responder<'r> for RangeResponder<B> {
                     if ranges.len() == 1 {
                         let size = body.seek(io::SeekFrom::End(0))
                             .expect("Attempted to retrieve size by seeking, but failed.");
-                        
+
                         let (start, end) = match ranges[0] {
                             ByteRangeSpec::FromTo(mut start, mut end) => {
                                 if start > size {
@@ -359,7 +359,7 @@ impl<'r> Responder<'r> for File {
         match metadata {
             Ok(_) => RangeResponder(file).respond_to(req),
             Err(_) => Response::build().streamed_body(file).ok()
-        }        
+        }
     }
 }
 

--- a/core/lib/src/response/responder.rs
+++ b/core/lib/src/response/responder.rs
@@ -58,20 +58,21 @@ use request::Request;
 ///
 ///     Sets the `Content-Type` to `application/octet-stream`. The slice
 ///     is used as the body of the response, which is fixed size and not
-///     streamed. To stream a slice of bytes, use
+///     streamed. Supports range requests. To stream a slice of bytes, use
 ///     `Stream::from(Cursor::new(data))`.
 ///
 ///   * **Vec&lt;u8>**
 ///
 ///     Sets the `Content-Type` to `application/octet-stream`. The vector's data
 ///     is used as the body of the response, which is fixed size and not
-///     streamed. To stream a vector of bytes, use
+///     streamed. Supports range requests. To stream a vector of bytes, use
 ///     `Stream::from(Cursor::new(vec))`.
 ///
 ///   * **File**
 ///
 ///     Responds with a streamed body containing the data in the `File`. No
-///     `Content-Type` is set. To automatically have a `Content-Type` set based
+///     `Content-Type` is set. Supports range requests.
+///     To automatically have a `Content-Type` set based
 ///     on the file's extension, use [`NamedFile`](::response::NamedFile).
 ///
 ///   * **()**

--- a/core/lib/src/response/responder.rs
+++ b/core/lib/src/response/responder.rs
@@ -255,7 +255,7 @@ impl<'r, B: io::Seek + io::Read + 'r> Responder<'r> for RangeResponder<B> {
                                 if start > size {
                                     start = size;
                                 }
-                                (start, size - start)
+                                (start, size)
                             },
                             ByteRangeSpec::Last(len) => {
                                 // we could seek to SeekFrom::End(-len), but if we reach a value < 0, that is an error.
@@ -263,7 +263,7 @@ impl<'r, B: io::Seek + io::Read + 'r> Responder<'r> for RangeResponder<B> {
                                 //      If the selected representation is shorter than the specified
                                 //      suffix-length, the entire representation is used.
                                 let start = size.checked_sub(len).unwrap_or(0);
-                                (start, size - start)
+                                (start, size)
                             }
                         };
 

--- a/core/lib/src/response/responder.rs
+++ b/core/lib/src/response/responder.rs
@@ -219,62 +219,55 @@ impl<'r> Responder<'r> for String {
     }
 }
 
-fn try_range_response<'r, B: io::Read + io::Seek + 'r>(req: Request<'r>, mut body: B) -> Result<response::Response<'r>, B> {
+fn range_response<'r, B: io::Seek + io::Read + 'r>(mut body: B, req: &Request) -> Response<'r> {
     use std::cmp;
     use http::hyper::header::{ContentRange, ByteRangeSpec, ContentRangeSpec};
-
+    
     //  A server MUST ignore a Range header field received with a request method other than GET.
-    if req.method() == Method::Get {
-        return Err(body);
-    }
-     
-    let range = req.headers().get_one("Range").and_then(Range::from_str).map_err(|_| body)?;
-         
-    match range {
-        Range::Bytes(ranges) => {
-            if ranges.len() == 1 {
-                let size = body.seek(io::SeekFrom::End(0))
-                    .expect("Attempted to retrieve size by seeking, but failed.");
-                
-                let (start, end) = match ranges[0] {
-                    ByteRangeSpec::FromTo(mut start, mut end) => {
-                        if end < start {
-                            return Ok(
-                                Response::build()
+    if req.method() != Method::Get {
+        let range = req.headers().get_one("Range").and_then(|x| Range::from_str(x).ok());
+        match range {
+            Some(Range::Bytes(ranges)) => {
+                if ranges.len() == 1 {
+                    let size = body.seek(io::SeekFrom::End(0))
+                        .expect("Attempted to retrieve size by seeking, but failed.");
+                    
+                    let (start, end) = match ranges[0] {
+                        ByteRangeSpec::FromTo(mut start, mut end) => {
+                            if end < start {
+                                return Response::build()
                                     .status(Status::RangeNotSatisfiable)
                                     .header(AcceptRanges(vec![RangeUnit::Bytes]))
                                     .finalize()
-                            );
+                            }
+                            if start > size {
+                                start = size;
+                            }
+                            if end > size {
+                                end = size;
+                            }
+                            (start, end)
+                        },
+                        ByteRangeSpec::AllFrom(mut start) => {
+                            if start > size {
+                                start = size;
+                            }
+                            (start, size - start)
+                        },
+                        ByteRangeSpec::Last(len) => {
+                            // we could seek to SeekFrom::End(-len), but if we reach a value < 0, that is an error.
+                            // but the RFC reads:
+                            //      If the selected representation is shorter than the specified
+                            //      suffix-length, the entire representation is used.
+                            let start = cmp::max(size - len, 0);
+                            (start, size - start)
                         }
-                        if start > size {
-                            start = size;
-                        }
-                        if end > size {
-                            end = size;
-                        }
-                        (start, end)
-                    },
-                    ByteRangeSpec::AllFrom(mut start) => {
-                        if start > size {
-                            start = size;
-                        }
-                        (start, size - start)
-                    },
-                    ByteRangeSpec::Last(len) => {
-                        // we could seek to SeekFrom::End(-len), but if we reach a value < 0, that is an error.
-                        // but the RFC reads:
-                        //      If the selected representation is shorter than the specified
-                        //      suffix-length, the entire representation is used.
-                        let start = cmp::max(size - len, 0);
-                        (start, size - start)
-                    }
-                };
+                    };
 
-                body.seek(io::SeekFrom::Start(start))
-                    .expect("Attempted to seek to the start of the requested range, but failed.");
+                    body.seek(io::SeekFrom::Start(start))
+                        .expect("Attempted to seek to the start of the requested range, but failed.");
 
-                return Ok(
-                    Response::build()
+                    return Response::build()
                         .status(Status::PartialContent)
                         .header(AcceptRanges(vec![RangeUnit::Bytes]))
                         .header(ContentRange(ContentRangeSpec::Bytes {
@@ -283,36 +276,28 @@ fn try_range_response<'r, B: io::Read + io::Seek + 'r>(req: Request<'r>, mut bod
                         }))
                         .raw_body(Body::Sized(body, end - start))
                         .finalize()
-                )
-            }
-            // A server MAY ignore the Range header field.
-        },
-        // An origin server MUST ignore a Range header field that contains a
-        // range unit it does not understand.
-        Range::Unregistered(_, _) => {},
-    };
+                }
+                // A server MAY ignore the Range header field.
+            },
+            // An origin server MUST ignore a Range header field that contains a
+            // range unit it does not understand.
+            Some(Range::Unregistered(_, _)) => {},
+            None => {},
+        };
+    }
 
-    Err(body)
+    Response::build()
+        .header(AcceptRanges(vec![RangeUnit::Bytes]))
+        .sized_body(body)
+        .finalize()
 }
 
 /// Returns a response with Content-Type `application/octet-stream` and a
 /// fixed-size body containing the data in `self`. Always returns `Ok`.
 impl<'r> Responder<'r> for &'r [u8] {
     fn respond_to(self, req: &Request) -> response::Result<'r> {
-        let mut body = Cursor::new(self);
-        
-        match try_range_response(req, body) {
-            Ok(mut resp) => {
-                resp.set_header(ContentType::Binary);
-                return Ok(resp)
-            },
-            Err(old_body) => body = old_body,
-        };
-
-        Response::build()
+        Response::build_from(range_response(Cursor::new(self), req))
             .header(ContentType::Binary)
-            .header(AcceptRanges(vec![RangeUnit::Bytes]))
-            .sized_body(body)
             .ok()
     }
 }
@@ -321,20 +306,8 @@ impl<'r> Responder<'r> for &'r [u8] {
 /// fixed-size body containing the data in `self`. Always returns `Ok`.
 impl<'r> Responder<'r> for Vec<u8> {
     fn respond_to(self, req: &Request) -> response::Result<'r> {
-        let mut body = Cursor::new(self);
-
-        match try_range_response(req, body) {
-            Ok(mut resp) => {
-                resp.set_header(ContentType::Binary);
-                return Ok(resp)
-            },
-            Err(old_body) => body = old_body,
-        };
-
-        Response::build()
+        Response::build_from(range_response(Cursor::new(self), req))
             .header(ContentType::Binary)
-            .header(AcceptRanges(vec![RangeUnit::Bytes]))
-            .sized_body(body)
             .ok()
     }
 }
@@ -342,21 +315,7 @@ impl<'r> Responder<'r> for Vec<u8> {
 /// Returns a response with a sized body for the file. Always returns `Ok`.
 impl<'r> Responder<'r> for File {
     fn respond_to(self, req: &Request) -> response::Result<'r> {
-        let (metadata, mut file) = (self.metadata(), BufReader::new(self));
-        match metadata {
-            Ok(md) => {
-                match try_range_response(req, body) {
-                    Ok(mut resp) => return Ok(resp),
-                    Err(old_body) => body = old_body,
-                };
-
-                Response::build()
-                .header(AcceptRanges(vec![RangeUnit::Bytes]))
-                .raw_body(Body::Sized(file, md.len()))
-                .ok()
-            },
-            Err(_) => Response::build().streamed_body(file).ok()
-        }
+        Response::build_from(range_response(BufReader::new(self), req)).ok()
     }
 }
 

--- a/core/lib/src/rocket.rs
+++ b/core/lib/src/rocket.rs
@@ -143,9 +143,11 @@ impl Rocket {
                 hyp_res.start()?.end()
             }
             Some(Body::Sized(body, size)) => {
+                use std::io::Read;
+
                 hyp_res.headers_mut().set(header::ContentLength(size));
                 let mut stream = hyp_res.start()?;
-                io::copy(body, &mut stream)?;
+                io::copy(&mut body.take(size), &mut stream)?;
                 stream.end()
             }
             Some(Body::Chunked(mut body, chunk_size)) => {

--- a/core/lib/tests/range_responses.rs
+++ b/core/lib/tests/range_responses.rs
@@ -43,7 +43,7 @@ mod tests {
             assert_eq!(headers.get_one("Content-Range"), Some("bytes 1-4/10"));
         }
 
-        assert_eq!(response.body_bytes(), Some(vec![1, 2, 3]));
+        assert_eq!(response.body_bytes(), Some(vec![1, 2, 3, 4]));
     }
 
     #[test]
@@ -59,18 +59,11 @@ mod tests {
     #[test]
     fn range_between_overflow() {
         let client = Client::new(rocket()).unwrap();
-        let mut response = client.get("/")
+        let response = client.get("/")
             .header(Range::bytes(11, 12))
             .dispatch();
 
-        assert_eq!(response.status(), Status::PartialContent);
-
-        {
-            let headers = response.headers();
-            assert_eq!(headers.get_one("Content-Range"), Some("bytes 10-10/10"));
-        }
-
-        assert_eq!(response.body_bytes(), Some(vec![]));
+        assert_eq!(response.status(), Status::RangeNotSatisfiable);
     }
 
     #[test]
@@ -86,7 +79,7 @@ mod tests {
 
         {
             let headers = response.headers();
-            assert_eq!(headers.get_one("Content-Range"), Some("bytes 4-10/10"));
+            assert_eq!(headers.get_one("Content-Range"), Some("bytes 4-9/10"));
         }
 
         assert_eq!(response.body_bytes(), Some(vec![4, 5, 6, 7, 8, 9]));
@@ -95,20 +88,13 @@ mod tests {
     #[test]
     fn range_from_overflow() {
         let client = Client::new(rocket()).unwrap();
-        let mut response = client.get("/")
+        let response = client.get("/")
             .header(Range::Bytes(vec![
                 ByteRangeSpec::AllFrom(12),
             ]))
             .dispatch();
 
-        assert_eq!(response.status(), Status::PartialContent);
-
-        {
-            let headers = response.headers();
-            assert_eq!(headers.get_one("Content-Range"), Some("bytes 10-10/10"));
-        }
-
-        assert_eq!(response.body_bytes(), Some(vec![]));
+        assert_eq!(response.status(), Status::RangeNotSatisfiable);
     }
 
     #[test]
@@ -124,7 +110,7 @@ mod tests {
 
         {
             let headers = response.headers();
-            assert_eq!(headers.get_one("Content-Range"), Some("bytes 7-10/10"));
+            assert_eq!(headers.get_one("Content-Range"), Some("bytes 7-9/10"));
         }
 
         assert_eq!(response.body_bytes(), Some(vec![7, 8, 9]));
@@ -143,7 +129,7 @@ mod tests {
 
         {
             let headers = response.headers();
-            assert_eq!(headers.get_one("Content-Range"), Some("bytes 0-10/10"));
+            assert_eq!(headers.get_one("Content-Range"), Some("bytes 0-9/10"));
         }
 
         assert_eq!(response.body_bytes(), Some(Vec::from(data())));

--- a/core/lib/tests/range_responses.rs
+++ b/core/lib/tests/range_responses.rs
@@ -1,0 +1,151 @@
+#![feature(proc_macro_hygiene, decl_macro)]
+
+#[macro_use] extern crate rocket;
+
+#[get("/")]
+fn data() -> &'static [u8] {
+    &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+}
+
+mod tests {
+    use super::*;
+
+    use rocket::Rocket;
+    use rocket::local::Client;
+    use rocket::http::Status;
+    use rocket::http::hyper::header::{Range, ByteRangeSpec};
+    
+    fn rocket() -> Rocket {
+        rocket::ignite()
+            .mount("/", routes![data])
+    }
+
+    #[test]
+    fn head() {
+        let client = Client::new(rocket()).unwrap();
+        let response = client.head("/").dispatch();
+        let headers = response.headers();
+
+        assert_eq!(headers.get_one("Accept-Ranges"), Some("bytes"));
+    }
+
+    #[test]
+    fn range_between() {
+        let client = Client::new(rocket()).unwrap();
+        let mut response = client.get("/")
+            .header(Range::bytes(1, 4))
+            .dispatch();
+        
+        assert_eq!(response.status(), Status::PartialContent);
+        
+        {
+            let headers = response.headers();
+            assert_eq!(headers.get_one("Content-Range"), Some("bytes 1-4/10"));
+        }
+
+        assert_eq!(response.body_bytes(), Some(vec![1, 2, 3]));
+    }
+    
+    #[test]
+    fn range_between_invalid() {
+        let client = Client::new(rocket()).unwrap();
+        let response = client.get("/")
+            .header(Range::bytes(4, 2))
+            .dispatch();
+        
+        assert_eq!(response.status(), Status::RangeNotSatisfiable);
+    }
+    
+    #[test]
+    fn range_between_overflow() {
+        let client = Client::new(rocket()).unwrap();
+        let mut response = client.get("/")
+            .header(Range::bytes(11, 12))
+            .dispatch();
+        
+        assert_eq!(response.status(), Status::PartialContent);
+        
+        {
+            let headers = response.headers();
+            assert_eq!(headers.get_one("Content-Range"), Some("bytes 10-10/10"));
+        }
+
+        assert_eq!(response.body_bytes(), Some(vec![]));
+    }
+
+    #[test]
+    fn range_from() {
+        let client = Client::new(rocket()).unwrap();
+        let mut response = client.get("/")
+            .header(Range::Bytes(vec![
+                ByteRangeSpec::AllFrom(4),
+            ]))
+            .dispatch();
+
+        assert_eq!(response.status(), Status::PartialContent);
+        
+        {
+            let headers = response.headers();
+            assert_eq!(headers.get_one("Content-Range"), Some("bytes 4-10/10"));
+        }
+
+        assert_eq!(response.body_bytes(), Some(vec![4, 5, 6, 7, 8, 9]));
+    }
+
+    #[test]
+    fn range_from_overflow() {
+        let client = Client::new(rocket()).unwrap();
+        let mut response = client.get("/")
+            .header(Range::Bytes(vec![
+                ByteRangeSpec::AllFrom(12),
+            ]))
+            .dispatch();
+        
+        assert_eq!(response.status(), Status::PartialContent);
+        
+        {
+            let headers = response.headers();
+            assert_eq!(headers.get_one("Content-Range"), Some("bytes 10-10/10"));
+        }
+
+        assert_eq!(response.body_bytes(), Some(vec![]));
+    }
+
+    #[test]
+    fn range_last() {
+        let client = Client::new(rocket()).unwrap();
+        let mut response = client.get("/")
+            .header(Range::Bytes(vec![
+                ByteRangeSpec::Last(3),
+            ]))
+            .dispatch();
+
+        assert_eq!(response.status(), Status::PartialContent);
+        
+        {
+            let headers = response.headers();
+            assert_eq!(headers.get_one("Content-Range"), Some("bytes 7-10/10"));
+        }
+
+        assert_eq!(response.body_bytes(), Some(vec![7, 8, 9]));
+    }
+    
+    #[test]
+    fn range_last_overflow() {
+        let client = Client::new(rocket()).unwrap();
+        let mut response = client.get("/")
+            .header(Range::Bytes(vec![
+                ByteRangeSpec::Last(12),
+            ]))
+            .dispatch();
+
+        assert_eq!(response.status(), Status::PartialContent);
+        
+        {
+            let headers = response.headers();
+            assert_eq!(headers.get_one("Content-Range"), Some("bytes 0-10/10"));
+        }
+
+        assert_eq!(response.body_bytes(), Some(Vec::from(data())));
+    }
+}

--- a/core/lib/tests/range_responses.rs
+++ b/core/lib/tests/range_responses.rs
@@ -14,7 +14,7 @@ mod tests {
     use rocket::local::Client;
     use rocket::http::Status;
     use rocket::http::hyper::header::{Range, ByteRangeSpec};
-    
+
     fn rocket() -> Rocket {
         rocket::ignite()
             .mount("/", routes![data])
@@ -35,9 +35,9 @@ mod tests {
         let mut response = client.get("/")
             .header(Range::bytes(1, 4))
             .dispatch();
-        
+
         assert_eq!(response.status(), Status::PartialContent);
-        
+
         {
             let headers = response.headers();
             assert_eq!(headers.get_one("Content-Range"), Some("bytes 1-4/10"));
@@ -45,26 +45,26 @@ mod tests {
 
         assert_eq!(response.body_bytes(), Some(vec![1, 2, 3]));
     }
-    
+
     #[test]
     fn range_between_invalid() {
         let client = Client::new(rocket()).unwrap();
         let response = client.get("/")
             .header(Range::bytes(4, 2))
             .dispatch();
-        
+
         assert_eq!(response.status(), Status::RangeNotSatisfiable);
     }
-    
+
     #[test]
     fn range_between_overflow() {
         let client = Client::new(rocket()).unwrap();
         let mut response = client.get("/")
             .header(Range::bytes(11, 12))
             .dispatch();
-        
+
         assert_eq!(response.status(), Status::PartialContent);
-        
+
         {
             let headers = response.headers();
             assert_eq!(headers.get_one("Content-Range"), Some("bytes 10-10/10"));
@@ -83,7 +83,7 @@ mod tests {
             .dispatch();
 
         assert_eq!(response.status(), Status::PartialContent);
-        
+
         {
             let headers = response.headers();
             assert_eq!(headers.get_one("Content-Range"), Some("bytes 4-10/10"));
@@ -100,9 +100,9 @@ mod tests {
                 ByteRangeSpec::AllFrom(12),
             ]))
             .dispatch();
-        
+
         assert_eq!(response.status(), Status::PartialContent);
-        
+
         {
             let headers = response.headers();
             assert_eq!(headers.get_one("Content-Range"), Some("bytes 10-10/10"));
@@ -121,7 +121,7 @@ mod tests {
             .dispatch();
 
         assert_eq!(response.status(), Status::PartialContent);
-        
+
         {
             let headers = response.headers();
             assert_eq!(headers.get_one("Content-Range"), Some("bytes 7-10/10"));
@@ -129,7 +129,7 @@ mod tests {
 
         assert_eq!(response.body_bytes(), Some(vec![7, 8, 9]));
     }
-    
+
     #[test]
     fn range_last_overflow() {
         let client = Client::new(rocket()).unwrap();
@@ -140,7 +140,7 @@ mod tests {
             .dispatch();
 
         assert_eq!(response.status(), Status::PartialContent);
-        
+
         {
             let headers = response.headers();
             assert_eq!(headers.get_one("Content-Range"), Some("bytes 0-10/10"));


### PR DESCRIPTION
This is an attempt to fix #806 (at least partially).

This transparently handles `Range` requests for `&[u8]`, `Vec<u8>`, `File` and `NamedFile`, when the total size is known, allowing partial downloads.

It also advertises this feature for the listed types by adding an `AcceptRanges` header.

The implementation follows the [MDN examples](https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests) and the corresponding [RFC](https://tools.ietf.org/html/rfc7233), but only supports `Single part ranges`, which is compliant with the RFC, as a server may choose to ignore or reject any range request.

`Multipart ranges` would most likely be better implemented as a custom `Body` variant and would be more complicated. I have no use case for those, which is why I did not bother, but if that would be blocking and someone can provide some directions/suggestion on how to implement those (I am not very familiar with rocket's codebase), I would try to tackle that as well. But I would strongly prefer to do that in a separate PR.

I am looking for some initial feedback on the approach. I did implement it in the corresponding `Responder` implementations to have access to the `Range` header of the request and the response as well. It seemed fitting. But it would probably also be possible to just parse the header in the `Responder` and just store that in the `Response` or `Body` and deal with it later in the chain (when writing out the `Response` for example).

Docs and Tests are completely lacking, also formatting was not working well, `cargo fmt` changed the whole codebase. So I would appreciate some more comments on what I should provide on those subjects as well.

Thanks for your time :)