### PR TITLE
Disable unused ring dependency for rocket_contrib

### DIFF
--- a/contrib/lib/Cargo.toml
+++ b/contrib/lib/Cargo.toml
@@ -39,7 +39,7 @@ memcache_pool = ["databases", "memcache", "r2d2-memcache"]
 [dependencies]
 # Global dependencies.
 rocket_contrib_codegen = { version = "0.4.0", path = "../codegen", optional = true }
-rocket = { version = "0.4.0", path = "../../core/lib/" }
+rocket = { version = "0.4.0", default-features = false, path = "../../core/lib/" }
 log = "0.4"
 
 # Serialization and templating dependencies.


### PR DESCRIPTION
This resolves #905

It seems the `private-cookies` feature isn't actually used by rocket_contrib at all, which means it can be safely disabled.

This is not a breaking change because this feature is getting re-enabled in rocket as soon as any crate in the dependency tree depends on rocket with explicitly disabling default features, which is the case if private cookies are actually needed.

Please consider publishing this as 0.4.1. Thanks!