### PR TITLE
multiple allowed versions of packages that depend on ring

### DIFF
--- a/core/http/Cargo.toml
+++ b/core/http/Cargo.toml
@@ -24,14 +24,14 @@ percent-encoding = "1"
 hyper = { version = "0.10.13", default-features = false }
 time = "0.1"
 indexmap = "1.0"
-rustls = { version = "0.14", optional = true }
+rustls = { version = ">=0.14, <=0.15", optional = true }
 state = "0.4"
-cookie = { version = "0.11", features = ["percent-encode"] }
+cookie = { version = ">=0.11, <=0.12", features = ["percent-encode"] }
 pear = "0.1"
 unicode-xid = "0.1"
 
 [dependencies.hyper-sync-rustls]
-version = "=0.3.0-rc.4"
+version = ">=0.3.0-rc.4, <=0.3.0-rc.5"
 features = ["server"]
 optional = true
 


### PR DESCRIPTION
Set a more permissive range to allow for more projects to co-depend on ring.
This way cargo will choose the best version