### PR TITLE
Replace all uses of the never type (`!`) with the stable `Infallible`

### DIFF
--- a/contrib/lib/src/lib.rs
+++ b/contrib/lib/src/lib.rs
@@ -1,5 +1,4 @@
 #![feature(crate_visibility_modifier)]
-#![feature(never_type)]
 #![feature(doc_cfg)]
 
 #![doc(html_root_url = "https://api.rocket.rs/v0.5")]

--- a/core/http/src/cookies.rs
+++ b/core/http/src/cookies.rs
@@ -1,8 +1,8 @@
 use std::fmt;
 use std::cell::RefMut;
 
-use cookie::Delta;
 use crate::Header;
+use cookie::Delta;
 
 #[doc(hidden)] pub use self::key::*;
 pub use cookie::{Cookie, CookieJar, SameSite};

--- a/core/http/src/cookies.rs
+++ b/core/http/src/cookies.rs
@@ -1,10 +1,11 @@
-use std::fmt;
 use std::cell::RefMut;
+use std::fmt;
 
-use crate::Header;
 use cookie::Delta;
+use crate::Header;
 
-#[doc(hidden)] pub use self::key::*;
+#[doc(hidden)]
+pub use self::key::*;
 pub use cookie::{Cookie, CookieJar, SameSite};
 
 /// Types and methods to manage a `Key` when private cookies are enabled.
@@ -20,8 +21,12 @@ mod key {
     pub struct Key;
 
     impl Key {
-        pub fn generate() -> Self { Key }
-        pub fn from_master(_bytes: &[u8]) -> Self { Key }
+        pub fn generate() -> Self {
+            Key
+        }
+        pub fn from_master(_bytes: &[u8]) -> Self {
+            Key
+        }
     }
 }
 
@@ -74,20 +79,21 @@ mod key {
 /// [private cookie]: Cookies::add_private()
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene, decl_macro, never_type)]
+/// # #![feature(proc_macro_hygiene, decl_macro)]
 /// # #[macro_use] extern crate rocket;
 /// #
 /// use rocket::http::Status;
 /// use rocket::outcome::IntoOutcome;
 /// use rocket::request::{self, Request, FromRequest};
+/// use std::convert::Infallible;
 ///
 /// // In practice, we'd probably fetch the user from the database.
 /// struct User(usize);
 ///
 /// impl FromRequest<'_, '_> for User {
-///     type Error = !;
+///     type Error = Infallible;
 ///
-///     fn from_request(request: &Request<'_>) -> request::Outcome<User, !> {
+///     fn from_request(request: &Request<'_>) -> request::Outcome<Self, Self::Error> {
 ///         request.cookies()
 ///             .get_private("user_id")
 ///             .and_then(|cookie| cookie.value().parse().ok())
@@ -130,7 +136,7 @@ pub enum Cookies<'a> {
     #[doc(hidden)]
     Jarred(RefMut<'a, CookieJar>, &'a Key),
     #[doc(hidden)]
-    Empty(CookieJar)
+    Empty(CookieJar),
 }
 
 impl<'a> Cookies<'a> {
@@ -152,7 +158,9 @@ impl<'a> Cookies<'a> {
     #[doc(hidden)]
     #[inline(always)]
     pub fn parse_cookie(cookie_str: &str) -> Option<Cookie<'static>> {
-        Cookie::parse_encoded(cookie_str).map(|c| c.into_owned()).ok()
+        Cookie::parse_encoded(cookie_str)
+            .map(|c| c.into_owned())
+            .ok()
     }
 
     /// Adds an original `cookie` to this collection.
@@ -181,7 +189,7 @@ impl<'a> Cookies<'a> {
     pub fn get(&self, name: &str) -> Option<&Cookie<'static>> {
         match *self {
             Cookies::Jarred(ref jar, _) => jar.get(name),
-            Cookies::Empty(_) => None
+            Cookies::Empty(_) => None,
         }
     }
 
@@ -250,10 +258,10 @@ impl<'a> Cookies<'a> {
     ///     }
     /// }
     /// ```
-    pub fn iter(&self) -> impl Iterator<Item=&Cookie<'static>> {
+    pub fn iter(&self) -> impl Iterator<Item = &Cookie<'static>> {
         match *self {
             Cookies::Jarred(ref jar, _) => jar.iter(),
-            Cookies::Empty(ref jar) => jar.iter()
+            Cookies::Empty(ref jar) => jar.iter(),
         }
     }
 
@@ -263,7 +271,7 @@ impl<'a> Cookies<'a> {
     pub fn delta(&self) -> Delta<'_> {
         match *self {
             Cookies::Jarred(ref jar, _) => jar.delta(),
-            Cookies::Empty(ref jar) => jar.delta()
+            Cookies::Empty(ref jar) => jar.delta(),
         }
     }
 }
