### PR TITLE
Add rustfmt to do nothing

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+unstable_features = true
+ignore = ["src", "contrib", "core", "examples"]

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,2 @@
 unstable_features = true
-ignore = ["src", "contrib", "core", "examples"]
+ignore = ["/"]


### PR DESCRIPTION
Basically this PR tells cargo fmt to do nothing if run. Would have saved me trouble when I accidentally ran it and so messed up some work I was doing.