### PR TITLE
Replace deprecated dependency

### DIFF
--- a/core/lib/Cargo.toml
+++ b/core/lib/Cargo.toml
@@ -34,7 +34,7 @@ time = "0.1"
 memchr = "2" # TODO: Use pear instead.
 base64 = "0.10"
 pear = "0.1"
-isatty = "0.1"
+atty = "0.2"
 
 [build-dependencies]
 yansi = "0.5"

--- a/core/lib/src/lib.rs
+++ b/core/lib/src/lib.rs
@@ -111,7 +111,7 @@ extern crate state;
 extern crate time;
 extern crate memchr;
 extern crate base64;
-extern crate isatty;
+extern crate atty;
 
 #[cfg(test)] #[macro_use] extern crate lazy_static;
 

--- a/core/lib/src/logger.rs
+++ b/core/lib/src/logger.rs
@@ -150,7 +150,7 @@ crate fn try_init(level: LoggingLevel, verbose: bool) -> bool {
         return false;
     }
 
-    if !::isatty::stdout_isatty()
+    if !::atty::is(atty::Stream::Stdout)
         || (cfg!(windows) && !Paint::enable_windows_ascii())
         || env::var_os(COLORS_ENV).map(|v| v == "0" || v == "off").unwrap_or(false)
     {


### PR DESCRIPTION
According to https://crates.io/crates/isatty isatty is no longer maintained.