### PR TITLE
Fix typo in fairings guide: 'to the launch' -> 'to launch'

### DIFF
--- a/site/guide/7-fairings.md
+++ b/site/guide/7-fairings.md
@@ -196,7 +196,7 @@ to create an `AdHoc` structure from a function or closure.
 
 As an example, the code below creates a `Rocket` instance with two attached
 ad-hoc fairings. The first, a launch fairing named "Launch Printer", simply
-prints a message indicating that the application is about to the launch. The
+prints a message indicating that the application is about to launch. The
 second named "Put Rewriter", a request fairing, rewrites the method of all
 requests to be `PUT`.
 


### PR DESCRIPTION
There is a typo in the fairings guide under the section [Ad-Hoc Fairings](https://rocket.rs/v0.4/guide/fairings/#ad-hoc-fairings):

> [...] simply prints a message indicating that the application is about to _the_ launch.