### PR TITLE
Remove use of decl_macro by using a different hack.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Rocket is web framework for Rust (nightly) with a focus on ease-of-use,
 expressibility, and speed. Here's an example of a complete Rocket application:
 
 ```rust
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/contrib/lib/src/databases.rs
+++ b/contrib/lib/src/databases.rs
@@ -50,7 +50,7 @@
 //! In your application's source code, one-time:
 //!
 //! ```rust
-//! #![feature(proc_macro_hygiene, decl_macro)]
+//! #![feature(proc_macro_hygiene)]
 //!
 //! #[macro_use] extern crate rocket;
 //! #[macro_use] extern crate rocket_contrib;
@@ -73,7 +73,7 @@
 //! Whenever a connection to the database is needed:
 //!
 //! ```rust
-//! # #![feature(proc_macro_hygiene, decl_macro)]
+//! # #![feature(proc_macro_hygiene)]
 //! #
 //! # #[macro_use] extern crate rocket;
 //! # #[macro_use] extern crate rocket_contrib;
@@ -289,7 +289,7 @@
 //! connection to a given database:
 //!
 //! ```rust
-//! # #![feature(proc_macro_hygiene, decl_macro)]
+//! # #![feature(proc_macro_hygiene)]
 //! #
 //! # #[macro_use] extern crate rocket;
 //! # #[macro_use] extern crate rocket_contrib;
@@ -311,7 +311,7 @@
 //! connection type:
 //!
 //! ```rust
-//! # #![feature(proc_macro_hygiene, decl_macro)]
+//! # #![feature(proc_macro_hygiene)]
 //! #
 //! # #[macro_use] extern crate rocket;
 //! # #[macro_use] extern crate rocket_contrib;

--- a/contrib/lib/src/json.rs
+++ b/contrib/lib/src/json.rs
@@ -41,7 +41,7 @@ pub use serde_json::{json_internal, json_internal_vec};
 /// or from [`serde`]. The data is parsed from the HTTP request body.
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene, decl_macro)]
+/// # #![feature(proc_macro_hygiene)]
 /// # #[macro_use] extern crate rocket;
 /// # extern crate rocket_contrib;
 /// # type User = usize;
@@ -65,7 +65,7 @@ pub use serde_json::{json_internal, json_internal_vec};
 /// set to `application/json` automatically.
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene, decl_macro)]
+/// # #![feature(proc_macro_hygiene)]
 /// # #[macro_use] extern crate rocket;
 /// # extern crate rocket_contrib;
 /// # type User = usize;
@@ -210,7 +210,7 @@ impl<T> DerefMut for Json<T> {
 /// fashion during request handling. This looks something like:
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene, decl_macro)]
+/// # #![feature(proc_macro_hygiene)]
 /// # #[macro_use] extern crate rocket;
 /// # #[macro_use] extern crate rocket_contrib;
 /// use rocket_contrib::json::JsonValue;
@@ -305,7 +305,7 @@ impl<'a> Responder<'a> for JsonValue {
 /// value created with this macro can be returned from a handler as follows:
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene, decl_macro)]
+/// # #![feature(proc_macro_hygiene)]
 /// # #[macro_use] extern crate rocket;
 /// # #[macro_use] extern crate rocket_contrib;
 /// use rocket_contrib::json::JsonValue;

--- a/contrib/lib/src/msgpack.rs
+++ b/contrib/lib/src/msgpack.rs
@@ -40,7 +40,7 @@ pub use rmp_serde::decode::Error;
 /// request body.
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene, decl_macro)]
+/// # #![feature(proc_macro_hygiene)]
 /// # #[macro_use] extern crate rocket;
 /// # extern crate rocket_contrib;
 /// # type User = usize;
@@ -64,7 +64,7 @@ pub use rmp_serde::decode::Error;
 /// response is set to `application/msgpack` automatically.
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene, decl_macro)]
+/// # #![feature(proc_macro_hygiene)]
 /// # #[macro_use] extern crate rocket;
 /// # extern crate rocket_contrib;
 /// # type User = usize;

--- a/contrib/lib/src/templates/metadata.rs
+++ b/contrib/lib/src/templates/metadata.rs
@@ -12,7 +12,7 @@ use crate::templates::ContextManager;
 /// used as a request guard in any request handler.
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene, decl_macro)]
+/// # #![feature(proc_macro_hygiene)]
 /// # #[macro_use] extern crate rocket;
 /// # #[macro_use] extern crate rocket_contrib;
 /// use rocket_contrib::templates::{Template, Metadata};
@@ -46,7 +46,7 @@ impl Metadata<'_> {
     /// # Example
     ///
     /// ```rust
-    /// # #![feature(proc_macro_hygiene, decl_macro)]
+    /// # #![feature(proc_macro_hygiene)]
     /// # #[macro_use] extern crate rocket;
     /// # extern crate rocket_contrib;
     /// #
@@ -67,7 +67,7 @@ impl Metadata<'_> {
     /// # Example
     ///
     /// ```rust
-    /// # #![feature(proc_macro_hygiene, decl_macro)]
+    /// # #![feature(proc_macro_hygiene)]
     /// # #[macro_use] extern crate rocket;
     /// # extern crate rocket_contrib;
     /// #

--- a/contrib/lib/src/templates/mod.rs
+++ b/contrib/lib/src/templates/mod.rs
@@ -37,7 +37,7 @@
 //!      of the template file minus the last two extensions, from a handler.
 //!
 //!      ```rust
-//!      # #![feature(proc_macro_hygiene, decl_macro)]
+//!      # #![feature(proc_macro_hygiene)]
 //!      # #[macro_use] extern crate rocket;
 //!      # #[macro_use] extern crate rocket_contrib;
 //!      # fn context() {  }
@@ -179,7 +179,7 @@ const DEFAULT_TEMPLATE_DIR: &str = "templates";
 /// returned from a request handler directly:
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene, decl_macro)]
+/// # #![feature(proc_macro_hygiene)]
 /// # #[macro_use] extern crate rocket;
 /// # #[macro_use] extern crate rocket_contrib;
 /// # fn context() {  }

--- a/contrib/lib/src/uuid.rs
+++ b/contrib/lib/src/uuid.rs
@@ -42,7 +42,7 @@ pub use self::uuid_crate::parser::ParseError;
 /// You can use the `Uuid` type directly as a target of a dynamic parameter:
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene, decl_macro)]
+/// # #![feature(proc_macro_hygiene)]
 /// # #[macro_use] extern crate rocket;
 /// # #[macro_use] extern crate rocket_contrib;
 /// use rocket_contrib::uuid::Uuid;
@@ -56,7 +56,7 @@ pub use self::uuid_crate::parser::ParseError;
 /// You can also use the `Uuid` as a form value, including in query strings:
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene, decl_macro)]
+/// # #![feature(proc_macro_hygiene)]
 /// # #[macro_use] extern crate rocket;
 /// # #[macro_use] extern crate rocket_contrib;
 /// use rocket_contrib::uuid::Uuid;

--- a/contrib/lib/tests/compress_responder.rs
+++ b/contrib/lib/tests/compress_responder.rs
@@ -1,4 +1,4 @@
-#![feature(decl_macro, proc_macro_hygiene)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use]
 #[cfg(all(feature = "brotli_compression", feature = "gzip_compression"))]

--- a/contrib/lib/tests/compression_fairing.rs
+++ b/contrib/lib/tests/compression_fairing.rs
@@ -1,4 +1,4 @@
-#![feature(decl_macro, proc_macro_hygiene)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use]
 #[cfg(all(feature = "brotli_compression", feature = "gzip_compression"))]

--- a/contrib/lib/tests/helmet.rs
+++ b/contrib/lib/tests/helmet.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use]
 #[cfg(feature = "helmet")]

