### PR TITLE
Update conflicting postgres and mysql database config references

### DIFF
--- a/contrib/lib/src/databases.rs
+++ b/contrib/lib/src/databases.rs
@@ -118,8 +118,8 @@
 //! sqlite_db = { url = "db.sqlite" }
 //!
 //! # Option 2:
-//! [global.databases.pg_db]
-//! url = "mysql://root:root@localhost/pg_db"
+//! [global.databases.my_db]
+//! url = "mysql://root:root@localhost/my_db"
 //!
 //! # With a `pool_size` key:
 //! [global.databases]


### PR DESCRIPTION
Small consistency cleanup: When looking through the database documentation, I noticed that the database was named `pg_db` (implying a postgres db), but the database url was configured to point to a mysql db. Just wanted to help with consistency.

Thanks so much for Rocket, it's been fantastic to work with so far!