@@ -291,7 +299,7 @@ impl Cookies<'_> {
     pub fn get_private(&mut self, name: &str) -> Option<Cookie<'static>> {
         match *self {
             Cookies::Jarred(ref mut jar, key) => jar.private(key).get(name),
-            Cookies::Empty(_) => None
+            Cookies::Empty(_) => None,
         }
     }
 
@@ -404,7 +412,7 @@ impl fmt::Debug for Cookies<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             Cookies::Jarred(ref jar, _) => write!(f, "{:?}", jar),
-            Cookies::Empty(ref jar) => write!(f, "{:?}", jar)
+            Cookies::Empty(ref jar) => write!(f, "{:?}", jar),
         }
     }
 }

--- a/core/http/src/cookies.rs
+++ b/core/http/src/cookies.rs
@@ -1,11 +1,10 @@
-use std::cell::RefMut;
 use std::fmt;
+use std::cell::RefMut;
 
 use cookie::Delta;
 use crate::Header;
 
-#[doc(hidden)]
-pub use self::key::*;
+#[doc(hidden)] pub use self::key::*;
 pub use cookie::{Cookie, CookieJar, SameSite};
 
 /// Types and methods to manage a `Key` when private cookies are enabled.
@@ -21,12 +20,8 @@ mod key {
     pub struct Key;
 
     impl Key {
-        pub fn generate() -> Self {
-            Key
-        }
-        pub fn from_master(_bytes: &[u8]) -> Self {
-            Key
-        }
+        pub fn generate() -> Self { Key }
+        pub fn from_master(_bytes: &[u8]) -> Self { Key }
     }
 }
 
@@ -136,7 +131,7 @@ pub enum Cookies<'a> {
     #[doc(hidden)]
     Jarred(RefMut<'a, CookieJar>, &'a Key),
     #[doc(hidden)]
-    Empty(CookieJar),
+    Empty(CookieJar)
 }
 
 impl<'a> Cookies<'a> {
@@ -158,9 +153,7 @@ impl<'a> Cookies<'a> {
     #[doc(hidden)]
     #[inline(always)]
     pub fn parse_cookie(cookie_str: &str) -> Option<Cookie<'static>> {
-        Cookie::parse_encoded(cookie_str)
-            .map(|c| c.into_owned())
-            .ok()
+        Cookie::parse_encoded(cookie_str).map(|c| c.into_owned()).ok()
     }
 
     /// Adds an original `cookie` to this collection.
@@ -189,7 +182,7 @@ impl<'a> Cookies<'a> {
     pub fn get(&self, name: &str) -> Option<&Cookie<'static>> {
         match *self {
             Cookies::Jarred(ref jar, _) => jar.get(name),
-            Cookies::Empty(_) => None,
+            Cookies::Empty(_) => None
         }
     }
 
@@ -258,10 +251,10 @@ impl<'a> Cookies<'a> {
     ///     }
     /// }
     /// ```
-    pub fn iter(&self) -> impl Iterator<Item = &Cookie<'static>> {
+    pub fn iter(&self) -> impl Iterator<Item=&Cookie<'static>> {
         match *self {
             Cookies::Jarred(ref jar, _) => jar.iter(),
-            Cookies::Empty(ref jar) => jar.iter(),
+            Cookies::Empty(ref jar) => jar.iter()
         }
     }
 
@@ -271,7 +264,7 @@ impl<'a> Cookies<'a> {
     pub fn delta(&self) -> Delta<'_> {
         match *self {
             Cookies::Jarred(ref jar, _) => jar.delta(),
-            Cookies::Empty(ref jar) => jar.delta(),
+            Cookies::Empty(ref jar) => jar.delta()
         }
     }
 }