--- a/contrib/lib/tests/static_files.rs
+++ b/contrib/lib/tests/static_files.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[cfg(feature = "serve")]
 mod static_tests {

--- a/contrib/lib/tests/templates.rs
+++ b/contrib/lib/tests/templates.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[cfg(feature = "templates")]
 #[macro_use] extern crate rocket;

--- a/core/codegen/Cargo.toml
+++ b/core/codegen/Cargo.toml
@@ -20,7 +20,6 @@ indexmap = "1.0"
 quote = "0.6.1"
 rocket_http = { version = "0.5.0-dev", path = "../http/" }
 devise = "0.2"
-rand = "0.7.0"
 
 [build-dependencies]
 yansi = "0.5"

--- a/core/codegen/Cargo.toml
+++ b/core/codegen/Cargo.toml
@@ -20,6 +20,7 @@ indexmap = "1.0"
 quote = "0.6.1"
 rocket_http = { version = "0.5.0-dev", path = "../http/" }
 devise = "0.2"
+rand = "0.7.0"
 
 [build-dependencies]
 yansi = "0.5"

--- a/core/codegen/src/lib.rs
+++ b/core/codegen/src/lib.rs
@@ -30,7 +30,7 @@
 //! crate root:
 //!
 //! ```rust
-//! #![feature(proc_macro_hygiene, decl_macro)]
+//! #![feature(proc_macro_hygiene)]
 //!
 //! #[macro_use] extern crate rocket;
 //! # #[get("/")] fn hello() { }
@@ -40,7 +40,7 @@
 //! Or, alternatively, selectively import from the top-level scope:
 //!
 //! ```rust
-//! #![feature(proc_macro_hygiene, decl_macro)]
+//! #![feature(proc_macro_hygiene)]
 //! # extern crate rocket;
 //!
 //! use rocket::{get, routes};
@@ -131,7 +131,7 @@ macro_rules! route_attribute {
         /// functions:
         ///
         /// ```rust
-        /// # #![feature(proc_macro_hygiene, decl_macro)]
+        /// # #![feature(proc_macro_hygiene)]
         /// # #[macro_use] extern crate rocket;
         /// #
         /// #[get("/")]
@@ -154,7 +154,7 @@ macro_rules! route_attribute {
         /// explicitly specified:
         ///
         /// ```rust
-        /// # #![feature(proc_macro_hygiene, decl_macro)]
+        /// # #![feature(proc_macro_hygiene)]
         /// # #[macro_use] extern crate rocket;
         /// #
         /// #[route(GET, path = "/")]
@@ -215,7 +215,7 @@ macro_rules! route_attribute {
         /// the arguments `foo`, `baz`, `msg`, `rest`, and `form`:
         ///
         /// ```rust
-        /// # #![feature(proc_macro_hygiene, decl_macro)]
+        /// # #![feature(proc_macro_hygiene)]
         /// # #[macro_use] extern crate rocket;
         /// # use rocket::request::Form;
         /// # use std::path::PathBuf;
@@ -327,7 +327,7 @@ route_attribute!(options => Method::Options);
 /// This attribute can only be applied to free functions:
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene, decl_macro)]
+/// # #![feature(proc_macro_hygiene)]
 /// # #[macro_use] extern crate rocket;
 /// #
 /// use rocket::Request;
@@ -739,7 +739,7 @@ pub fn derive_uri_display_path(input: TokenStream) -> TokenStream {
 /// corresponding [`Route`] structures. For example, given the following routes:
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene, decl_macro)]
+/// # #![feature(proc_macro_hygiene)]
 /// # #[macro_use] extern crate rocket;
 /// #
 /// #[get("/")]
@@ -754,7 +754,7 @@ pub fn derive_uri_display_path(input: TokenStream) -> TokenStream {
 /// The `routes!` macro can be used as:
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene, decl_macro)]
+/// # #![feature(proc_macro_hygiene)]
 /// # #[macro_use] extern crate rocket;
 /// #
 /// # use rocket::http::Method;
@@ -798,7 +798,7 @@ pub fn routes(input: TokenStream) -> TokenStream {
 /// catchers:
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene, decl_macro)]
+/// # #![feature(proc_macro_hygiene)]
 /// # #[macro_use] extern crate rocket;
 /// #
 /// #[catch(404)]
@@ -813,7 +813,7 @@ pub fn routes(input: TokenStream) -> TokenStream {
 /// The `catchers!` macro can be used as:
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene, decl_macro)]
+/// # #![feature(proc_macro_hygiene)]
 /// # #[macro_use] extern crate rocket;
 /// #
 /// # #[catch(404)] fn not_found() { /* .. */ }
@@ -855,7 +855,7 @@ pub fn catchers(input: TokenStream) -> TokenStream {
 /// For example, for the following route:
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene, decl_macro)]
+/// # #![feature(proc_macro_hygiene)]
 /// # #[macro_use] extern crate rocket;
 /// #
 /// #[get("/person/<name>?<age>")]
@@ -869,7 +869,7 @@ pub fn catchers(input: TokenStream) -> TokenStream {
 /// A URI can be created as follows:
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene, decl_macro)]
+/// # #![feature(proc_macro_hygiene)]
 /// # #[macro_use] extern crate rocket;
 /// #
 /// # #[get("/person/<name>?<age>")]

