### PR TITLE
[WIP/experiment] automatic route mounting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
   "core/http/",
   "contrib/lib",
   "contrib/codegen",
+  "examples/auto_mounting",
   "examples/cookies",
   "examples/errors",
   "examples/form_validation",

--- a/core/codegen/Cargo.toml
+++ b/core/codegen/Cargo.toml
@@ -14,6 +14,10 @@ build = "build.rs"
 [lib]
 proc-macro = true
 
+[features]
+default=[]
+auto-mount = []
+
 [dependencies]
 indexmap = "1.0"
 quote = "0.6.1"

--- a/core/lib/Cargo.toml
+++ b/core/lib/Cargo.toml
@@ -21,6 +21,7 @@ all-features = true
 default = ["private-cookies"]
 tls = ["rocket_http/tls"]
 private-cookies = ["rocket_http/private-cookies"]
+auto-mount = ["rocket_codegen/auto-mount", "inventory"]
 
 [dependencies]
 rocket_codegen = { version = "0.5.0-dev", path = "../codegen" }
@@ -35,6 +36,7 @@ memchr = "2" # TODO: Use pear instead.
 base64 = "0.10"
 pear = "0.1"
 atty = "0.2"
+inventory = { version = "0.1", optional = true}
 
 [build-dependencies]
 yansi = "0.5"

--- a/core/lib/src/auto_mount.rs
+++ b/core/lib/src/auto_mount.rs
@@ -16,9 +16,9 @@ pub mod __default_auto_mount_info {
 }
 
 /// Allows to configure behavior of [auto_mount()](Rocket::auto_mount) for all routes in module
-/// 
+///
 /// # Example - set base path for all routes in module
-/// 
+///
 /// ```rust
 /// # #![feature(proc_macro_hygiene, decl_macro)]
 /// # #[macro_use] extern crate rocket;
