### PR TITLE
Bump contrib dependencies

### DIFF
--- a/contrib/lib/Cargo.toml
+++ b/contrib/lib/Cargo.toml
@@ -65,8 +65,8 @@ r2d2 = { version = "0.8", optional = true }
 r2d2_postgres = { version = "0.14", optional = true }
 mysql = { version = "14", optional = true }
 r2d2_mysql = { version = "9", optional = true }
-rusqlite = { version = "0.14.0", optional = true }
-r2d2_sqlite = { version = "0.6", optional = true }
+rusqlite = { version = "0.16.0", optional = true }
+r2d2_sqlite = { version = "0.8", optional = true }
 rusted_cypher = { version = "1", optional = true }
 r2d2_cypher = { version = "0.4", optional = true }
 redis = { version = "0.9", optional = true }

--- a/contrib/lib/Cargo.toml
+++ b/contrib/lib/Cargo.toml
@@ -52,7 +52,7 @@ rmp-serde = { version = "^0.13", optional = true }
 
 # Templating dependencies.
 handlebars = { version = "1.0", optional = true }
-glob = { version = "0.2", optional = true }
+glob = { version = "0.3", optional = true }
 tera = { version = "0.11", optional = true }
 
 # UUID dependencies.
@@ -63,14 +63,14 @@ diesel = { version = "1.0", default-features = false, optional = true }
 postgres = { version = "0.15", optional = true }
 r2d2 = { version = "0.8", optional = true }
 r2d2_postgres = { version = "0.14", optional = true }
-mysql = { version = "14", optional = true }
-r2d2_mysql = { version = "9", optional = true }
+mysql = { version = "16", optional = true }
+r2d2_mysql = { version = "16", optional = true }
 rusqlite = { version = "0.16.0", optional = true }
 r2d2_sqlite = { version = "0.8", optional = true }
 rusted_cypher = { version = "1", optional = true }
 r2d2_cypher = { version = "0.4", optional = true }
-redis = { version = "0.9", optional = true }
-r2d2_redis = { version = "0.8", optional = true }
+redis = { version = "0.10", optional = true }
+r2d2_redis = { version = "0.9", optional = true }
 mongodb = { version = "0.3.12", optional = true }
 r2d2-mongodb = { version = "0.2.0", optional = true }
 memcache = { version = "0.11", optional = true }

--- a/contrib/lib/src/databases.rs
+++ b/contrib/lib/src/databases.rs
@@ -361,7 +361,7 @@
 //! [Diesel]: https://diesel.rs
 //! [`redis::Connection`]: https://docs.rs/redis/0.9.0/redis/struct.Connection.html
 //! [`rusted_cypher::GraphClient`]: https://docs.rs/rusted_cypher/1.1.0/rusted_cypher/graph/struct.GraphClient.html
-//! [`rusqlite::Connection`]: https://docs.rs/rusqlite/0.14.0/rusqlite/struct.Connection.html
+//! [`rusqlite::Connection`]: https://docs.rs/rusqlite/0.16.0/rusqlite/struct.Connection.html
 //! [`diesel::SqliteConnection`]: http://docs.diesel.rs/diesel/prelude/struct.SqliteConnection.html
 //! [`postgres::Connection`]: https://docs.rs/postgres/0.15.2/postgres/struct.Connection.html
 //! [`diesel::PgConnection`]: http://docs.diesel.rs/diesel/pg/struct.PgConnection.html

--- a/contrib/lib/tests/databases.rs
+++ b/contrib/lib/tests/databases.rs
@@ -20,6 +20,8 @@ mod rusqlite_integration_test {
     use rocket_contrib::databases::rusqlite;
     use rocket_contrib::database;
 
+    use self::rusqlite::types::ToSql;
+
     #[database("test_db")]
     struct SqliteDb(pub rusqlite::Connection);
 
@@ -40,7 +42,7 @@ mod rusqlite_integration_test {
         // Rusqlite's `transaction()` method takes `&mut self`; this tests the
         // presence of a `DerefMut` trait on the generated connection type.
         let tx = conn.transaction().unwrap();
-        let _: i32 = tx.query_row("SELECT 1", &[], |row| row.get(0)).expect("get row");
+        let _: i32 = tx.query_row("SELECT 1", &[] as &[&dyn ToSql], |row| row.get(0)).expect("get row");
         tx.commit().expect("committed transaction");
     }
 
@@ -57,6 +59,6 @@ mod rusqlite_integration_test {
 
         let rocket = rocket::custom(config).attach(SqliteDb::fairing());
         let conn = SqliteDb::get_one(&rocket).expect("unable to get connection");
-        let _: i32 = conn.query_row("SELECT 1", &[], |row| row.get(0)).expect("get row");
+        let _: i32 = conn.query_row("SELECT 1", &[] as &[&dyn ToSql], |row| row.get(0)).expect("get row");
     }
 }