--- a/core/codegen/src/syn_ext.rs
+++ b/core/codegen/src/syn_ext.rs
@@ -9,11 +9,16 @@ pub fn syn_to_diag(error: syn::parse::Error) -> Diagnostic {
 
 pub trait IdentExt {
     fn prepend(&self, string: &str) -> syn::Ident;
+    fn append(&self, string: &str) -> syn::Ident;
 }
 
 impl IdentExt for syn::Ident {
     fn prepend(&self, string: &str) -> syn::Ident {
         syn::Ident::new(&format!("{}{}", string, self), self.span())
+    }
+
+    fn append(&self, string: &str) -> syn::Ident {
+        syn::Ident::new(&format!("{}{}", self, string), self.span())
     }
 }
 

--- a/core/codegen/tests/expansion.rs
+++ b/core/codegen/tests/expansion.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/core/codegen/tests/responder.rs
+++ b/core/codegen/tests/responder.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 use rocket::local::Client;
 use rocket::response::Responder;

--- a/core/codegen/tests/route-data.rs
+++ b/core/codegen/tests/route-data.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/core/codegen/tests/route-format.rs
+++ b/core/codegen/tests/route-format.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/core/codegen/tests/route-ranking.rs
+++ b/core/codegen/tests/route-ranking.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/core/codegen/tests/route.rs
+++ b/core/codegen/tests/route.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 // Rocket sometimes generates mangled identifiers that activate the
 // non_snake_case lint. We deny the lint in this test to ensure that

--- a/core/codegen/tests/typed-uris.rs
+++ b/core/codegen/tests/typed-uris.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 #![allow(dead_code, unused_variables)]
 
 #[macro_use] extern crate rocket;
@@ -6,7 +6,7 @@
 use std::path::PathBuf;
 
 use rocket::http::{RawStr, Cookies};
-use rocket::http::uri::{Origin, FromUriParam, Query};
+use rocket::http::uri::{FromUriParam, Query};
 use rocket::request::Form;
 
 #[derive(FromForm, UriDisplayQuery)]
@@ -82,8 +82,10 @@ fn param_and_segments(path: PathBuf, id: usize) { }
 #[post("/a/<id>/then/<path..>")]
 fn guarded_segments(cookies: Cookies<'_>, path: PathBuf, id: usize) { }
 
-macro assert_uri_eq($($uri:expr => $expected:expr,)+) {
-    $(assert_eq!($uri, Origin::parse($expected).expect("valid origin URI"));)+
+macro_rules! assert_uri_eq {
+    ($($uri:expr => $expected:expr,)+) => {
+        $(assert_eq!($uri, rocket::http::uri::Origin::parse($expected).expect("valid origin URI"));)+
+    };
 }
 
 #[test]
@@ -323,8 +325,6 @@ fn check_scoped() {
 }
 
 mod typed_uris {
-    use super::assert_uri_eq;
-
     #[post("/typed_uris/<id>")]
     fn simple(id: i32) { }
 
@@ -339,8 +339,6 @@ mod typed_uris {
     }
 
     pub mod deeper {
-        use super::assert_uri_eq;
-
         #[post("/typed_uris/deeper/<id>")]
         fn simple(id: i32) { }
 

--- a/core/codegen/tests/ui-fail/route-attribute-general-syntax.rs
+++ b/core/codegen/tests/ui-fail/route-attribute-general-syntax.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/core/codegen/tests/ui-fail/route-path-bad-syntax.rs
+++ b/core/codegen/tests/ui-fail/route-path-bad-syntax.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/core/codegen/tests/ui-fail/route-type-errors.rs
+++ b/core/codegen/tests/ui-fail/route-type-errors.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/core/codegen/tests/ui-fail/route-warnings.rs
+++ b/core/codegen/tests/ui-fail/route-warnings.rs
@@ -1,6 +1,6 @@
 // must-compile-successfully
 
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/core/codegen/tests/ui-fail/typed-uri-bad-type.rs
+++ b/core/codegen/tests/ui-fail/typed-uri-bad-type.rs
@@ -1,7 +1,7 @@
 // normalize-stderr-test: "<(.*) as (.*)>" -> "$1 as $$TRAIT"
 // normalize-stderr-test: "and \d+ others" -> "and $$N others"
 
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/core/codegen/tests/ui-fail/typed-uris-bad-params.rs
+++ b/core/codegen/tests/ui-fail/typed-uris-bad-params.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/core/codegen/tests/ui-fail/typed-uris-bad-params.stderr
+++ b/core/codegen/tests/ui-fail/typed-uris-bad-params.stderr
@@ -1,196 +1,28 @@
-error: `has_one` route uri expects 1 parameter but 0 were supplied
-  --> $DIR/typed-uris-bad-params.rs:22:10
+error: path parameters cannot be ignored
+  --> $DIR/typed-uris-bad-params.rs:79:37
    |
-22 |     uri!(has_one); //~ ERROR expects 1 parameter but 0
-   |          ^^^^^^^
-   |
-   = note: expected parameter: id: i32
+79 |     uri!(optionals: id = 10, name = _);
+   |                                     ^
 
-error: `has_one` route uri expects 1 parameter but 2 were supplied
-  --> $DIR/typed-uris-bad-params.rs:24:19
+error: path parameters cannot be ignored
+  --> $DIR/typed-uris-bad-params.rs:76:26
    |
-24 |     uri!(has_one: 1, 23); //~ ERROR expects 1 parameter but 2
-   |                   ^^^^^
-   |
-   = note: expected parameter: id: i32
-
-error: `has_one` route uri expects 1 parameter but 2 were supplied
-  --> $DIR/typed-uris-bad-params.rs:25:19
-   |
-25 |     uri!(has_one: "Hello", 23, ); //~ ERROR expects 1 parameter but 2
-   |                   ^^^^^^^^^^^^
-   |
-   = note: expected parameter: id: i32
-
-error: `has_one_guarded` route uri expects 1 parameter but 2 were supplied
-  --> $DIR/typed-uris-bad-params.rs:26:27
-   |
-26 |     uri!(has_one_guarded: "hi", 100); //~ ERROR expects 1 parameter but 2
-   |                           ^^^^^^^^^
-   |
-   = note: expected parameter: id: i32
-
-error: `has_two` route uri expects 2 parameters but 3 were supplied
-  --> $DIR/typed-uris-bad-params.rs:28:19
-   |
-28 |     uri!(has_two: 10, "hi", "there"); //~ ERROR expects 2 parameters but 3
-   |                   ^^^^^^^^^^^^^^^^^
-   |
-   = note: expected parameters: id: i32, name: String
-
-error: `has_two` route uri expects 2 parameters but 1 was supplied
-  --> $DIR/typed-uris-bad-params.rs:29:19
-   |
-29 |     uri!(has_two: 10); //~ ERROR expects 2 parameters but 1
-   |                   ^^
-   |
-   = note: expected parameters: id: i32, name: String
-
-error: invalid parameters for `has_one` route uri
-  --> $DIR/typed-uris-bad-params.rs:31:19
-   |
-31 |     uri!(has_one: id = 100, name = "hi"); //~ ERROR invalid parameters
-   |                   ^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: uri parameters are: id: i32
-help: unknown parameter: `name`
-  --> $DIR/typed-uris-bad-params.rs:31:29
-   |
-31 |     uri!(has_one: id = 100, name = "hi"); //~ ERROR invalid parameters
-   |                             ^^^^
-
-error: invalid parameters for `has_one` route uri
-  --> $DIR/typed-uris-bad-params.rs:34:19
-   |
-34 |     uri!(has_one: name = 100, id = 100); //~ ERROR invalid parameters
-   |                   ^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: uri parameters are: id: i32
-help: unknown parameter: `name`
-  --> $DIR/typed-uris-bad-params.rs:34:19
-   |
-34 |     uri!(has_one: name = 100, id = 100); //~ ERROR invalid parameters
-   |                   ^^^^
-
-error: invalid parameters for `has_one` route uri
-  --> $DIR/typed-uris-bad-params.rs:37:19
-   |
-37 |     uri!(has_one: name = 100, age = 50, id = 100); //~ ERROR invalid parameters
-   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: uri parameters are: id: i32
-help: unknown parameters: `name`, `age`
-  --> $DIR/typed-uris-bad-params.rs:37:19
-   |
-37 |     uri!(has_one: name = 100, age = 50, id = 100); //~ ERROR invalid parameters
-   |                   ^^^^        ^^^
-
-error: invalid parameters for `has_one` route uri
-  --> $DIR/typed-uris-bad-params.rs:40:19
-   |
-40 |     uri!(has_one: name = 100, age = 50, id = 100, id = 50); //~ ERROR invalid parameters
-   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: uri parameters are: id: i32
-help: unknown parameters: `name`, `age`
-  --> $DIR/typed-uris-bad-params.rs:40:19
-   |
-40 |     uri!(has_one: name = 100, age = 50, id = 100, id = 50); //~ ERROR invalid parameters
-   |                   ^^^^        ^^^
-help: duplicate parameter: `id`
-  --> $DIR/typed-uris-bad-params.rs:40:51
-   |
-40 |     uri!(has_one: name = 100, age = 50, id = 100, id = 50); //~ ERROR invalid parameters
-   |                                                   ^^
-
-error: invalid parameters for `has_one` route uri
-  --> $DIR/typed-uris-bad-params.rs:44:19
-   |
-44 |     uri!(has_one: id = 100, id = 100); //~ ERROR invalid parameters
-   |                   ^^^^^^^^^^^^^^^^^^
-   |
-   = note: uri parameters are: id: i32
-help: duplicate parameter: `id`
-  --> $DIR/typed-uris-bad-params.rs:44:29
-   |
-44 |     uri!(has_one: id = 100, id = 100); //~ ERROR invalid parameters
-   |                             ^^
-
-error: invalid parameters for `has_one` route uri
-  --> $DIR/typed-uris-bad-params.rs:47:19
-   |
-47 |     uri!(has_one: id = 100, id = 100, ); //~ ERROR invalid parameters
-   |                   ^^^^^^^^^^^^^^^^^^^
-   |
-   = note: uri parameters are: id: i32
-help: duplicate parameter: `id`
-  --> $DIR/typed-uris-bad-params.rs:47:29
-   |
-47 |     uri!(has_one: id = 100, id = 100, ); //~ ERROR invalid parameters
-   |                             ^^
-
-error: invalid parameters for `has_one` route uri
-  --> $DIR/typed-uris-bad-params.rs:50:19
-   |
-50 |     uri!(has_one: name = "hi"); //~ ERROR invalid parameters
-   |                   ^^^^^^^^^^^
-   |
-   = note: uri parameters are: id: i32
-   = help: missing parameter: `id`
-help: unknown parameter: `name`
-  --> $DIR/typed-uris-bad-params.rs:50:19
-   |
-50 |     uri!(has_one: name = "hi"); //~ ERROR invalid parameters
-   |                   ^^^^
-
-error: invalid parameters for `has_one_guarded` route uri
-  --> $DIR/typed-uris-bad-params.rs:54:27
-   |
-54 |     uri!(has_one_guarded: cookies = "hi", id = 100); //~ ERROR invalid parameters
-   |                           ^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: uri parameters are: id: i32
-help: unknown parameter: `cookies`
-  --> $DIR/typed-uris-bad-params.rs:54:27
-   |
-54 |     uri!(has_one_guarded: cookies = "hi", id = 100); //~ ERROR invalid parameters
-   |                           ^^^^^^^
-
-error: invalid parameters for `has_one_guarded` route uri
-  --> $DIR/typed-uris-bad-params.rs:57:27
-   |
-57 |     uri!(has_one_guarded: id = 100, cookies = "hi"); //~ ERROR invalid parameters
-   |                           ^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: uri parameters are: id: i32
-help: unknown parameter: `cookies`
-  --> $DIR/typed-uris-bad-params.rs:57:37
-   |
-57 |     uri!(has_one_guarded: id = 100, cookies = "hi"); //~ ERROR invalid parameters
-   |                                     ^^^^^^^
+76 |     uri!(optionals: id = _, name = "bob".into());
+   |                          ^
 
 error: invalid parameters for `has_two` route uri
-  --> $DIR/typed-uris-bad-params.rs:60:19
+  --> $DIR/typed-uris-bad-params.rs:72:19
    |
-60 |     uri!(has_two: id = 100, id = 100, ); //~ ERROR invalid parameters
-   |                   ^^^^^^^^^^^^^^^^^^^
+72 |     uri!(has_two: id = 100, cookies = "hi"); //~ ERROR invalid parameters
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: uri parameters are: id: i32, name: String
    = help: missing parameter: `name`
-help: duplicate parameter: `id`
-  --> $DIR/typed-uris-bad-params.rs:60:29
+help: unknown parameter: `cookies`
+  --> $DIR/typed-uris-bad-params.rs:72:29
    |
-60 |     uri!(has_two: id = 100, id = 100, ); //~ ERROR invalid parameters
-   |                             ^^
-
-error: invalid parameters for `has_two` route uri
-  --> $DIR/typed-uris-bad-params.rs:64:19
-   |
-64 |     uri!(has_two: name = "hi"); //~ ERROR invalid parameters
-   |                   ^^^^^^^^^^^
-   |
-   = note: uri parameters are: id: i32, name: String
-   = help: missing parameter: `id`
+72 |     uri!(has_two: id = 100, cookies = "hi"); //~ ERROR invalid parameters
+   |                             ^^^^^^^
 
 error: invalid parameters for `has_two` route uri
   --> $DIR/typed-uris-bad-params.rs:67:19
@@ -212,30 +44,198 @@ help: duplicate parameter: `id`
    |                                             ^^       ^^
 
 error: invalid parameters for `has_two` route uri
-  --> $DIR/typed-uris-bad-params.rs:72:19
+  --> $DIR/typed-uris-bad-params.rs:64:19
    |
-72 |     uri!(has_two: id = 100, cookies = "hi"); //~ ERROR invalid parameters
-   |                   ^^^^^^^^^^^^^^^^^^^^^^^^
+64 |     uri!(has_two: name = "hi"); //~ ERROR invalid parameters
+   |                   ^^^^^^^^^^^
+   |
+   = note: uri parameters are: id: i32, name: String
+   = help: missing parameter: `id`
+
+error: invalid parameters for `has_two` route uri
+  --> $DIR/typed-uris-bad-params.rs:60:19
+   |
+60 |     uri!(has_two: id = 100, id = 100, ); //~ ERROR invalid parameters
+   |                   ^^^^^^^^^^^^^^^^^^^
    |
    = note: uri parameters are: id: i32, name: String
    = help: missing parameter: `name`
+help: duplicate parameter: `id`
+  --> $DIR/typed-uris-bad-params.rs:60:29
+   |
+60 |     uri!(has_two: id = 100, id = 100, ); //~ ERROR invalid parameters
+   |                             ^^
+
+error: invalid parameters for `has_one_guarded` route uri
+  --> $DIR/typed-uris-bad-params.rs:57:27
+   |
+57 |     uri!(has_one_guarded: id = 100, cookies = "hi"); //~ ERROR invalid parameters
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: uri parameters are: id: i32
 help: unknown parameter: `cookies`
-  --> $DIR/typed-uris-bad-params.rs:72:29
+  --> $DIR/typed-uris-bad-params.rs:57:37
    |
-72 |     uri!(has_two: id = 100, cookies = "hi"); //~ ERROR invalid parameters
-   |                             ^^^^^^^
+57 |     uri!(has_one_guarded: id = 100, cookies = "hi"); //~ ERROR invalid parameters
+   |                                     ^^^^^^^
 
-error: path parameters cannot be ignored
-  --> $DIR/typed-uris-bad-params.rs:76:26
+error: invalid parameters for `has_one_guarded` route uri
+  --> $DIR/typed-uris-bad-params.rs:54:27
    |
-76 |     uri!(optionals: id = _, name = "bob".into());
-   |                          ^
+54 |     uri!(has_one_guarded: cookies = "hi", id = 100); //~ ERROR invalid parameters
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: uri parameters are: id: i32
+help: unknown parameter: `cookies`
+  --> $DIR/typed-uris-bad-params.rs:54:27
+   |
+54 |     uri!(has_one_guarded: cookies = "hi", id = 100); //~ ERROR invalid parameters
+   |                           ^^^^^^^
 
-error: path parameters cannot be ignored
-  --> $DIR/typed-uris-bad-params.rs:79:37
+error: invalid parameters for `has_one` route uri
+  --> $DIR/typed-uris-bad-params.rs:50:19
    |
-79 |     uri!(optionals: id = 10, name = _);
-   |                                     ^
+50 |     uri!(has_one: name = "hi"); //~ ERROR invalid parameters
+   |                   ^^^^^^^^^^^
+   |
+   = note: uri parameters are: id: i32
+   = help: missing parameter: `id`
+help: unknown parameter: `name`
+  --> $DIR/typed-uris-bad-params.rs:50:19
+   |
+50 |     uri!(has_one: name = "hi"); //~ ERROR invalid parameters
+   |                   ^^^^
+
+error: invalid parameters for `has_one` route uri
+  --> $DIR/typed-uris-bad-params.rs:47:19
+   |
+47 |     uri!(has_one: id = 100, id = 100, ); //~ ERROR invalid parameters
+   |                   ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: uri parameters are: id: i32
+help: duplicate parameter: `id`
+  --> $DIR/typed-uris-bad-params.rs:47:29
+   |
+47 |     uri!(has_one: id = 100, id = 100, ); //~ ERROR invalid parameters
+   |                             ^^
+
+error: invalid parameters for `has_one` route uri
+  --> $DIR/typed-uris-bad-params.rs:44:19
+   |
+44 |     uri!(has_one: id = 100, id = 100); //~ ERROR invalid parameters
+   |                   ^^^^^^^^^^^^^^^^^^
+   |
+   = note: uri parameters are: id: i32
+help: duplicate parameter: `id`
+  --> $DIR/typed-uris-bad-params.rs:44:29
+   |
+44 |     uri!(has_one: id = 100, id = 100); //~ ERROR invalid parameters
+   |                             ^^
+
+error: invalid parameters for `has_one` route uri
+  --> $DIR/typed-uris-bad-params.rs:40:19
+   |
+40 |     uri!(has_one: name = 100, age = 50, id = 100, id = 50); //~ ERROR invalid parameters
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: uri parameters are: id: i32
+help: unknown parameters: `name`, `age`
+  --> $DIR/typed-uris-bad-params.rs:40:19
+   |
+40 |     uri!(has_one: name = 100, age = 50, id = 100, id = 50); //~ ERROR invalid parameters
+   |                   ^^^^        ^^^
+help: duplicate parameter: `id`
+  --> $DIR/typed-uris-bad-params.rs:40:51
+   |
+40 |     uri!(has_one: name = 100, age = 50, id = 100, id = 50); //~ ERROR invalid parameters
+   |                                                   ^^
+
+error: invalid parameters for `has_one` route uri
+  --> $DIR/typed-uris-bad-params.rs:37:19
+   |
+37 |     uri!(has_one: name = 100, age = 50, id = 100); //~ ERROR invalid parameters
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: uri parameters are: id: i32
+help: unknown parameters: `name`, `age`
+  --> $DIR/typed-uris-bad-params.rs:37:19
+   |
+37 |     uri!(has_one: name = 100, age = 50, id = 100); //~ ERROR invalid parameters
+   |                   ^^^^        ^^^
+
+error: invalid parameters for `has_one` route uri
+  --> $DIR/typed-uris-bad-params.rs:34:19
+   |
+34 |     uri!(has_one: name = 100, id = 100); //~ ERROR invalid parameters
+   |                   ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: uri parameters are: id: i32
+help: unknown parameter: `name`
+  --> $DIR/typed-uris-bad-params.rs:34:19
+   |
+34 |     uri!(has_one: name = 100, id = 100); //~ ERROR invalid parameters
+   |                   ^^^^
+
+error: invalid parameters for `has_one` route uri
+  --> $DIR/typed-uris-bad-params.rs:31:19
+   |
+31 |     uri!(has_one: id = 100, name = "hi"); //~ ERROR invalid parameters
+   |                   ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: uri parameters are: id: i32
+help: unknown parameter: `name`
+  --> $DIR/typed-uris-bad-params.rs:31:29
+   |
+31 |     uri!(has_one: id = 100, name = "hi"); //~ ERROR invalid parameters
+   |                             ^^^^
+
+error: `has_two` route uri expects 2 parameters but 1 was supplied
+  --> $DIR/typed-uris-bad-params.rs:29:19
+   |
+29 |     uri!(has_two: 10); //~ ERROR expects 2 parameters but 1
+   |                   ^^
+   |
+   = note: expected parameters: id: i32, name: String
+
+error: `has_two` route uri expects 2 parameters but 3 were supplied
+  --> $DIR/typed-uris-bad-params.rs:28:19
+   |
+28 |     uri!(has_two: 10, "hi", "there"); //~ ERROR expects 2 parameters but 3
+   |                   ^^^^^^^^^^^^^^^^^
+   |
+   = note: expected parameters: id: i32, name: String
+
+error: `has_one_guarded` route uri expects 1 parameter but 2 were supplied
+  --> $DIR/typed-uris-bad-params.rs:26:27
+   |
+26 |     uri!(has_one_guarded: "hi", 100); //~ ERROR expects 1 parameter but 2
+   |                           ^^^^^^^^^
+   |
+   = note: expected parameter: id: i32
+
+error: `has_one` route uri expects 1 parameter but 2 were supplied
+  --> $DIR/typed-uris-bad-params.rs:25:19
+   |
+25 |     uri!(has_one: "Hello", 23, ); //~ ERROR expects 1 parameter but 2
+   |                   ^^^^^^^^^^^^
+   |
+   = note: expected parameter: id: i32
+
+error: `has_one` route uri expects 1 parameter but 2 were supplied
+  --> $DIR/typed-uris-bad-params.rs:24:19
+   |
+24 |     uri!(has_one: 1, 23); //~ ERROR expects 1 parameter but 2
+   |                   ^^^^^
+   |
+   = note: expected parameter: id: i32
+
+error: `has_one` route uri expects 1 parameter but 0 were supplied
+  --> $DIR/typed-uris-bad-params.rs:22:10
+   |
+22 |     uri!(has_one); //~ ERROR expects 1 parameter but 0
+   |          ^^^^^^^
+   |
+   = note: expected parameter: id: i32
 
 error: aborting due to 21 previous errors
 

--- a/core/codegen/tests/ui-fail/typed-uris-invalid-syntax.rs
+++ b/core/codegen/tests/ui-fail/typed-uris-invalid-syntax.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/core/codegen/tests/uri_display.rs
+++ b/core/codegen/tests/uri_display.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/core/http/src/cookies.rs
+++ b/core/http/src/cookies.rs
@@ -54,7 +54,7 @@ mod key {
 /// a handler to retrieve the value of a "message" cookie.
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene, decl_macro)]
+/// # #![feature(proc_macro_hygiene)]
 /// # #[macro_use] extern crate rocket;
 /// use rocket::http::Cookies;
 ///
@@ -74,7 +74,7 @@ mod key {
 /// [private cookie]: Cookies::add_private()
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene, decl_macro)]
+/// # #![feature(proc_macro_hygiene)]
 /// # #[macro_use] extern crate rocket;
 /// #
 /// use rocket::http::Status;

--- a/core/http/src/uri/from_uri_param.rs
+++ b/core/http/src/uri/from_uri_param.rs
@@ -155,7 +155,7 @@ use crate::uri::{self, UriPart, UriDisplay};
 /// With these implementations, the following typechecks:
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene, decl_macro)]
+/// # #![feature(proc_macro_hygiene)]
 /// # #[macro_use] extern crate rocket;
 /// # use std::fmt;
 /// use rocket::http::RawStr;

--- a/core/http/src/uri/uri_display.rs
+++ b/core/http/src/uri/uri_display.rs
@@ -61,7 +61,7 @@ use crate::uri::{Uri, UriPart, Path, Query, Formatter};
 /// the following route:
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene, decl_macro)]
+/// # #![feature(proc_macro_hygiene)]
 /// # #[macro_use] extern crate rocket;
 /// #[get("/item/<id>?<track>")]
 /// fn get_item(id: i32, track: Option<String>) { /* .. */ }