@@ -26,17 +26,17 @@ pub mod __default_auto_mount_info {
 ///
 /// mod secret_routes {
 ///     mod_auto_mount!("/foo");
-/// 
+///
 ///     // this route will be mounted at /foo/bar when auto_mount() is used
-///     #[get("/bar")] 
+///     #[get("/bar")]
 ///     fn bar() -> &'static str {
 ///         "Hello!"
-///     } 
+///     }
 /// }
-/// 
+///
 /// ```
 ///  # Example - disable automatic mounting for all routes in module
-/// 
+///
 /// ```rust
 /// # #![feature(proc_macro_hygiene, decl_macro)]
 /// # #[macro_use] extern crate rocket;
@@ -44,12 +44,12 @@ pub mod __default_auto_mount_info {
 ///
 /// mod secret_routes {
 ///     mod_auto_mount!(disabled);
-/// 
+///
 ///     // this route will not be mounted by auto_mount()
-///     #[get("/secret")] 
+///     #[get("/secret")]
 ///     fn secret() -> &'static str {
 ///         "secret route"
-///     } 
+///     }
 /// }
 /// ```
 #[macro_export]

--- a/core/lib/src/auto_mount.rs
+++ b/core/lib/src/auto_mount.rs
@@ -1,0 +1,65 @@
+pub struct AutoMountRoute {
+    pub route: &'static ::StaticRouteInfo,
+    pub mod_info: &'static AutoMountModuleInfo,
+}
+
+::inventory::collect!(AutoMountRoute);
+
+pub struct AutoMountModuleInfo {
+    pub base: &'static str,
+    pub enabled: bool,
+}
+
+pub mod __default_auto_mount_info {
+    use super::*;
+    pub static __rocket_mod_auto_mount_info : AutoMountModuleInfo = AutoMountModuleInfo {base: "/", enabled: true};
+}
+
+/// Allows to configure behavior of [auto_mount()](Rocket::auto_mount) for all routes in module
+/// 
+/// # Example - set base path for all routes in module
+/// 
+/// ```rust
+/// # #![feature(proc_macro_hygiene, decl_macro)]
+/// # #[macro_use] extern crate rocket;
+/// use rocket::{mod_auto_mount,get};
+///
+/// mod secret_routes {
+///     mod_auto_mount!("/foo");
+/// 
+///     // this route will be mounted at /foo/bar when auto_mount() is used
+///     #[get("/bar")] 
+///     fn bar() -> &'static str {
+///         "Hello!"
+///     } 
+/// }
+/// 
+/// ```
+///  # Example - disable automatic mounting for all routes in module
+/// 
+/// ```rust
+/// # #![feature(proc_macro_hygiene, decl_macro)]
+/// # #[macro_use] extern crate rocket;
+/// use rocket::{mod_auto_mount,get};
+///
+/// mod secret_routes {
+///     mod_auto_mount!(disabled);
+/// 
+///     // this route will not be mounted by auto_mount()
+///     #[get("/secret")] 
+///     fn secret() -> &'static str {
+///         "secret route"
+///     } 
+/// }
+/// ```
+#[macro_export]
+macro_rules! mod_auto_mount {
+    ($l:literal) => {
+        use $crate::auto_mount::AutoMountModuleInfo;
+        static __rocket_mod_auto_mount_info : AutoMountModuleInfo = AutoMountModuleInfo {base: $l, enabled: true};
+    };
+    (disabled) => {
+        use $crate::auto_mount::AutoMountModuleInfo;
+        static __rocket_mod_auto_mount_info : AutoMountModuleInfo = AutoMountModuleInfo {base: "/", enabled: false};
+    }
+}

--- a/core/lib/src/lib.rs
+++ b/core/lib/src/lib.rs
@@ -110,6 +110,7 @@ extern crate time;
 extern crate memchr;
 extern crate base64;
 extern crate atty;
+#[cfg(feature="auto-mount")] #[doc(hidden)]pub extern crate inventory; 
 
 #[cfg(test)] #[macro_use] extern crate lazy_static;
 
@@ -140,6 +141,7 @@ mod rocket;
 mod codegen;
 mod catcher;
 mod ext;
+#[cfg(feature="auto-mount")] #[doc(hidden)] pub mod auto_mount;
 
 #[doc(inline)] pub use response::Response;
 #[doc(inline)] pub use handler::{Handler, ErrorHandler};

--- a/core/lib/src/lib.rs
+++ b/core/lib/src/lib.rs
@@ -110,7 +110,7 @@ extern crate time;
 extern crate memchr;
 extern crate base64;
 extern crate atty;
-#[cfg(feature="auto-mount")] #[doc(hidden)]pub extern crate inventory; 
+#[cfg(feature="auto-mount")] #[doc(hidden)]pub extern crate inventory;
 
 #[cfg(test)] #[macro_use] extern crate lazy_static;
 

--- a/core/lib/src/rocket.rs
+++ b/core/lib/src/rocket.rs
@@ -810,4 +810,34 @@ impl Rocket {
     pub fn config(&self) -> &Config {
         &self.config
     }
+
+    /// Mounts all available routes in compiled binary
+    /// 
+    /// # Example
+    /// 
+    /// ```rust
+    /// # #![feature(proc_macro_hygiene, decl_macro)]
+    /// # #[macro_use] extern crate rocket;
+    /// use rocket::Rocket;
+    ///
+    /// fn main() {
+    /// # if false { // We don't actually want to launch the server in an example.
+    ///     rocket::ignite()
+    ///         .auto_mount()
+    ///         .launch();
+    /// # }
+    /// }
+    /// ```
+    /// 
+    /// See the [mod_auto_mount!() macro ](macro.mod_auto_mount.html) for information about configuring automatic mounting
+
+    #[cfg(feature="auto-mount")]
+    pub fn auto_mount(mut self) -> Self {
+        for route in ::inventory::iter::<::auto_mount::AutoMountRoute > {
+            if route.mod_info.enabled {
+                self = self.mount(route.mod_info.base,vec![route.route.into()]);
+            }
+        }
+        self
+    }
 }

--- a/core/lib/src/rocket.rs
+++ b/core/lib/src/rocket.rs
@@ -812,9 +812,9 @@ impl Rocket {
     }
 
     /// Mounts all available routes in compiled binary
-    /// 
+    ///
     /// # Example
-    /// 
+    ///
     /// ```rust
     /// # #![feature(proc_macro_hygiene, decl_macro)]
     /// # #[macro_use] extern crate rocket;
@@ -828,7 +828,7 @@ impl Rocket {
     /// # }
     /// }
     /// ```
-    /// 
+    ///
     /// See the [mod_auto_mount!() macro ](macro.mod_auto_mount.html) for information about configuring automatic mounting
 
     #[cfg(feature="auto-mount")]

--- a/examples/auto_mounting/Cargo.toml
+++ b/examples/auto_mounting/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "auto_mounting"
+version = "0.0.0"
+workspace = "../../"
+publish = false
+edition = "2018"
+
+[dependencies]
+rocket = { path = "../../core/lib", features=["auto-mount"]}

--- a/examples/auto_mounting/src/main.rs
+++ b/examples/auto_mounting/src/main.rs
@@ -34,7 +34,7 @@ mod disabled {
     #[get("/w")] // will not be mounted
     fn w() -> &'static str {
         "this route should be disabled"
-    }   
+    }
 }
 
 fn main() {

--- a/examples/auto_mounting/src/main.rs
+++ b/examples/auto_mounting/src/main.rs
@@ -1,0 +1,42 @@
+#![feature(proc_macro_hygiene, decl_macro)]
+
+#[macro_use] extern crate rocket;
+
+#[cfg(test)] mod tests;
+
+#[get("/")]
+fn hello() -> &'static str {
+    "Hello, world!"
+}
+
+#[get("/x")]
+fn x() -> &'static str {
+    "This is x route"
+}
+
+mod test {
+    mod_auto_mount!("/test");
+
+    #[get("/y")] // will be mounted to /test/y
+    fn y() -> &'static str {
+        "This is y route in test module"
+    }
+
+    #[get("/z")] // will be mounted to /test/w
+    fn z() -> &'static str {
+        "This is z route in test module"
+    }
+}
+
+mod disabled {
+    mod_auto_mount!(disabled);
+
+    #[get("/w")] // will not be mounted
+    fn w() -> &'static str {
+        "this route should be disabled"
+    }   
+}
+
+fn main() {
+    rocket::ignite().auto_mount().launch();
+}