--- a/examples/raw_sqlite/Cargo.toml
+++ b/examples/raw_sqlite/Cargo.toml
@@ -6,4 +6,4 @@ publish = false
 
 [dependencies]
 rocket = { path = "../../core/lib" }
-rusqlite = "0.14"
+rusqlite = "0.16"

--- a/examples/raw_sqlite/src/main.rs
+++ b/examples/raw_sqlite/src/main.rs
@@ -2,6 +2,7 @@
 
 #[macro_use] extern crate rocket;
 extern crate rusqlite;
+use rusqlite::types::ToSql;
 
 #[cfg(test)] mod tests;
 
@@ -15,11 +16,11 @@ fn init_database(conn: &Connection) {
     conn.execute("CREATE TABLE entries (
                   id              INTEGER PRIMARY KEY,
                   name            TEXT NOT NULL
-                  )", &[])
+                  )", &[] as &[&dyn ToSql])
         .expect("create entries table");
 
     conn.execute("INSERT INTO entries (id, name) VALUES ($1, $2)",
-            &[&0, &"Rocketeer"])
+            &[&0 as &dyn ToSql, &"Rocketeer"])
         .expect("insert single entry into entries table");
 }
 
@@ -28,7 +29,7 @@ fn hello(db_conn: State<DbConn>) -> Result<String, Error>  {
     db_conn.lock()
         .expect("db connection lock")
         .query_row("SELECT name FROM entries WHERE id = 0",
-                   &[], |row| { row.get(0) })
+                   &[] as &[&dyn ToSql], |row| { row.get(0) })
 }
 
 fn rocket() -> Rocket {

--- a/site/guide/6-state.md
+++ b/site/guide/6-state.md
@@ -194,7 +194,7 @@ Presently, Rocket provides built-in support for the following databases:
 [Diesel]: https://diesel.rs
 [`redis::Connection`]: https://docs.rs/redis/0.9.0/redis/struct.Connection.html
 [`rusted_cypher::GraphClient`]: https://docs.rs/rusted_cypher/1.1.0/rusted_cypher/graph/struct.GraphClient.html
-[`rusqlite::Connection`]: https://docs.rs/rusqlite/0.14.0/rusqlite/struct.Connection.html
+[`rusqlite::Connection`]: https://docs.rs/rusqlite/0.16.0/rusqlite/struct.Connection.html
 [`diesel::SqliteConnection`]: http://docs.diesel.rs/diesel/prelude/struct.SqliteConnection.html
 [`postgres::Connection`]: https://docs.rs/postgres/0.15.2/postgres/struct.Connection.html
 [`diesel::PgConnection`]: http://docs.diesel.rs/diesel/pg/struct.PgConnection.html

--- a/site/guide/6-state.md
+++ b/site/guide/6-state.md
@@ -192,13 +192,13 @@ Presently, Rocket provides built-in support for the following databases:
 
 [`r2d2`]: https://crates.io/crates/r2d2
 [Diesel]: https://diesel.rs
-[`redis::Connection`]: https://docs.rs/redis/0.9.0/redis/struct.Connection.html
+[`redis::Connection`]: https://docs.rs/redis/0.10.0/redis/struct.Connection.html
 [`rusted_cypher::GraphClient`]: https://docs.rs/rusted_cypher/1.1.0/rusted_cypher/graph/struct.GraphClient.html
 [`rusqlite::Connection`]: https://docs.rs/rusqlite/0.16.0/rusqlite/struct.Connection.html
 [`diesel::SqliteConnection`]: http://docs.diesel.rs/diesel/prelude/struct.SqliteConnection.html
 [`postgres::Connection`]: https://docs.rs/postgres/0.15.2/postgres/struct.Connection.html
 [`diesel::PgConnection`]: http://docs.diesel.rs/diesel/pg/struct.PgConnection.html
-[`mysql::conn`]: https://docs.rs/mysql/14.0.0/mysql/struct.Conn.html
+[`mysql::conn`]: https://docs.rs/mysql/16.0.0/mysql/struct.Conn.html
 [`diesel::MysqlConnection`]: http://docs.diesel.rs/diesel/mysql/struct.MysqlConnection.html
 [`redis-rs`]: https://github.com/mitsuhiko/redis-rs
 [`rusted_cypher`]: https://github.com/livioribeiro/rusted-cypher


### PR DESCRIPTION
This should be everything that can be bumped for contrib at this time. This includes breaking changes in some dependencies.

Not bumped:
* `rusqlite`: `rusqlite` 0.17 depends on `libsqlite3-sys 0.13`, which conflicts with `diesel` which depends on `libsqlite3-sys < 0.13`
* Some dependencies (`tera`, `postgres`) have a rc out, but not a stable version yet.
