### PR TITLE
Allow non_snake_case in query parameter codegen.

### DIFF
--- a/core/codegen/src/attribute/route.rs
+++ b/core/codegen/src/attribute/route.rs
@@ -220,9 +220,11 @@ fn query_exprs(route: &Route) -> Option<TokenStream2> {
 
         let decl = match segment.kind {
             Kind::Single => quote_spanned! { span =>
+                #[allow(non_snake_case)]
                 let mut #ident: Option<#ty> = None;
             },
             Kind::Multi => quote_spanned! { span =>
+                #[allow(non_snake_case)]
                 let mut #trail = #SmallVec::<[#request::FormItem; 8]>::new();
             },
             Kind::Static => quote!()
@@ -253,6 +255,7 @@ fn query_exprs(route: &Route) -> Option<TokenStream2> {
 
         let builder = match segment.kind {
             Kind::Single => quote_spanned! { span =>
+                #[allow(non_snake_case)]
                 let #ident = match #ident.or_else(<#ty as #request::FromFormValue>::default) {
                     Some(__v) => __v,
                     None => {
@@ -262,6 +265,7 @@ fn query_exprs(route: &Route) -> Option<TokenStream2> {
                 };
             },
             Kind::Multi => quote_spanned! { span =>
+                #[allow(non_snake_case)]
                 let #ident = match <#ty as #request::FromQuery>::from_query(#Query(&#trail)) {
                     Ok(__v) => __v,
                     Err(__e) => {

--- a/core/codegen/tests/route.rs
+++ b/core/codegen/tests/route.rs
@@ -1,5 +1,7 @@
 #![feature(proc_macro_hygiene, decl_macro)]
 
+#![deny(non_snake_case)]
+
 #[macro_use] extern crate rocket;
 
 use std::path::PathBuf;
@@ -63,6 +65,10 @@ fn post2(
     let uri = uri!(post2: a, name.url_decode_lossy(), path, sky, query.into_inner());
 
     format!("({}) ({})", string, uri.to_string())
+}
+
+#[post("/<_unused_param>?<_unused_query>", data="<_unused_data>")]
+fn test_unused_params(_unused_param: String, _unused_query: String, _unused_data: Data) {
 }
 
 #[test]

--- a/core/codegen/tests/route.rs
+++ b/core/codegen/tests/route.rs
@@ -1,5 +1,8 @@
 #![feature(proc_macro_hygiene, decl_macro)]
 
+// Rocket sometimes generates mangled identifiers that activate the
+// non_snake_case lint. We deny the lint in this test to ensure that
+// code generation uses #[allow(non_snake_case)] in the appropriate places.
 #![deny(non_snake_case)]
 
 #[macro_use] extern crate rocket;


### PR DESCRIPTION
Fixes #1003.

Tested by adding the following to `examples/hello_person/src/main.rs`:

```rust
#![deny(non_snake_case)]

#[get("/hello2?<_name>")]
pub fn hello2(_name: String) -> String {
    _name
}
```

Although, it might be applying `allow()`s in more places than are strictly necessary.

This commit can be safely backported to 0.4 as well.