@@ -70,7 +70,7 @@ use crate::uri::{Uri, UriPart, Path, Query, Formatter};
 /// A URI for this route can be generated as follows:
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene, decl_macro)]
+/// # #![feature(proc_macro_hygiene)]
 /// # #[macro_use] extern crate rocket;
 /// # type T = ();
 /// # #[get("/item/<id>?<track>")]
@@ -234,7 +234,7 @@ use crate::uri::{Uri, UriPart, Path, Query, Formatter};
 /// `UriDisplay` implementation is required.
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene, decl_macro)]
+/// # #![feature(proc_macro_hygiene)]
 /// # #[macro_use] extern crate rocket;
 /// use rocket::http::RawStr;
 /// use rocket::request::FromParam;
@@ -432,7 +432,7 @@ impl<T: UriDisplay<Query>, E> UriDisplay<Query> for Result<T, E> {
 /// trait for the corresponding `UriPart`.
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene, decl_macro)]
+/// # #![feature(proc_macro_hygiene)]
 /// # #[macro_use] extern crate rocket;
 /// #[get("/item/<id>?<track>")]
 /// fn get_item(id: i32, track: Option<u8>) { /* .. */ }

--- a/core/lib/benches/format-routing.rs
+++ b/core/lib/benches/format-routing.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/core/lib/benches/ranked-routing.rs
+++ b/core/lib/benches/ranked-routing.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/core/lib/benches/simple-routing.rs
+++ b/core/lib/benches/simple-routing.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 // #![feature(alloc_system)]
 // extern crate alloc_system;
 

