### PR TITLE
Implementing FromIterator on JsonValue

### DIFF
--- a/contrib/lib/src/json.rs
+++ b/contrib/lib/src/json.rs
@@ -280,7 +280,7 @@ impl From<serde_json::Value> for JsonValue {
 
 impl<T> FromIterator<T> for JsonValue where serde_json::Value: FromIterator<T> {
     fn from_iter<I: IntoIterator<Item=T>>(iter: I) -> Self {
-        JsonValue(iter.into_iter().collect())
+        JsonValue(serde_json::Value::from_iter(iter))
     }
 }
 

--- a/contrib/lib/src/json.rs
+++ b/contrib/lib/src/json.rs
@@ -19,6 +19,7 @@ extern crate serde_json;
 
 use std::ops::{Deref, DerefMut};
 use std::io::{self, Read};
+use std::iter::FromIterator;
 
 use rocket::request::Request;
 use rocket::outcome::Outcome::*;
@@ -274,6 +275,12 @@ impl From<serde_json::Value> for JsonValue {
     #[inline(always)]
     fn from(value: serde_json::Value) -> JsonValue {
         JsonValue(value)
+    }
+}
+
+impl<T> FromIterator<T> for JsonValue where serde_json::Value: FromIterator<T> {
+    fn from_iter<I: IntoIterator<Item=T>>(iter: I) -> Self {
+        JsonValue(iter.into_iter().collect())
     }
 }
 


### PR DESCRIPTION
Exposing the `FromIterator` implementation from `serde_json::Value` on JsonValue makes it more rare to need to unpack it.

This makes code cleaner without overhead.