### PR TITLE
Remove newly stabilized features

### DIFF
--- a/core/codegen/src/lib.rs
+++ b/core/codegen/src/lib.rs
@@ -1,6 +1,5 @@
 #![feature(proc_macro_diagnostic, proc_macro_span)]
 #![feature(crate_visibility_modifier)]
-#![feature(transpose_result)]
 #![recursion_limit="128"]
 
 #![doc(html_root_url = "https://api.rocket.rs/v0.4")]

--- a/core/http/src/lib.rs
+++ b/core/http/src/lib.rs
@@ -1,6 +1,5 @@
 #![feature(specialization)]
 #![feature(proc_macro_hygiene)]
-#![feature(try_from)]
 #![feature(crate_visibility_modifier)]
 #![feature(doc_cfg)]
 #![recursion_limit="512"]

--- a/core/lib/build.rs
+++ b/core/lib/build.rs
@@ -8,8 +8,8 @@ use yansi::Color::{Red, Yellow, Blue};
 use version_check::{supports_features, is_min_version, is_min_date};
 
 // Specifies the minimum nightly version needed to compile Rocket.
-const MIN_DATE: &'static str = "2018-10-05";
-const MIN_VERSION: &'static str = "1.31.0-nightly";
+const MIN_DATE: &'static str = "2019-02-25";
+const MIN_VERSION: &'static str = "1.34.0-nightly";
 
 fn main() {
     let ok_channel = supports_features();

--- a/core/lib/src/lib.rs
+++ b/core/lib/src/lib.rs
@@ -5,7 +5,6 @@
 #![feature(never_type)]
 #![feature(proc_macro_hygiene)]
 #![feature(crate_visibility_modifier)]
-#![feature(try_from)]
 #![feature(label_break_value)]
 
 #![recursion_limit="256"]


### PR DESCRIPTION
`transpose_result` and `try_from` have both been stabilized in 1.34. This removes the compiler flags.

Related: Compile on stable Rust (#19).