### PR TITLE
Implement UriDisplay for contrib Uuid

### DIFF
--- a/contrib/lib/src/uuid.rs
+++ b/contrib/lib/src/uuid.rs
@@ -17,11 +17,12 @@
 pub extern crate uuid as uuid_crate;
 
 use std::fmt;
-use std::str::FromStr;
 use std::ops::Deref;
+use std::str::FromStr;
 
-use rocket::request::{FromParam, FromFormValue};
-use rocket::http::RawStr;
+use rocket::http::uri::{Formatter, Path, Query, UriDisplay};
+use rocket::http::{impl_from_uri_param_identity, RawStr};
+use rocket::request::{FromFormValue, FromParam};
 
 pub use self::uuid_crate::parser::ParseError;
 
@@ -100,6 +101,23 @@ impl fmt::Display for Uuid {
     }
 }
 
+impl UriDisplay<Path> for Uuid {
+    #[inline(always)]
+    fn fmt(&self, f: &mut Formatter<Path>) -> fmt::Result {
+        f.write_value(&format!("{}", self.0))
+    }
+}
+
+impl UriDisplay<Query> for Uuid {
+    #[inline(always)]
+    fn fmt(&self, f: &mut Formatter<Query>) -> fmt::Result {
+        f.write_value(&format!("{}", self.0))
+    }
+}
+
+impl_from_uri_param_identity!([Path] Uuid);
+impl_from_uri_param_identity!([Query] Uuid);
+
 impl<'a> FromParam<'a> for Uuid {
     type Error = ParseError;
 
@@ -149,9 +167,9 @@ impl PartialEq<uuid_crate::Uuid> for Uuid {
 #[cfg(test)]
 mod test {
     use super::uuid_crate;
-    use super::Uuid;
     use super::FromParam;
     use super::FromStr;
+    use super::Uuid;
 
     #[test]
     fn test_from_str() {


### PR DESCRIPTION
Hello there!

I use the contrib Uuid wrapper, and bind uuid types to my route handlers. When trying to use Uuid types in conjunction with the `uri!` macro, with code like this:

```rust
Redirect::to(uri!(show: instance_membership_id = instance_membership_id))
```

Where `instance_membership_id` is a contrib `Uuid` wrapper type, and the route handler function signature looks something like:

```rust
use rocket_contrib::uuid::Uuid as RocketUuid;

#[get("/instances/<instance_membership_id>/topics/<topic_name>")]
pub fn show(
    instance_membership_id: RocketUuid,
    topic_name: String,
    db: WebappDb,
    user: User,
) -> Result<Template, ExecuteError> {
   ...
}
```

I get an error like this:

```
error[E0277]: the trait bound `rocket_contrib::uuid::Uuid: rocket::http::uri::FromUriParam<rocket::http::uri::Path, _>` is not satisfied                                       
   --> webapp/src/instances.rs:319:58
    |
319 |         Redirect::to(uri!(show: instance_membership_id = instance_membership_id)),                                                                                       
    |                                                          ^^^^^^^^^^^^^^^^^^^^^^ the trait `rocket::http::uri::FromUriParam<rocket::http::uri::Path, _>` is not implemented for `rocket_contrib::uuid::Uuid`
```

This PR adds trait implementations for `UriDisplay`, and their corresponding `FromUriParam` identity implementation. Everything type checks and works after local testing. A few questions / notes:

1. I attempted to use the `impl_with_display!` macro, since UUIDs should be able to use the exact same `Display` implementation for their Uri representation, but had trouble with the macro visibility.
2. I wasn't sure about the best way to unit test this, with the uri `Formatter`: I had trouble understanding how Uri `Formatters` are constructed, given that they seem to be built using macro code-gen. Any advice on how to unit test this would be helpful.

Please let me know if there's a better way to implement this, especially if it makes sense to hook into the `impl_with_display!` macro.

Thanks, and thanks for Rocket!