### PR TITLE
Support raw identifiers (e.g. r#type) in forms and in route functions.

### DIFF
--- a/core/codegen/src/attribute/route.rs
+++ b/core/codegen/src/attribute/route.rs
@@ -7,7 +7,7 @@ use devise::ext::{SpanDiagnosticExt, TypeExt};
 use indexmap::IndexSet;
 
 use crate::proc_macro_ext::{Diagnostics, StringLit};
-use crate::syn_ext::IdentExt;
+use crate::syn_ext::{IdentExt, NameSource};
 use crate::proc_macro2::{TokenStream, Span};
 use crate::http_codegen::{Method, MediaType, RoutePath, DataSegment, Optional};
 use crate::attribute::segments::{Source, Kind, Segment};
@@ -48,7 +48,7 @@ struct Route {
     /// The parsed inputs to the user's function. The first ident is the ident
     /// as the user wrote it, while the second ident is the identifier that
     /// should be used during code generation, the `rocket_ident`.
-    inputs: Vec<(syn::Ident, syn::Ident, syn::Type)>,
+    inputs: Vec<(NameSource, syn::Ident, syn::Type)>,
 }
 
 fn parse_route(attr: RouteAttribute, function: syn::ItemFn) -> Result<Route> {
@@ -74,7 +74,7 @@ fn parse_route(attr: RouteAttribute, function: syn::ItemFn) -> Result<Route> {
         for segment in iter.filter(|s| s.is_dynamic()) {
             let span = segment.span;
             if let Some(previous) = set.replace(segment.clone()) {
-                diags.push(span.error(format!("duplicate parameter: `{}`", previous.name))
+                diags.push(span.error(format!("duplicate parameter: `{}`", previous.name.name()))
                     .span_note(previous.span, "previous parameter with the same name here"))
             }
         }
@@ -110,7 +110,7 @@ fn parse_route(attr: RouteAttribute, function: syn::ItemFn) -> Result<Route> {
         };
 
         let rocket_ident = ident.prepend(ROCKET_PARAM_PREFIX);
-        inputs.push((ident.clone(), rocket_ident, ty.with_stripped_lifetimes()));
+        inputs.push((ident.clone().into(), rocket_ident, ty.with_stripped_lifetimes()));
         fn_segments.insert(ident.into());
     }
 
@@ -118,7 +118,7 @@ fn parse_route(attr: RouteAttribute, function: syn::ItemFn) -> Result<Route> {
     let span = function.sig.paren_token.span;
     for missing in segments.difference(&fn_segments) {
         diags.push(missing.span.error("unused dynamic parameter")
-            .span_note(span, format!("expected argument named `{}` here", missing.name)))
+            .span_note(span, format!("expected argument named `{}` here", missing.name.name())))
     }
 
     diags.head_err_or(Route { attribute: attr, function, inputs, segments })
@@ -207,10 +207,10 @@ fn query_exprs(route: &Route) -> Option<TokenStream> {
     let query_segments = route.attribute.path.query.as_ref()?;
     let (mut decls, mut matchers, mut builders) = (vec![], vec![], vec![]);
     for segment in query_segments {
-        let name = &segment.name;
+        let name = segment.name.name();
         let (ident, ty, span) = if segment.kind != Kind::Static {
             let (ident, ty) = route.inputs.iter()
-                .find(|(ident, _, _)| ident == &segment.name)
+                .find(|(name, _, _)| name == &segment.name)
                 .map(|(_, rocket_ident, ty)| (rocket_ident, ty))
                 .unwrap();
 
@@ -327,8 +327,8 @@ fn generate_internal_uri_macro(route: &Route) -> TokenStream {
         .filter(|seg| seg.source == Source::Path || seg.source == Source::Query)
         .filter(|seg| seg.kind != Kind::Static)
         .map(|seg| &seg.name)
-        .map(|name| route.inputs.iter().find(|(ident, ..)| ident == name).unwrap())
-        .map(|(ident, _, ty)| quote!(#ident: #ty));
+        .map(|name| route.inputs.iter().find(|(name2, ..)| name2 == name).unwrap())
+        .map(|(name, _, ty)| { let id = name.ident().unwrap(); quote!(#id: #ty) });
 
     let mut hasher = DefaultHasher::new();
     route.function.sig.ident.hash(&mut hasher);
@@ -385,8 +385,8 @@ fn codegen_route(route: Route) -> Result<TokenStream> {
     let mut data_stmt = None;
     let mut req_guard_definitions = vec![];
     let mut parameter_definitions = vec![];
-    for (ident, rocket_ident, ty) in &route.inputs {
-        let fn_segment: Segment = ident.into();
+    for (name, rocket_ident, ty) in &route.inputs {
+        let fn_segment: Segment = name.ident().unwrap().into();
         match route.segments.get(&fn_segment) {
             Some(seg) if seg.source == Source::Path => {
                 parameter_definitions.push(param_expr(seg, rocket_ident, &ty));

--- a/core/codegen/src/attribute/route.rs
+++ b/core/codegen/src/attribute/route.rs
@@ -74,7 +74,7 @@ fn parse_route(attr: RouteAttribute, function: syn::ItemFn) -> Result<Route> {
         for segment in iter.filter(|s| s.is_dynamic()) {
             let span = segment.span;
             if let Some(previous) = set.replace(segment.clone()) {
-                diags.push(span.error(format!("duplicate parameter: `{}`", previous.name.name()))
+                diags.push(span.error(format!("duplicate parameter: `{}`", previous.name))
                     .span_note(previous.span, "previous parameter with the same name here"))
             }
         }
@@ -118,7 +118,7 @@ fn parse_route(attr: RouteAttribute, function: syn::ItemFn) -> Result<Route> {
     let span = function.sig.paren_token.span;
     for missing in segments.difference(&fn_segments) {
         diags.push(missing.span.error("unused dynamic parameter")
-            .span_note(span, format!("expected argument named `{}` here", missing.name.name())))
+            .span_note(span, format!("expected argument named `{}` here", missing.name)))
     }
 
     diags.head_err_or(Route { attribute: attr, function, inputs, segments })
@@ -207,7 +207,6 @@ fn query_exprs(route: &Route) -> Option<TokenStream> {
     let query_segments = route.attribute.path.query.as_ref()?;
     let (mut decls, mut matchers, mut builders) = (vec![], vec![], vec![]);
     for segment in query_segments {
-        let name = segment.name.name();
         let (ident, ty, span) = if segment.kind != Kind::Static {
             let (ident, ty) = route.inputs.iter()
                 .find(|(name, _, _)| name == &segment.name)
@@ -232,6 +231,7 @@ fn query_exprs(route: &Route) -> Option<TokenStream> {
             Kind::Static => quote!()
         };
 
+        let name = segment.name.name();
         let matcher = match segment.kind {
             Kind::Single => quote_spanned! { span =>
                 (_, #name, __v) => {
@@ -327,8 +327,9 @@ fn generate_internal_uri_macro(route: &Route) -> TokenStream {
         .filter(|seg| seg.source == Source::Path || seg.source == Source::Query)
         .filter(|seg| seg.kind != Kind::Static)
         .map(|seg| &seg.name)
-        .map(|name| route.inputs.iter().find(|(name2, ..)| name2 == name).unwrap())
-        .map(|(name, _, ty)| { let id = name.ident().unwrap(); quote!(#id: #ty) });
+        .map(|seg_name| route.inputs.iter().find(|(in_name, ..)| in_name == seg_name).unwrap())
+        .map(|(name, _, ty)| (name.ident(), ty))
+        .map(|(ident, ty)| quote!(#ident: #ty));
 
     let mut hasher = DefaultHasher::new();
     route.function.sig.ident.hash(&mut hasher);
@@ -386,7 +387,7 @@ fn codegen_route(route: Route) -> Result<TokenStream> {
     let mut req_guard_definitions = vec![];
     let mut parameter_definitions = vec![];
     for (name, rocket_ident, ty) in &route.inputs {
-        let fn_segment: Segment = name.ident().unwrap().into();
+        let fn_segment: Segment = name.ident().into();
         match route.segments.get(&fn_segment) {
             Some(seg) if seg.source == Source::Path => {
                 parameter_definitions.push(param_expr(seg, rocket_ident, &ty));

--- a/core/codegen/src/attribute/segments.rs
+++ b/core/codegen/src/attribute/segments.rs
@@ -36,7 +36,7 @@ impl Segment {
         };
 
         let (kind, index) = (segment.kind, segment.index);
-        Segment { span, kind, source, index, name: NameSource::from(segment.name.to_string()) }
+        Segment { span, kind, source, index, name: NameSource::new(&segment.name, span) }
     }
 
     pub fn is_wild(&self) -> bool {

--- a/core/codegen/src/attribute/segments.rs
+++ b/core/codegen/src/attribute/segments.rs
@@ -6,6 +6,7 @@ use crate::proc_macro2::Span;
 use crate::http::uri::{self, UriPart};
 use crate::http::route::RouteSegment;
 use crate::proc_macro_ext::{Diagnostics, StringLit, PResult, DResult};
+use crate::syn_ext::NameSource;
 
 pub use crate::http::route::{Error, Kind};
 
@@ -14,7 +15,7 @@ pub struct Segment {
     pub span: Span,
     pub kind: Kind,
     pub source: Source,
-    pub name: String,
+    pub name: NameSource,
     pub index: Option<usize>,
 }
 
@@ -35,7 +36,7 @@ impl Segment {
         };
 
         let (kind, index) = (segment.kind, segment.index);
-        Segment { span, kind, source, index, name: segment.name.into_owned() }
+        Segment { span, kind, source, index, name: NameSource::from(segment.name.to_string()) }
     }
 
     pub fn is_wild(&self) -> bool {
@@ -56,7 +57,7 @@ impl From<&syn::Ident> for Segment {
             kind: Kind::Static,
             source: Source::Unknown,
             span: ident.span(),
-            name: ident.to_string(),
+            name: ident.clone().into(),
             index: None,
         }
     }

--- a/core/codegen/src/bang/uri_parsing.rs
+++ b/core/codegen/src/bang/uri_parsing.rs
@@ -231,9 +231,9 @@ impl InternalUriParams {
                 let (mut extra, mut dup) = (vec![], vec![]);
                 for (name, expr) in args.named().unwrap() {
                     match params.get_mut(name) {
-                        Some(ref entry) if entry.is_some() => dup.push(name.ident().unwrap()),
+                        Some(ref entry) if entry.is_some() => dup.push(name.ident()),
                         Some(entry) => *entry = Some(expr),
-                        None => extra.push(name.ident().unwrap()),
+                        None => extra.push(name.ident()),
                     }
                 }
 
@@ -339,7 +339,10 @@ impl ToTokens for Arg {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         match self {
             Arg::Unnamed(e) => e.to_tokens(tokens),
-            Arg::Named(name, eq, expr) => { let id = name.ident().unwrap(); tokens.extend(quote!(#id #eq #expr)) },
+            Arg::Named(name, eq, expr) => {
+                let ident = name.ident();
+                tokens.extend(quote!(#ident #eq #expr))
+            }
         }
     }
 }

--- a/core/codegen/src/derive/from_form.rs
+++ b/core/codegen/src/derive/from_form.rs
@@ -87,10 +87,10 @@ pub fn derive_from_form(input: proc_macro::TokenStream) -> TokenStream {
             define_vars_and_mods!(_None, _Some, _Ok, _Err);
             let (constructors, matchers, builders) = fields.iter().map(|field| {
                 let (ident, span) = (&field.ident, field.span());
-                let default_name_source = NameSource::from(ident.clone().expect("named"));
-                let name_source = Form::from_attrs("form", &field.attrs)
+                let default_name = NameSource::from(ident.clone().expect("named"));
+                let name = Form::from_attrs("form", &field.attrs)
                     .map(|result| result.map(|form| form.field.name))
-                    .unwrap_or_else(|| Ok(default_name_source))?;
+                    .unwrap_or_else(|| Ok(default_name))?;
 
                 let ty = field.ty.with_stripped_lifetimes();
                 let ty = quote_spanned! {
@@ -99,7 +99,7 @@ pub fn derive_from_form(input: proc_macro::TokenStream) -> TokenStream {
 
                 let constructor = quote_spanned!(span => let mut #ident = #_None;);
 
-                let name = name_source.name();
+                let name = name.name();
                 let matcher = quote_spanned! { span =>
                     #name => { #ident = #_Some(#ty::from_form_value(__v)
                                 .map_err(|_| #form_error::BadValue(__k, __v))?); },

--- a/core/codegen/src/derive/from_form_value.rs
+++ b/core/codegen/src/derive/from_form_value.rs
@@ -48,7 +48,7 @@ pub fn derive_from_form_value(input: proc_macro::TokenStream) -> TokenStream {
 
             let variant_str = variant_name_source.name();
 
-            let builder = variant.builder(|_| unreachable!());
+            let builder = variant.builder(|_| unreachable!("no fields"));
             Ok(quote! {
                 if uncased == #variant_str {
                     return #_Ok(#builder);

--- a/core/codegen/src/derive/uri_display.rs
+++ b/core/codegen/src/derive/uri_display.rs
@@ -62,7 +62,6 @@ pub fn derive_uri_display_query(input: proc_macro::TokenStream) -> TokenStream {
                     .unwrap_or_else(|| Ok(ident.clone().into()))?;
 
                 let name = name_source.name();
-
                 quote_spanned!(span => f.write_named_value(#name, &#accessor)?;)
             } else {
                 quote_spanned!(span => f.write_value(&#accessor)?;)

--- a/core/codegen/src/derive/uri_display.rs
+++ b/core/codegen/src/derive/uri_display.rs
@@ -57,9 +57,11 @@ pub fn derive_uri_display_query(input: proc_macro::TokenStream) -> TokenStream {
             let span = field.span().into();
             let accessor = field.accessor();
             let tokens = if let Some(ref ident) = field.ident {
-                let name = Form::from_attrs("form", &field.attrs)
+                let name_source = Form::from_attrs("form", &field.attrs)
                     .map(|result| result.map(|form| form.field.name))
-                    .unwrap_or_else(|| Ok(ident.to_string()))?;
+                    .unwrap_or_else(|| Ok(ident.clone().into()))?;
+
+                let name = name_source.name();
 
                 quote_spanned!(span => f.write_named_value(#name, &#accessor)?;)
             } else {

--- a/core/codegen/src/syn_ext.rs
+++ b/core/codegen/src/syn_ext.rs
@@ -1,6 +1,7 @@
 //! Extensions to `syn` types.
 
-use devise::syn;
+use devise::ext::SpanDiagnosticExt;
+use devise::syn::{self, Ident, ext::IdentExt as _};
 
 pub trait IdentExt {
     fn prepend(&self, string: &str) -> syn::Ident;
@@ -9,7 +10,7 @@ pub trait IdentExt {
 
 impl IdentExt for syn::Ident {
     fn prepend(&self, string: &str) -> syn::Ident {
-        syn::Ident::new(&format!("{}{}", string, self), self.span())
+        syn::Ident::new(&format!("{}{}", string, self.unraw()), self.span())
     }
 
     fn append(&self, string: &str) -> syn::Ident {
@@ -40,5 +41,87 @@ impl TokenStreamExt for crate::proc_macro2::TokenStream {
             token.set_span(span);
             token
         }).collect()
+    }
+}
+
+/// Represents the source of a name; usually either a string or an Ident. It is
+/// normally constructed using FromMeta, From<String>, or From<Ident> depending
+/// on the source.
+///
+/// NameSource implements Hash, PartialEq, and Eq, and additionally PartialEq<S>
+/// for all types `S: AsStr<str>`. These implementations all compare the value
+/// of `name()` only.
+#[derive(Debug, Clone)]
+pub struct NameSource {
+    name: String,
+    ident: Option<Ident>,
+}
+
+impl NameSource {
+    /// Returns the name as a string. Notably, if this NameSource was
+    /// constructed from an Ident this method returns a name *without* an `r#`
+    /// prefix.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Returns the Ident this NameSource was originally constructed from,
+    /// if applicable.
+    pub fn ident(&self) -> Option<&Ident> {
+        self.ident.as_ref()
+    }
+}
+
+impl devise::FromMeta for NameSource {
+    fn from_meta(meta: devise::MetaItem<'_>) -> devise::Result<Self> {
+        if let syn::Lit::Str(s) = meta.lit()? {
+            return Ok(Self { name: s.value(), ident: None });
+        }
+
+        Err(meta.value_span().error("invalid value: expected string literal"))
+    }
+}
+
+impl From<Ident> for NameSource {
+    fn from(ident: Ident) -> Self {
+        Self {
+            name: ident.unraw().to_string(),
+            ident: Some(ident),
+        }
+    }
+}
+
+impl From<String> for NameSource {
+    fn from(string: String) -> Self {
+        Self {
+            name: string,
+            ident: None,
+        }
+    }
+}
+
+impl std::hash::Hash for NameSource {
+    fn hash<H: std::hash::Hasher>(&self, hasher: &mut H) {
+        self.name.hash(hasher)
+    }
+}
+
+impl PartialEq for NameSource {
+    fn eq(&self, other: &Self) -> bool {
+        self.name() == other.name()
+    }
+}
+
+impl Eq for NameSource { }
+
+impl<S: AsRef<str>> PartialEq<S> for NameSource {
+    fn eq(&self, other: &S) -> bool {
+        self.name == other.as_ref()
+    }
+}
+
+impl std::fmt::Display for NameSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.name().fmt(f)
     }
 }

--- a/core/codegen/src/syn_ext.rs
+++ b/core/codegen/src/syn_ext.rs
@@ -44,9 +44,9 @@ impl TokenStreamExt for crate::proc_macro2::TokenStream {
     }
 }
 
-/// Represents the source of a name; usually either a string or an Ident. It is
-/// normally constructed using FromMeta, From<String>, or From<Ident> depending
-/// on the source.
+/// Represents the source of a name read by codegen, which may or may not be a
+/// valid identifier: this usually either a string or an Ident. A `NameSource`
+/// is typically constructed indirectly via FromMeta, or From<Ident>.
 ///
 /// NameSource implements Hash, PartialEq, and Eq, and additionally PartialEq<S>
 /// for all types `S: AsStr<str>`. These implementations all compare the value
@@ -58,24 +58,34 @@ pub struct NameSource {
 }
 
 impl NameSource {
-    /// Returns the name as a string. Notably, if this NameSource was
-    /// constructed from an Ident this method returns a name *without* an `r#`
-    /// prefix.
+    /// Creates a new `NameSource` from the string `name` and span `span`. If
+    /// `name` is a valid ident, the ident is stored as well.
+    pub fn new<S: AsRef<str>>(name: S, span: crate::proc_macro2::Span) -> Self {
+        let name = name.as_ref();
+        syn::parse_str::<Ident>(name)
+            .map(|mut ident| { ident.set_span(span); ident })
+            .map(|ident| NameSource::from(ident))
+            .unwrap_or_else(|_| NameSource { name: name.into(), ident: None })
+    }
+
+    /// Returns the name as a string. Notably, if `self` was constructed from an
+    /// Ident this method returns a name *without* an `r#` prefix.
     pub fn name(&self) -> &str {
         &self.name
     }
 
-    /// Returns the Ident this NameSource was originally constructed from,
-    /// if applicable.
-    pub fn ident(&self) -> Option<&Ident> {
-        self.ident.as_ref()
+    /// Returns the Ident corresponding to `self`, if any, otherwise panics. If
+    /// `self` was constructed from an `Ident`, this never panics. Otherwise,
+    /// panics if the string `self` was constructed from was not a valid ident.
+    pub fn ident(&self) -> &Ident {
+        self.ident.as_ref().expect("ident from namesource")
     }
 }
 
 impl devise::FromMeta for NameSource {
     fn from_meta(meta: devise::MetaItem<'_>) -> devise::Result<Self> {
         if let syn::Lit::Str(s) = meta.lit()? {
-            return Ok(Self { name: s.value(), ident: None });
+            return Ok(NameSource::new(s.value(), s.span()));
         }
 
         Err(meta.value_span().error("invalid value: expected string literal"))
@@ -84,25 +94,13 @@ impl devise::FromMeta for NameSource {
 
 impl From<Ident> for NameSource {
     fn from(ident: Ident) -> Self {
-        Self {
-            name: ident.unraw().to_string(),
-            ident: Some(ident),
-        }
-    }
-}
-
-impl From<String> for NameSource {
-    fn from(string: String) -> Self {
-        Self {
-            name: string,
-            ident: None,
-        }
+        Self { name: ident.unraw().to_string(), ident: Some(ident), }
     }
 }
 
 impl std::hash::Hash for NameSource {
     fn hash<H: std::hash::Hasher>(&self, hasher: &mut H) {
-        self.name.hash(hasher)
+        self.name().hash(hasher)
     }
 }
 

--- a/core/codegen/tests/from_form.rs
+++ b/core/codegen/tests/from_form.rs
@@ -317,3 +317,14 @@ fn form_errors() {
     let form: Result<WhoopsForm, _> = strict("complete=true");
     assert_eq!(form, Err(FormParseError::Missing("other".into())));
 }
+
+#[derive(Debug, PartialEq, FromForm)]
+struct RawIdentForm {
+    r#type: String,
+}
+
+#[test]
+fn raw_ident_form() {
+    let form: Result<RawIdentForm, _> = strict("type=a");
+    assert_eq!(form, Ok(RawIdentForm { r#type: "a".into() }));
+}

--- a/core/codegen/tests/from_form_value.rs
+++ b/core/codegen/tests/from_form_value.rs
@@ -65,3 +65,17 @@ fn from_form_value_renames() {
     assert_parse!(":book", ":BOOK", ":bOOk", ":booK" => Foo::Book);
     assert_no_parse!("book", "bar" => Foo);
 }
+
+#[test]
+fn from_form_value_raw() {
+    #[allow(non_camel_case_types)]
+    #[derive(Debug, FromFormValue)]
+    enum Keyword {
+        r#type,
+        this,
+    }
+
+    assert_parse!("type", "tYpE" => Keyword::r#type);
+    assert_parse!("this" => Keyword::this);
+    assert_no_parse!("r#type" => Keyword);
+}

--- a/core/codegen/tests/route-raw.rs
+++ b/core/codegen/tests/route-raw.rs
@@ -1,0 +1,42 @@
+#[macro_use] extern crate rocket;
+
+use rocket::local::blocking::Client;
+
+// Test that raw idents can be used for route parameter names
+
+#[get("/<enum>?<type>")]
+fn get(r#enum: String, r#type: i32) -> String {
+    format!("{} is {}", r#enum, r#type)
+}
+
+#[get("/swap/<raw>/<bare>")]
+fn swap(r#raw: String, bare: String) -> String {
+    format!("{}, {}", raw, bare)
+}
+
+#[catch(400)]
+fn catch(r#raw: &rocket::Request) -> String {
+    format!("{}", raw.method())
+}
+
+#[test]
+fn test_raw_ident() {
+    let rocket = rocket::ignite()
+        .mount("/", routes![get, swap])
+        .register(catchers![catch]);
+    let client = Client::new(rocket).unwrap();
+
+    let response = client.get("/example?type=1").dispatch();
+    assert_eq!(response.into_string().unwrap(), "example is 1");
+
+    let uri_named = uri!(get: r#enum = "test_named", r#type = 1);
+    assert_eq!(uri_named.to_string(), "/test_named?type=1");
+
+    let uri_unnamed = uri!(get: "test_unnamed", 2);
+    assert_eq!(uri_unnamed.to_string(), "/test_unnamed?type=2");
+
+    let uri_raws = uri!(swap: r#raw = "1", r#bare = "2");
+    assert_eq!(uri_raws.to_string(), "/swap/1/2");
+    let uri_bare = uri!(swap: raw = "1", bare = "2");
+    assert_eq!(uri_bare.to_string(), "/swap/1/2");
+}

--- a/core/codegen/tests/route-raw.rs
+++ b/core/codegen/tests/route-raw.rs
@@ -24,7 +24,8 @@ fn test_raw_ident() {
     let rocket = rocket::ignite()
         .mount("/", routes![get, swap])
         .register(catchers![catch]);
-    let client = Client::new(rocket).unwrap();
+
+    let client = Client::untracked(rocket).unwrap();
 
     let response = client.get("/example?type=1").dispatch();
     assert_eq!(response.into_string().unwrap(), "example is 1");


### PR DESCRIPTION
Resolves #881.

Brief explanation:

* For forms, a field named `r#type` without a `#[form(name="something")]` will now match `&type=` in an input string, when it currently matches `&r#type=`. This test currently passes in `master`:
    ```rust
    #[derive(Debug, PartialEq, FromForm)]
   struct Hazard { r#type: String, }

    #[test]
    fn test_hazard() {
        let form: Result<Hazard, _> = strict("r#type=test");
        assert_eq!(form, Ok(Hazard { r#type: "test".into() }));
    }
    ```

* For routes, two things happen:
  * Prefixing is always done to an `unraw`ed ident. This is implemented in `prefix()` itself.
  * Comparison of route segment names (e.g. "<enum>") is done against the `unraw`ed idents instead of the original idents.

TODO:

* [x] Use `unraw` from syn (dtolnay/syn#625) once it's in a release, instead of implementing it here
* [x] rebase on top of latest `master` and update for 1.0 releases of proc_macro2 and syn
* [x] Unconditionally call `unraw()` in `prefix()` instead
* [x] Explore interactions when using a raw ident in one place and a normal ident in another. In particular, there is some tricky behavior with the `uri!` macro that might be more likely to show up when mixing 2015 code (think `async: bool`) with 2018 code (passing in `r#async: true` to `uri!`).
* [x] Comprehensive reform of handling raw identifiers (see https://github.com/SergioBenitez/Rocket/pull/894#pullrequestreview-259139845)