--- a/core/lib/src/catcher.rs
+++ b/core/lib/src/catcher.rs
@@ -34,7 +34,7 @@ use yansi::Color::*;
 /// declared using the `catch` decorator, as follows:
 ///
 /// ```rust
-/// #![feature(proc_macro_hygiene, decl_macro)]
+/// #![feature(proc_macro_hygiene)]
 ///
 /// #[macro_use] extern crate rocket;
 ///

--- a/core/lib/src/data/data.rs
+++ b/core/lib/src/data/data.rs
@@ -31,7 +31,7 @@ const PEEK_BYTES: usize = 512;
 /// specifying the `data = "<var>"` route parameter as follows:
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene, decl_macro)]
+/// # #![feature(proc_macro_hygiene)]
 /// # #[macro_use] extern crate rocket;
 /// # type DataGuard = rocket::data::Data;
 /// #[post("/submit", data = "<var>")]

--- a/core/lib/src/data/from_data.rs
+++ b/core/lib/src/data/from_data.rs
@@ -135,7 +135,7 @@ pub type Transformed<'a, T> =
 /// if the guard returns successfully.
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene, decl_macro)]
+/// # #![feature(proc_macro_hygiene)]
 /// # #[macro_use] extern crate rocket;
 /// # type DataGuard = rocket::data::Data;
 /// #[post("/submit", data = "<var>")]
