### PR TITLE
Show multiple routes in forwarding example

### DIFF
--- a/site/guide/4-requests.md
+++ b/site/guide/4-requests.md
@@ -183,13 +183,23 @@ routes:
 
 ```rust
 #[get("/user/<id>")]
-fn user(id: usize) -> T { ... }
+fn user(id: usize) -> String {
+    format!("Unsigned ID, {}!", id)
+}
 
 #[get("/user/<id>", rank = 2)]
-fn user_int(id: isize) -> T { ... }
+fn user_int(id: isize) -> String {
+    format!("Signed ID, {}!", id)
+}
 
 #[get("/user/<id>", rank = 3)]
-fn user_str(id: &RawStr) -> T { ... }
+fn user_str(id: &RawStr) -> String {
+    format!("String ID, {}!", id)
+}
+
+fn main() {
+    rocket::ignite().mount("/", routes![user, user_int, user_str]).launch();
+}
 ```
 
 Notice the `rank` parameters in `user_int` and `user_str`. If we run this


### PR DESCRIPTION
As a proposed fix for #981 update the example to be able to copy-paste it (i.e. use specific return types) and also include the main function that specifies multiple routes. This gives a useful real world example of using multiple routes.