@@ -299,7 +292,7 @@ impl Cookies<'_> {
     pub fn get_private(&mut self, name: &str) -> Option<Cookie<'static>> {
         match *self {
             Cookies::Jarred(ref mut jar, key) => jar.private(key).get(name),
-            Cookies::Empty(_) => None,
+            Cookies::Empty(_) => None
         }
     }
 
@@ -412,7 +405,7 @@ impl fmt::Debug for Cookies<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             Cookies::Jarred(ref jar, _) => write!(f, "{:?}", jar),
-            Cookies::Empty(ref jar) => write!(f, "{:?}", jar),
+            Cookies::Empty(ref jar) => write!(f, "{:?}", jar)
         }
     }
 }

--- a/core/lib/src/config/mod.rs
+++ b/core/lib/src/config/mod.rs
@@ -194,6 +194,7 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process;
 use std::env;
+use std::convert::Infallible;
 
 use toml;
 
@@ -444,23 +445,36 @@ impl RocketConfig {
 ///
 /// If there is a problem, prints a nice error message and bails.
 crate fn init() -> Config {
-    let bail = |e: ConfigError| -> ! {
+    let bail = |e: ConfigError| -> Infallible {
         logger::init(LoggingLevel::Debug);
         e.pretty_print();
-        process::exit(1)
+        process::exit(1);
     };
+
+    // The compiler is unable to realize that a function returning `Infallible`
+    // will never return. We use `unreachable_unchecked()` to hint to the
+    // compiler that this location in code can never be reached, and it doesn't
+    // need to verify that fact. Once `Infallible` becomes an alias to `!`, this
+    // macro can be removed and its invocations replaced with `bail(e)`.
+    // FIXME: Remove when `!` type stabilizes.
+    macro_rules! bail {
+        ($e:ident) => {{
+            bail($e);
+            unsafe { std::hint::unreachable_unchecked() }
+        }}
+    }
 
     use self::ConfigError::*;
     let config = RocketConfig::read().unwrap_or_else(|e| {
         match e {
             | ParseError(..) | BadEntry(..) | BadEnv(..) | BadType(..) | Io(..)
             | BadFilePath(..) | BadEnvVal(..) | UnknownKey(..)
-            | Missing(..) => bail(e),
+            | Missing(..) => bail!(e),
             IoError => warn!("Failed reading Rocket.toml. Using defaults."),
             NotFound => { /* try using the default below */ }
         }
 
-        RocketConfig::active_default().unwrap_or_else(|e| bail(e))
+        RocketConfig::active_default().unwrap_or_else(|e| bail!(e))
     });
 
     // FIXME: Should probably store all of the config.

--- a/core/lib/src/config/mod.rs
+++ b/core/lib/src/config/mod.rs
@@ -194,7 +194,6 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process;
 use std::env;
-use std::convert::Infallible;
 
 use toml;
 

--- a/core/lib/src/data/from_data.rs
+++ b/core/lib/src/data/from_data.rs
@@ -1,4 +1,5 @@
 use std::borrow::Borrow;
+use std::convert::Infallible;
 
 use crate::outcome::{self, IntoOutcome};
 use crate::outcome::Outcome::*;
@@ -388,7 +389,7 @@ pub trait FromData<'a>: Sized {
 
 /// The identity implementation of `FromData`. Always returns `Success`.
 impl<'f> FromData<'f> for Data {
-    type Error = !;
+    type Error = Infallible;
     type Owned = Data;
     type Borrowed = Data;
 

--- a/core/lib/src/lib.rs
+++ b/core/lib/src/lib.rs
@@ -1,7 +1,6 @@
 #![feature(specialization)]
 #![feature(decl_macro)]
 #![feature(try_trait)]
-#![feature(never_type)]
 #![feature(proc_macro_hygiene)]
 #![feature(crate_visibility_modifier)]
 #![feature(label_break_value)]

--- a/core/lib/src/request/form/from_form.rs
+++ b/core/lib/src/request/form/from_form.rs
@@ -1,4 +1,5 @@
 use crate::request::FormItems;
+use std::convert::Infallible;
 
 /// Trait to create an instance of some type from an HTTP form.
 /// [`Form`](crate::request::Form) requires its generic type to implement this trait.
@@ -111,19 +112,19 @@ pub trait FromForm<'f>: Sized {
 }
 
 impl<'f, T: FromForm<'f>> FromForm<'f> for Option<T> {
-    type Error = !;
+    type Error = Infallible;
 
     #[inline]
-    fn from_form(items: &mut FormItems<'f>, strict: bool) -> Result<Option<T>, !> {
+    fn from_form(items: &mut FormItems<'f>, strict: bool) -> Result<Option<T>, Self::Error> {
         Ok(T::from_form(items, strict).ok())
     }
 }
 
 impl<'f, T: FromForm<'f>> FromForm<'f> for Result<T, T::Error> {
-    type Error = !;
+    type Error = Infallible;
 
     #[inline]
-    fn from_form(items: &mut FormItems<'f>, strict: bool) -> Result<Self, !> {
+    fn from_form(items: &mut FormItems<'f>, strict: bool) -> Result<Self, Self::Error> {
         Ok(T::from_form(items, strict))
     }
 }

--- a/core/lib/src/request/form/from_form_value.rs
+++ b/core/lib/src/request/form/from_form_value.rs
@@ -4,6 +4,7 @@ use std::num::{
     NonZeroI8, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI128, NonZeroIsize,
     NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU128, NonZeroUsize,
 };
+use std::convert::Infallible;
 
 use crate::http::RawStr;
 
@@ -191,7 +192,7 @@ pub trait FromFormValue<'v>: Sized {
 }
 
 impl<'v> FromFormValue<'v> for &'v RawStr {
-    type Error = !;
+    type Error = Infallible;
 
     // This just gives the raw string.
     #[inline(always)]
@@ -248,7 +249,7 @@ impl_with_fromstr!(
 );
 
 impl<'v, T: FromFormValue<'v>> FromFormValue<'v> for Option<T> {
-    type Error = !;
+    type Error = Infallible;
 
     #[inline(always)]
     fn from_form_value(v: &'v RawStr) -> Result<Self, Self::Error> {
@@ -266,7 +267,7 @@ impl<'v, T: FromFormValue<'v>> FromFormValue<'v> for Option<T> {
 
 // // TODO: Add more useful implementations (range, regex, etc.).
 impl<'v, T: FromFormValue<'v>> FromFormValue<'v> for Result<T, T::Error> {
-    type Error = !;
+    type Error = Infallible;
 
     #[inline(always)]
     fn from_form_value(v: &'v RawStr) -> Result<Self, Self::Error> {

--- a/core/lib/src/request/from_request.rs
+++ b/core/lib/src/request/from_request.rs
@@ -1,5 +1,6 @@
 use std::fmt::Debug;
 use std::net::SocketAddr;
+use std::convert::Infallible;
 
 use crate::router::Route;
 use crate::request::Request;
@@ -284,11 +285,11 @@ impl<S, E> IntoOutcome<S, (Status, E), ()> for Result<S, E> {
 ///
 /// ```rust
 /// # #![feature(proc_macro_hygiene, decl_macro)]
-/// # #![feature(never_type)]
 /// # #[macro_use] extern crate rocket;
 /// # #[cfg(feature = "private-cookies")] mod inner {
 /// # use rocket::outcome::{IntoOutcome, Outcome};
 /// # use rocket::request::{self, FromRequest, Request};
+/// # use std::convert::Infallible;
 /// # struct User { id: String, is_admin: bool }
 /// # struct Database;
 /// # impl Database {
@@ -306,9 +307,9 @@ impl<S, E> IntoOutcome<S, (Status, E), ()> for Result<S, E> {
 /// # struct Admin<'a> { user: &'a User }
 /// #
 /// impl<'a> FromRequest<'a, '_> for &'a User {
-///     type Error = !;
+///     type Error = Infallible;
 ///
-///     fn from_request(request: &'a Request<'_>) -> request::Outcome<&'a User, !> {
+///     fn from_request(request: &'a Request<'_>) -> request::Outcome<Self, Self::Error> {
 ///         // This closure will execute at most once per request, regardless of
 ///         // the number of times the `User` guard is executed.
 ///         let user_result = request.local_cache(|| {
@@ -324,9 +325,9 @@ impl<S, E> IntoOutcome<S, (Status, E), ()> for Result<S, E> {
 /// }
 ///
 /// impl<'a> FromRequest<'a, '_> for Admin<'a> {
-///     type Error = !;
+///     type Error = Infallible;
 ///
-///     fn from_request(request: &'a Request<'_>) -> request::Outcome<Admin<'a>, !> {
+///     fn from_request(request: &'a Request<'_>) -> request::Outcome<Self, Self::Error> {
 ///         let user = request.guard::<&User>()?;
 ///
 ///         if user.is_admin {
@@ -358,7 +359,7 @@ pub trait FromRequest<'a, 'r>: Sized {
 }
 
 impl FromRequest<'_, '_> for Method {
-    type Error = !;
+    type Error = Infallible;
 
     fn from_request(request: &Request<'_>) -> Outcome<Self, Self::Error> {
         Success(request.method())
@@ -366,7 +367,7 @@ impl FromRequest<'_, '_> for Method {
 }
 
 impl<'a> FromRequest<'a, '_> for &'a Origin<'a> {
-    type Error = !;
+    type Error = Infallible;
 
     fn from_request(request: &'a Request<'_>) -> Outcome<Self, Self::Error> {
         Success(request.uri())
@@ -374,7 +375,7 @@ impl<'a> FromRequest<'a, '_> for &'a Origin<'a> {
 }
 
 impl<'r> FromRequest<'_, 'r> for &'r Route {
-    type Error = !;
+    type Error = Infallible;
 
     fn from_request(request: &Request<'r>) -> Outcome<Self, Self::Error> {
         match request.route() {
@@ -385,7 +386,7 @@ impl<'r> FromRequest<'_, 'r> for &'r Route {
 }
 
 impl<'a> FromRequest<'a, '_> for Cookies<'a> {
-    type Error = !;
+    type Error = Infallible;
 
     fn from_request(request: &'a Request<'_>) -> Outcome<Self, Self::Error> {
         Success(request.cookies())
@@ -393,7 +394,7 @@ impl<'a> FromRequest<'a, '_> for Cookies<'a> {
 }
 
 impl<'a> FromRequest<'a, '_> for &'a Accept {
-    type Error = !;
+    type Error = Infallible;
 
     fn from_request(request: &'a Request<'_>) -> Outcome<Self, Self::Error> {
         match request.accept() {
@@ -404,7 +405,7 @@ impl<'a> FromRequest<'a, '_> for &'a Accept {
 }
 
 impl<'a> FromRequest<'a, '_> for &'a ContentType {
-    type Error = !;
+    type Error = Infallible;
 
     fn from_request(request: &'a Request<'_>) -> Outcome<Self, Self::Error> {
         match request.content_type() {
@@ -415,7 +416,7 @@ impl<'a> FromRequest<'a, '_> for &'a ContentType {
 }
 
 impl FromRequest<'_, '_> for SocketAddr {
-    type Error = !;
+    type Error = Infallible;
 
     fn from_request(request: &Request<'_>) -> Outcome<Self, Self::Error> {
         match request.remote() {
@@ -426,7 +427,7 @@ impl FromRequest<'_, '_> for SocketAddr {
 }
 
 impl<'a, 'r, T: FromRequest<'a, 'r>> FromRequest<'a, 'r> for Result<T, T::Error> {
-    type Error = !;
+    type Error = Infallible;
 
     fn from_request(request: &'a Request<'r>) -> Outcome<Self, Self::Error> {
         match T::from_request(request) {
@@ -438,7 +439,7 @@ impl<'a, 'r, T: FromRequest<'a, 'r>> FromRequest<'a, 'r> for Result<T, T::Error>
 }
 
 impl<'a, 'r, T: FromRequest<'a, 'r>> FromRequest<'a, 'r> for Option<T> {
-    type Error = !;
+    type Error = Infallible;
 
     fn from_request(request: &'a Request<'r>) -> Outcome<Self, Self::Error> {
         match T::from_request(request) {

--- a/core/lib/src/request/param.rs
+++ b/core/lib/src/request/param.rs
@@ -2,6 +2,7 @@ use std::str::FromStr;
 use std::path::PathBuf;
 use std::fmt::Debug;
 use std::borrow::Cow;
+use std::convert::Infallible;
 
 use crate::http::{RawStr, uri::{Segments, SegmentError}};
 
@@ -205,7 +206,7 @@ pub trait FromParam<'a>: Sized {
 }
 
 impl<'a> FromParam<'a> for &'a RawStr {
-    type Error = !;
+    type Error = Infallible;
 
     #[inline(always)]
     fn from_param(param: &'a RawStr) -> Result<&'a RawStr, Self::Error> {
@@ -258,7 +259,7 @@ impl_with_fromstr! {
 }
 
 impl<'a, T: FromParam<'a>> FromParam<'a> for Result<T, T::Error> {
-    type Error = !;
+    type Error = Infallible;
 
     #[inline]
     fn from_param(param: &'a RawStr) -> Result<Self, Self::Error> {
@@ -270,7 +271,7 @@ impl<'a, T: FromParam<'a>> FromParam<'a> for Result<T, T::Error> {
 }
 
 impl<'a, T: FromParam<'a>> FromParam<'a> for Option<T> {
-    type Error = !;
+    type Error = Infallible;
 
     #[inline]
     fn from_param(param: &'a RawStr) -> Result<Self, Self::Error> {
@@ -309,7 +310,7 @@ pub trait FromSegments<'a>: Sized {
 }
 
 impl<'a> FromSegments<'a> for Segments<'a> {
-    type Error = !;
+    type Error = Infallible;
 
     #[inline(always)]
     fn from_segments(segments: Segments<'a>) -> Result<Segments<'a>, Self::Error> {
@@ -342,10 +343,10 @@ impl FromSegments<'_> for PathBuf {
 }
 
 impl<'a, T: FromSegments<'a>> FromSegments<'a> for Result<T, T::Error> {
-    type Error = !;
+    type Error = Infallible;
 
     #[inline]
-    fn from_segments(segments: Segments<'a>) -> Result<Result<T, T::Error>, !> {
+    fn from_segments(segments: Segments<'a>) -> Result<Result<T, T::Error>, Self::Error> {
         match T::from_segments(segments) {
             Ok(val) => Ok(Ok(val)),
             Err(e) => Ok(Err(e)),
@@ -354,10 +355,10 @@ impl<'a, T: FromSegments<'a>> FromSegments<'a> for Result<T, T::Error> {
 }
 
 impl<'a, T: FromSegments<'a>> FromSegments<'a> for Option<T> {
-    type Error = !;
+    type Error = Infallible;
 
     #[inline]
-    fn from_segments(segments: Segments<'a>) -> Result<Option<T>, !> {
+    fn from_segments(segments: Segments<'a>) -> Result<Option<T>, Self::Error> {
         match T::from_segments(segments) {
             Ok(val) => Ok(Some(val)),
             Err(_) => Ok(None)

--- a/core/lib/src/request/query.rs
+++ b/core/lib/src/request/query.rs
@@ -1,4 +1,5 @@
 use crate::request::{FormItems, FormItem, Form, LenientForm, FromForm};
+use std::convert::Infallible;
 
 /// Iterator over form items in a query string.
 ///
@@ -219,7 +220,7 @@ impl<'q, T: FromForm<'q>> FromQuery<'q> for LenientForm<T> {
 }
 
 impl<'q, T: FromQuery<'q>> FromQuery<'q> for Option<T> {
-    type Error = !;
+    type Error = Infallible;
 
     #[inline]
     fn from_query(q: Query<'q>) -> Result<Self, Self::Error> {
@@ -228,7 +229,7 @@ impl<'q, T: FromQuery<'q>> FromQuery<'q> for Option<T> {
 }
 
 impl<'q, T: FromQuery<'q>> FromQuery<'q> for Result<T, T::Error> {
-    type Error = !;
+    type Error = Infallible;
 
     #[inline]
     fn from_query(q: Query<'q>) -> Result<Self, Self::Error> {

--- a/examples/request_guard/src/main.rs
+++ b/examples/request_guard/src/main.rs
@@ -1,17 +1,18 @@
-#![feature(proc_macro_hygiene, decl_macro, never_type)]
+#![feature(proc_macro_hygiene, decl_macro)]
 
 #[macro_use] extern crate rocket;
 
 use rocket::request::{self, Request, FromRequest};
 use rocket::outcome::Outcome::*;
+use std::convert::Infallible;
 
 #[derive(Debug)]
 struct HeaderCount(usize);
 
 impl<'a, 'r> FromRequest<'a, 'r> for HeaderCount {
-    type Error = !;
+    type Error = Infallible;
 
-    fn from_request(request: &'a Request<'r>) -> request::Outcome<Self, !> {
+    fn from_request(request: &'a Request<'r>) -> request::Outcome<Self, Infallible> {
         Success(HeaderCount(request.headers().len()))
     }
 }

--- a/examples/session/src/main.rs
+++ b/examples/session/src/main.rs
@@ -1,10 +1,11 @@
-#![feature(proc_macro_hygiene, decl_macro, never_type)]
+#![feature(proc_macro_hygiene, decl_macro)]
 
 #[macro_use] extern crate rocket;
 
 #[cfg(test)] mod tests;
 
 use std::collections::HashMap;
+use std::convert::Infallible;
 
 use rocket::outcome::IntoOutcome;
 use rocket::request::{self, Form, FlashMessage, FromRequest, Request};
@@ -22,9 +23,9 @@ struct Login {
 struct User(usize);
 
 impl<'a, 'r> FromRequest<'a, 'r> for User {
-    type Error = !;
+    type Error = Infallible;
 
-    fn from_request(request: &'a Request<'r>) -> request::Outcome<User, !> {
+    fn from_request(request: &'a Request<'r>) -> request::Outcome<User, Infallible> {
         request.cookies()
             .get_private("user_id")
             .and_then(|cookie| cookie.value().parse().ok())


### PR DESCRIPTION
`Infallible` will be stabilized on Thursday.

Most of the diff is simple substitution of types (along with the relevant `use`). ~~There is one situation that required a compiler hint regarding the function not actually returning; `Infallible` isn't a special case in the compiler, so it regards it the same as returning any other `enum`. I worked around this by creating a trivial macro (for readability) that adds `unsafe { std::hint::unreachable_unchecked() }` after a call; this will allow the compiler to avoid related errors and perform the relevant optimizations.~~

Related: Compile on stable Rust (#19).

Pinging @jebrosen for review.