@@ -181,7 +181,7 @@ pub type Transformed<'a, T> =
 /// `String` (an `&str`).
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene, decl_macro)]
+/// # #![feature(proc_macro_hygiene)]
 /// # #[macro_use] extern crate rocket;
 /// # #[derive(Debug)]
 /// # struct Name<'a> { first: &'a str, last: &'a str, }
@@ -427,7 +427,7 @@ impl<'f> FromData<'f> for Data {
 /// that you can retrieve it directly from a client's request body:
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene, decl_macro)]
+/// # #![feature(proc_macro_hygiene)]
 /// # #[macro_use] extern crate rocket;
 /// # type Person = rocket::data::Data;
 /// #[post("/person", data = "<person>")]
@@ -439,7 +439,7 @@ impl<'f> FromData<'f> for Data {
 /// A `FromDataSimple` implementation allowing this looks like:
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene, decl_macro)]
+/// # #![feature(proc_macro_hygiene)]
 /// # #[macro_use] extern crate rocket;
 /// #
 /// # #[derive(Debug)]

--- a/core/lib/src/handler.rs
+++ b/core/lib/src/handler.rs
@@ -86,7 +86,7 @@ pub type Outcome<'r> = outcome::Outcome<Response<'r>, Status, Data>;
 /// managed state and a static route, as follows:
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene, decl_macro)]
+/// # #![feature(proc_macro_hygiene)]
 /// # #[macro_use] extern crate rocket;
 /// #
 /// # #[derive(Copy, Clone)]

--- a/core/lib/src/lib.rs
+++ b/core/lib/src/lib.rs
@@ -1,5 +1,4 @@
 #![feature(specialization)]
-#![feature(decl_macro)]
 #![feature(try_trait)]
 #![feature(proc_macro_hygiene)]
 #![feature(crate_visibility_modifier)]
@@ -52,7 +51,7 @@
 //! Then, add the following to the top of your `main.rs` file:
 //!
 //! ```rust
-//! #![feature(proc_macro_hygiene, decl_macro)]
+//! #![feature(proc_macro_hygiene)]
 //!
 //! #[macro_use] extern crate rocket;
 //! # #[get("/")] fn hello() { }
@@ -63,7 +62,7 @@
 //! write Rocket applications. Here's a simple example to get you started:
 //!
 //! ```rust
-//! #![feature(proc_macro_hygiene, decl_macro)]
+//! #![feature(proc_macro_hygiene)]
 //!
 //! #[macro_use] extern crate rocket;
 //!

--- a/core/lib/src/local/mod.rs
+++ b/core/lib/src/local/mod.rs
@@ -67,7 +67,7 @@
 //! consider the following complete "Hello, world!" application, with testing.
 //!
 //! ```rust
-//! #![feature(proc_macro_hygiene, decl_macro)]
+//! #![feature(proc_macro_hygiene)]
 //!
 //! #[macro_use] extern crate rocket;
 //!

--- a/core/lib/src/request/form/error.rs
+++ b/core/lib/src/request/form/error.rs
@@ -50,7 +50,7 @@ pub enum FormDataError<'f, E> {
 /// # Example
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene, decl_macro)]
+/// # #![feature(proc_macro_hygiene)]
 /// # #[macro_use] extern crate rocket;
 /// use rocket::request::{Form, FormError, FormDataError};
 ///

--- a/core/lib/src/request/form/form.rs
+++ b/core/lib/src/request/form/form.rs
@@ -30,7 +30,7 @@ use crate::http::{Status, uri::{Query, FromUriParam}};
 /// implements the `FromForm` trait:
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene, decl_macro)]
+/// # #![feature(proc_macro_hygiene)]
 /// # #[macro_use] extern crate rocket;
 /// use rocket::request::Form;
 /// use rocket::http::RawStr;
@@ -66,7 +66,7 @@ use crate::http::{Status, uri::{Query, FromUriParam}};
 /// A handler that handles a form of this type can similarly by written:
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene, decl_macro)]
+/// # #![feature(proc_macro_hygiene)]
 /// # #![allow(deprecated, unused_attributes)]
 /// # #[macro_use] extern crate rocket;
 /// # use rocket::request::Form;
@@ -119,7 +119,7 @@ impl<T> Form<T> {
     /// # Example
     ///
     /// ```rust
-    /// # #![feature(proc_macro_hygiene, decl_macro)]
+    /// # #![feature(proc_macro_hygiene)]
     /// # #[macro_use] extern crate rocket;
     /// use rocket::request::Form;
     ///

--- a/core/lib/src/request/form/from_form.rs
+++ b/core/lib/src/request/form/from_form.rs
@@ -13,7 +13,7 @@ use crate::request::FormItems;
 /// validation.
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene, decl_macro)]
+/// # #![feature(proc_macro_hygiene)]
 /// # #![allow(deprecated, dead_code, unused_attributes)]
 /// # #[macro_use] extern crate rocket;
 /// #[derive(FromForm)]
@@ -30,7 +30,7 @@ use crate::request::FormItems;
 /// data via the `data` parameter and `Form` type.
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene, decl_macro)]
+/// # #![feature(proc_macro_hygiene)]
 /// # #![allow(deprecated, dead_code, unused_attributes)]
 /// # #[macro_use] extern crate rocket;
 /// # use rocket::request::Form;

--- a/core/lib/src/request/form/from_form_value.rs
+++ b/core/lib/src/request/form/from_form_value.rs
@@ -43,7 +43,7 @@ use crate::http::RawStr;
 /// according to its target type:
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene, decl_macro)]
+/// # #![feature(proc_macro_hygiene)]
 /// # #[macro_use] extern crate rocket;
 /// # type Size = String;
 /// #[get("/item?<id>&<size>")]

--- a/core/lib/src/request/form/lenient.rs
+++ b/core/lib/src/request/form/lenient.rs
@@ -31,7 +31,7 @@ use crate::http::uri::{Query, FromUriParam};
 /// handler:
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene, decl_macro)]
+/// # #![feature(proc_macro_hygiene)]
 /// # #[macro_use] extern crate rocket;
 /// use rocket::request::LenientForm;
 ///
@@ -67,7 +67,7 @@ impl<T> LenientForm<T> {
     /// # Example
     ///
     /// ```rust
-    /// # #![feature(proc_macro_hygiene, decl_macro)]
+    /// # #![feature(proc_macro_hygiene)]
     /// # #[macro_use] extern crate rocket;
     /// use rocket::request::LenientForm;
     ///

--- a/core/lib/src/request/from_request.rs
+++ b/core/lib/src/request/from_request.rs
@@ -55,7 +55,7 @@ impl<S, E> IntoOutcome<S, (Status, E), ()> for Result<S, E> {
 /// guard.
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene, decl_macro)]
+/// # #![feature(proc_macro_hygiene)]
 /// # #[macro_use] extern crate rocket;
 /// # use rocket::http::Method;
 /// # type A = Method; type B = Method; type C = Method; type T = ();
@@ -165,7 +165,7 @@ impl<S, E> IntoOutcome<S, (Status, E), ()> for Result<S, E> {
 /// `sensitive` handler.
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene, decl_macro)]
+/// # #![feature(proc_macro_hygiene)]
 /// # #[macro_use] extern crate rocket;
 /// #
 /// use rocket::Outcome;
