### PR TITLE
Change `rocket_contrib` to not depend on default features from `rocket`.

### DIFF
--- a/contrib/lib/Cargo.toml
+++ b/contrib/lib/Cargo.toml
@@ -39,7 +39,7 @@ memcache_pool = ["databases", "memcache", "r2d2-memcache"]
 [dependencies]
 # Global dependencies.
 rocket_contrib_codegen = { version = "0.4.0", path = "../codegen", optional = true }
-rocket = { version = "0.4.0", path = "../../core/lib/" }
+rocket = { version = "0.4.0", path = "../../core/lib/", default-features = false }
 log = "0.4"
 
 # Serialization and templating dependencies.


### PR DESCRIPTION
Fixes #905.

...this is technically a breaking change, I think? Any crate depending on `rocket` with `default_features = false` and also depending on `rocket_contrib` will lose access to private cookie functionality with this change.