### PR TITLE
Allow base16-encoded secret keys

### DIFF
--- a/core/lib/Cargo.toml
+++ b/core/lib/Cargo.toml
@@ -34,6 +34,7 @@ state = "0.4.1"
 time = "0.1"
 memchr = "2" # TODO: Use pear instead.
 base64 = "0.10"
+base16 = "0.2"
 pear = "0.1"
 atty = "0.2"
 

--- a/site/guide/9-configuration.md
+++ b/site/guide/9-configuration.md
@@ -92,9 +92,9 @@ limits = { forms = 32768 }
 The `workers` and `secret_key` default parameters are computed by Rocket
 automatically; the values above are not valid TOML syntax. When manually
 specifying the number of workers, the value should be an integer: `workers =
-10`. When manually specifying the secret key, the value should a 256-bit base64
-encoded string. Such a string can be generated using a tool such as openssl:
-`openssl rand -base64 32`.
+10`. When manually specifying the secret key, the value should a random 256-bit
+value, encoded as a base64 or base16 string. Such a string can be generated
+using a tool like openssl: `openssl rand -base64 32`.
 
 The "global" pseudo-environment can be used to set and/or override configuration
 parameters globally. A parameter defined in a `[global]` table sets, or


### PR DESCRIPTION
Why
---

It's basically a workaround for Heroku, which has built-in support for generating secret keys, but generates 256-bit hex-encoded strings, instead of 256-bit base64-encoded ones.

Right now, I have to work around it in my Procfile, which isn't bad, but it adds embarrasing friction to what would otherwise be a pretty clean 12-factor app wrapper.
<https://github.com/notriddle/more-interesting/blob/ac944cc97c26571f799d090bb8dae78c9a3b98cb/Procfile>

What alternatives are there?
----------------------------

We could, instead, lift the format requirements entirely. We'd run PKDIF2 or something on the secret_key, generating a 256-bit secret no matter what the input actually is. I don't think that's better, because it means the user could use predictable, memorable "passwords" instead of something truly random.

Leaving this alone is also an option, but it means punting to the application to handle converting this, and getting it wrong can result in subtle disasters (like generating a secret of `0` because of a typo).