@@ -220,7 +220,7 @@ impl<S, E> IntoOutcome<S, (Status, E), ()> for Result<S, E> {
 /// routes (`admin_dashboard` and `user_dashboard`):
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene, decl_macro)]
+/// # #![feature(proc_macro_hygiene)]
 /// # #[macro_use] extern crate rocket;
 /// # #[cfg(feature = "private-cookies")] mod inner {
 /// # use rocket::outcome::{IntoOutcome, Outcome};
@@ -283,7 +283,7 @@ impl<S, E> IntoOutcome<S, (Status, E), ()> for Result<S, E> {
 /// used, as illustrated below:
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene, decl_macro)]
+/// # #![feature(proc_macro_hygiene)]
 /// # #[macro_use] extern crate rocket;
 /// # #[cfg(feature = "private-cookies")] mod inner {
 /// # use rocket::outcome::{IntoOutcome, Outcome};

--- a/core/lib/src/request/param.rs
+++ b/core/lib/src/request/param.rs
@@ -19,7 +19,7 @@ use crate::http::{RawStr, uri::{Segments, SegmentError}};
 /// handler for the dynamic `"/<id>"` path:
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene, decl_macro)]
+/// # #![feature(proc_macro_hygiene)]
 /// # #[macro_use] extern crate rocket;
 /// #[get("/<id>")]
 /// fn hello(id: usize) -> String {
@@ -54,7 +54,7 @@ use crate::http::{RawStr, uri::{Segments, SegmentError}};
 /// parameter as follows:
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene, decl_macro)]
+/// # #![feature(proc_macro_hygiene)]
 /// # #[macro_use] extern crate rocket;
 /// # use rocket::http::RawStr;
 /// #[get("/<id>")]
@@ -172,7 +172,7 @@ use crate::http::{RawStr, uri::{Segments, SegmentError}};
 /// dynamic path segment:
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene, decl_macro)]
+/// # #![feature(proc_macro_hygiene)]
 /// # #[macro_use] extern crate rocket;
 /// # use rocket::request::FromParam;
 /// # use rocket::http::RawStr;

--- a/core/lib/src/request/query.rs
+++ b/core/lib/src/request/query.rs
@@ -8,7 +8,7 @@ use crate::request::{FormItems, FormItem, Form, LenientForm, FromForm};
 /// generation for every trailing query parameter, `<params..>` below:
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene, decl_macro)]
+/// # #![feature(proc_macro_hygiene)]
 /// # #[macro_use] extern crate rocket;
 /// #
 /// # use rocket::request::Form;
@@ -82,7 +82,7 @@ impl<'q> Iterator for Query<'q> {
 /// route:
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene, decl_macro)]
+/// # #![feature(proc_macro_hygiene)]
 /// # #[macro_use] extern crate rocket;
 /// use rocket::request::Form;
 ///

--- a/core/lib/src/request/state.rs
+++ b/core/lib/src/request/state.rs
@@ -22,7 +22,7 @@ use crate::http::Status;
 /// following example does just this:
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene, decl_macro)]
+/// # #![feature(proc_macro_hygiene)]
 /// # #[macro_use] extern crate rocket;
 /// use rocket::State;
 ///
@@ -87,7 +87,7 @@ use crate::http::Status;
 /// [`State::from()`] static method:
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene, decl_macro)]
+/// # #![feature(proc_macro_hygiene)]
 /// # #[macro_use] extern crate rocket;
 /// use rocket::State;
 ///

--- a/core/lib/src/response/flash.rs
+++ b/core/lib/src/response/flash.rs
@@ -45,7 +45,7 @@ const FLASH_COOKIE_NAME: &str = "_flash";
 /// message on both the request and response sides.
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene, decl_macro)]
+/// # #![feature(proc_macro_hygiene)]
 /// # #[macro_use] extern crate rocket;
 /// use rocket::response::{Flash, Redirect};
 /// use rocket::request::FlashMessage;

--- a/core/lib/src/response/redirect.rs
+++ b/core/lib/src/response/redirect.rs
@@ -26,7 +26,7 @@ use crate::http::Status;
 /// a route, _always_ use [`uri!`] to construct a valid [`Origin`]:
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene, decl_macro)]
+/// # #![feature(proc_macro_hygiene)]
 /// # #[macro_use] extern crate rocket;
 /// use rocket::response::Redirect;
 ///

--- a/core/lib/src/response/responder.rs
+++ b/core/lib/src/response/responder.rs
@@ -12,7 +12,7 @@ use crate::request::Request;
 /// as illustrated below with `T`:
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene, decl_macro)]
+/// # #![feature(proc_macro_hygiene)]
 /// # #[macro_use] extern crate rocket;
 /// # type T = ();
 /// #
@@ -153,7 +153,7 @@ use crate::request::Request;
 /// following `Responder` implementation accomplishes this:
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene, decl_macro)]
+/// # #![feature(proc_macro_hygiene)]
 /// # #[macro_use] extern crate rocket;
 /// #
 /// # #[derive(Debug)]