--- a/examples/auto_mounting/src/main.rs
+++ b/examples/auto_mounting/src/main.rs
@@ -22,7 +22,7 @@ mod test {
         "This is y route in test module"
     }
 
-    #[get("/z")] // will be mounted to /test/w
+    #[get("/z")] // will be mounted to /test/z
     fn z() -> &'static str {
         "This is z route in test module"
     }

--- a/examples/auto_mounting/src/tests.rs
+++ b/examples/auto_mounting/src/tests.rs
@@ -1,0 +1,33 @@
+use super::rocket;
+use rocket::local::Client;
+use rocket::http::Status;
+
+#[test]
+fn auto_mount() {
+    let rocket = rocket::ignite().auto_mount();
+    let client = Client::new(rocket).unwrap();
+
+    let mut response = client.get("/").dispatch();
+    assert_eq!(response.body_string(), Some("Hello, world!".into()));
+
+    let mut response = client.get("/x").dispatch();
+    assert_eq!(response.body_string(), Some("This is x route".into()));
+
+    let mut response = client.get("/test/y").dispatch();
+    assert_eq!(response.body_string(), Some("This is y route in test module".into()));
+
+    let mut response = client.get("/test/z").dispatch();
+    assert_eq!(response.body_string(), Some("This is z route in test module".into()));
+
+    let response = client.get("/y").dispatch();
+    assert_eq!(response.status(), Status::NotFound);
+
+    let response = client.get("/z").dispatch();
+    assert_eq!(response.status(), Status::NotFound);
+
+    let response = client.get("/w").dispatch();
+    assert_eq!(response.status(), Status::NotFound);
+
+    let response = client.get("/test/x").dispatch();
+    assert_eq!(response.status(), Status::NotFound);
+}


### PR DESCRIPTION
This pr allows user to ommit mounting each route manually. Instead all available routes can be automatically detected and mounted during launch. Additionaly, user is able to provide base path for all routes in module, or disable automatic mounting for all routes in module by using `mod_auto_mount!()` macro (see example). 

The main goal here is convinience of use - having to scroll to the `routes![]` macro after adding new route quickly becomes cumbersome.

`mod_auto_mount!()` probably could be an attribute macro that is applied to module, but for now i can't get it working 100% of the time when project is split into multiple files.

Next steps:

- [ ] better documentation
- [ ] better name for  `mod_auto_mount!()`  :smile: 
- [ ] limit ammount of calls to Rocket::mount

[inspired by](https://docs.servicestack.net/routing#auto-route-generation-strategies)