### PR TITLE
Bump cookie crate to 0.12.

### DIFF
--- a/core/http/Cargo.toml
+++ b/core/http/Cargo.toml
@@ -26,7 +26,7 @@ time = "0.1"
 indexmap = "1.0"
 rustls = { version = "0.14", optional = true }
 state = "0.4"
-cookie = { version = "0.11", features = ["percent-encode"] }
+cookie = { version = "0.12", features = ["percent-encode"] }
 pear = "0.1"
 unicode-xid = "0.1"
 

--- a/core/http/Cargo.toml
+++ b/core/http/Cargo.toml
@@ -24,14 +24,14 @@ percent-encoding = "1"
 hyper = { version = "0.10.13", default-features = false }
 time = "0.1"
 indexmap = "1.0"
-rustls = { version = "0.14", optional = true }
+rustls = { version = "0.15", optional = true }
 state = "0.4"
 cookie = { version = "0.12", features = ["percent-encode"] }
 pear = "0.1"
 unicode-xid = "0.1"
 
 [dependencies.hyper-sync-rustls]
-version = "=0.3.0-rc.4"
+version = "=0.3.0-rc.5"
 features = ["server"]
 optional = true
 


### PR DESCRIPTION
This fixes the dependency issues with cookie (as mentioned in #975).