--- a/core/lib/src/rocket.rs
+++ b/core/lib/src/rocket.rs
@@ -457,7 +457,7 @@ impl Rocket {
     /// dispatched to the `hi` route.
     ///
     /// ```rust
-    /// # #![feature(proc_macro_hygiene, decl_macro)]
+    /// # #![feature(proc_macro_hygiene)]
     /// # #[macro_use] extern crate rocket;
     /// #
     /// #[get("/world")]
@@ -529,7 +529,7 @@ impl Rocket {
     /// # Examples
     ///
     /// ```rust
-    /// # #![feature(proc_macro_hygiene, decl_macro)]
+    /// # #![feature(proc_macro_hygiene)]
     /// # #[macro_use] extern crate rocket;
     /// use rocket::Request;
     ///
@@ -584,7 +584,7 @@ impl Rocket {
     /// # Example
     ///
     /// ```rust
-    /// # #![feature(proc_macro_hygiene, decl_macro)]
+    /// # #![feature(proc_macro_hygiene)]
     /// # #[macro_use] extern crate rocket;
     /// use rocket::State;
     ///
@@ -621,7 +621,7 @@ impl Rocket {
     /// # Example
     ///
     /// ```rust
-    /// # #![feature(proc_macro_hygiene, decl_macro)]
+    /// # #![feature(proc_macro_hygiene)]
     /// # #[macro_use] extern crate rocket;
     /// use rocket::Rocket;
     /// use rocket::fairing::AdHoc;
@@ -735,7 +735,7 @@ impl Rocket {
     /// # Example
     ///
     /// ```rust
-    /// # #![feature(proc_macro_hygiene, decl_macro)]
+    /// # #![feature(proc_macro_hygiene)]
     /// # #[macro_use] extern crate rocket;
     /// use rocket::Rocket;
     /// use rocket::fairing::AdHoc;
@@ -791,7 +791,7 @@ impl Rocket {
     /// # Example
     ///
     /// ```rust
-    /// # #![feature(proc_macro_hygiene, decl_macro)]
+    /// # #![feature(proc_macro_hygiene)]
     /// # #[macro_use] extern crate rocket;
     /// use rocket::Rocket;
     /// use rocket::fairing::AdHoc;

--- a/core/lib/tests/absolute-uris-okay-issue-443.rs
+++ b/core/lib/tests/absolute-uris-okay-issue-443.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/core/lib/tests/conditionally-set-server-header-996.rs
+++ b/core/lib/tests/conditionally-set-server-header-996.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/core/lib/tests/derive-reexports.rs
+++ b/core/lib/tests/derive-reexports.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 use rocket;
 

--- a/core/lib/tests/fairing_before_head_strip-issue-546.rs
+++ b/core/lib/tests/fairing_before_head_strip-issue-546.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/core/lib/tests/flash-lazy-removes-issue-466.rs
+++ b/core/lib/tests/flash-lazy-removes-issue-466.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/core/lib/tests/form_method-issue-45.rs
+++ b/core/lib/tests/form_method-issue-45.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/core/lib/tests/form_value_decoding-issue-82.rs
+++ b/core/lib/tests/form_value_decoding-issue-82.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/core/lib/tests/head_handling.rs
+++ b/core/lib/tests/head_handling.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/core/lib/tests/limits.rs
+++ b/core/lib/tests/limits.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/core/lib/tests/local-request-content-type-issue-505.rs
+++ b/core/lib/tests/local-request-content-type-issue-505.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/core/lib/tests/local_request_private_cookie-issue-368.rs
+++ b/core/lib/tests/local_request_private_cookie-issue-368.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use]
 #[cfg(feature = "private-cookies")]

--- a/core/lib/tests/nested-fairing-attaches.rs
+++ b/core/lib/tests/nested-fairing-attaches.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/core/lib/tests/precise-content-type-matching.rs
+++ b/core/lib/tests/precise-content-type-matching.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/core/lib/tests/redirect_from_catcher-issue-113.rs
+++ b/core/lib/tests/redirect_from_catcher-issue-113.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/core/lib/tests/responder_lifetime-issue-345.rs
+++ b/core/lib/tests/responder_lifetime-issue-345.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 #![allow(dead_code)] // This test is only here so that we can ensure it compiles.
 
 #[macro_use] extern crate rocket;

--- a/core/lib/tests/route_guard.rs
+++ b/core/lib/tests/route_guard.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/core/lib/tests/segments-issues-41-86.rs
+++ b/core/lib/tests/segments-issues-41-86.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/core/lib/tests/strict_and_lenient_forms.rs
+++ b/core/lib/tests/strict_and_lenient_forms.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/core/lib/tests/uri-percent-encoding-issue-808.rs
+++ b/core/lib/tests/uri-percent-encoding-issue-808.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/examples/config/tests/development.rs
+++ b/examples/config/tests/development.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/examples/config/tests/production.rs
+++ b/examples/config/tests/production.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/examples/config/tests/staging.rs
+++ b/examples/config/tests/staging.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/examples/content_types/src/main.rs
+++ b/examples/content_types/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 #[macro_use] extern crate serde_derive;

--- a/examples/cookies/src/main.rs
+++ b/examples/cookies/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/examples/errors/src/main.rs
+++ b/examples/errors/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/examples/fairings/src/main.rs
+++ b/examples/fairings/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/examples/form_kitchen_sink/src/main.rs
+++ b/examples/form_kitchen_sink/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/examples/form_validation/src/main.rs
+++ b/examples/form_validation/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/examples/handlebars_templates/src/main.rs
+++ b/examples/handlebars_templates/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 #[macro_use] extern crate serde_derive;

--- a/examples/hello_2015/src/main.rs
+++ b/examples/hello_2015/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/examples/hello_2018/src/main.rs
+++ b/examples/hello_2018/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[cfg(test)] mod tests;
 

--- a/examples/hello_person/src/main.rs
+++ b/examples/hello_person/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/examples/hello_world/src/main.rs
+++ b/examples/hello_world/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/examples/json/src/main.rs
+++ b/examples/json/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 #[macro_use] extern crate rocket_contrib;

--- a/examples/managed_queue/src/main.rs
+++ b/examples/managed_queue/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/examples/msgpack/src/main.rs
+++ b/examples/msgpack/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 #[macro_use] extern crate serde_derive;

--- a/examples/optional_redirect/src/main.rs
+++ b/examples/optional_redirect/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/examples/pastebin/src/main.rs
+++ b/examples/pastebin/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/examples/query_params/src/main.rs
+++ b/examples/query_params/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/examples/ranking/src/main.rs
+++ b/examples/ranking/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/examples/raw_sqlite/src/main.rs
+++ b/examples/raw_sqlite/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/examples/raw_upload/src/main.rs
+++ b/examples/raw_upload/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/examples/redirect/src/main.rs
+++ b/examples/redirect/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/examples/request_guard/src/main.rs
+++ b/examples/request_guard/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/examples/request_local_state/src/main.rs
+++ b/examples/request_local_state/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/examples/session/src/main.rs
+++ b/examples/session/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/examples/state/src/main.rs
+++ b/examples/state/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/examples/stream/src/main.rs
+++ b/examples/stream/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/examples/tera_templates/src/main.rs
+++ b/examples/tera_templates/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 #[macro_use] extern crate serde_derive;

--- a/examples/testing/src/main.rs
+++ b/examples/testing/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/examples/tls/src/main.rs
+++ b/examples/tls/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/examples/todo/src/main.rs
+++ b/examples/todo/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 #[macro_use] extern crate diesel;

--- a/examples/uuid/src/main.rs
+++ b/examples/uuid/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 #[macro_use] extern crate lazy_static;

--- a/site/guide/10-pastebin.md
+++ b/site/guide/10-pastebin.md
@@ -50,7 +50,7 @@ And finally, create a skeleton Rocket application to work off of in
 `src/main.rs`:
 
 ```rust
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/site/guide/2-getting-started.md
+++ b/site/guide/2-getting-started.md
@@ -57,7 +57,7 @@ Modify `src/main.rs` so that it contains the code for the Rocket `Hello, world!`
 program, reproduced below:
 
 ```rust
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/site/guide/3-overview.md
+++ b/site/guide/3-overview.md
@@ -141,7 +141,7 @@ We typically call `launch` from the `main` function. Our complete _Hello,
 world!_ application thus looks like:
 
 ```rust
-#![feature(proc_macro_hygiene, decl_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 

--- a/site/index.toml
+++ b/site/index.toml
@@ -47,7 +47,7 @@ margin = 9
 [[sections]]
 title = "Hello, Rocket!"
 code = '''
-  #![feature(proc_macro_hygiene, decl_macro)]
+  #![feature(proc_macro_hygiene)]
 
   #[macro_use] extern crate rocket;
 


### PR DESCRIPTION
This removes the use of `decl_macro` in generated routes, removing it from the list of unstable features rocket depends on. This is done according to the strategy outlined in https://github.com/SergioBenitez/Rocket/issues/19#issuecomment-453822603, which became possible when `uniform_paths` was implemented and/or stabilized.

However, it requires that crates that use `#[route]` are compiled with the 2018 edition - see https://play.rust-lang.org/?version=stable&mode=debug&edition=2015&gist=17ec58c07d13f2309458dcf9060e642a, a smaller reproduction that works in the 2018 edition but fails on 2015 for the same reason as this approach.

Unresolved:
* [x] Is reexporting macro_rules macros like this really intended to work? ~~It almost seems like an accident, and it doesn't seem to be communicated/documented very well.~~ **Yes, it is.**
* [x] Is it at all possible to accomplish this in the 2015 edition? Whatever solution is used must also work for crates using the 2018 edition. *Note that async/await support will almost certainly require all application crates to update to the 2018 edition anyway, so 2015 compatibility for this issue might not be worth the effort.*
  * **Yes, as long as `rocket_codegen` itself is 2018 edition and we use the right spans the "hack" will work for both 2015 and 2018 application crates.**
* [ ] The random suffix generation is necessary with `#[macro_export]` + `pub use`, because all macros globally exported with `macro_export` must be unambiguous. It looks like we can skip `#[macro_export]` and do a `pub(crate) use` instead, making the random generation unnecessary. However, I believe that would restrict the `uri!` macro to being called from the same crate where the route was defined.
  * Instead of a random suffix, this could be a hash of file+line+column or something similar.
* [x] ~~blah blah 2015 2018 worrying~~ Will wait for #1013 to be merged, and `rocket_codegen` is 2018 edition and this PR will be much easier.
* [x] The "real" macro should be `#[doc(hidden)]` if possible.
* [x] This bumps the minimum rustc version, probably around 2019-01-13 (not as recent as `try_from`, but this is `codegen` and `try_from` is in `core`)
  * Something else already bumped this version up