### PR TITLE
Minor documentation correction

### DIFF
--- a/core/lib/src/data/data.rs
+++ b/core/lib/src/data/data.rs
@@ -39,7 +39,7 @@ const PEEK_BYTES: usize = 512;
 /// # fn main() { }
 /// ```
 ///
-/// Above, `T` can be any type that implements `FromData`. Note that `Data`
+/// Above, `DataGuard` can be any type that implements `FromData`. Note that `Data`
 /// itself implements `FromData`.
 ///
 /// # Reading Data


### PR DESCRIPTION
The type name in the documentation for Data was changed from `T` to `DataGuard` but the sentence below still says `T`. This corrects that to `DataGuard`.