### PR TITLE
add a  keyword because it must be explicit now

### DIFF
--- a/contrib/lib/src/templates/fairing.rs
+++ b/contrib/lib/src/templates/fairing.rs
@@ -123,7 +123,7 @@ pub struct TemplateFairing {
     /// The user-provided customization callback, allowing the use of
     /// functionality specific to individual template engines. In debug mode,
     /// this callback might be run multiple times as templates are reloaded.
-    crate custom_callback: Box<Fn(&mut Engines) + Send + Sync + 'static>,
+    crate custom_callback: Box<dyn Fn(&mut Engines) + Send + Sync + 'static>,
 }
 
 impl Fairing for TemplateFairing {

--- a/core/http/src/parse/checkers.rs
+++ b/core/http/src/parse/checkers.rs
@@ -6,7 +6,7 @@ pub fn is_whitespace(byte: char) -> bool {
 #[inline]
 pub fn is_valid_token(c: char) -> bool {
     match c {
-        '0'...'9' | 'A'...'Z' | '^'...'~' | '#'...'\''
+        '0'..='9' | 'A'..='Z' | '^'..='~' | '#'..='\''
             | '!' | '*' | '+' | '-' | '.'  => true,
         _ => false
     }

--- a/core/http/src/uri/uri_display.rs
+++ b/core/http/src/uri/uri_display.rs
@@ -294,7 +294,7 @@ pub trait UriDisplay<P: UriPart> {
     fn fmt(&self, f: &mut Formatter<P>) -> fmt::Result;
 }
 
-impl<'a, P: UriPart> fmt::Display for &'a UriDisplay<P> {
+impl<'a, P: UriPart> fmt::Display for &'a dyn UriDisplay<P> {
     #[inline(always)]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         UriDisplay::fmt(*self, &mut <Formatter<P>>::new(f))

--- a/core/lib/src/config/toml_ext.rs
+++ b/core/lib/src/config/toml_ext.rs
@@ -24,7 +24,7 @@ fn is_not_separator(byte: char) -> bool {
 #[inline(always)]
 fn is_ident_char(byte: char) -> bool {
     match byte {
-        '0'...'9' | 'A'...'Z' | 'a'...'z' | '_' | '-' => true,
+        '0'..='9' | 'A'..='Z' | 'a'..='z' | '_' | '-' => true,
         _ => false
     }
 }

--- a/core/lib/src/data/data.rs
+++ b/core/lib/src/data/data.rs
@@ -15,7 +15,7 @@ use http::hyper::h1::HttpReader::*;
 use http::hyper::net::{HttpStream, NetworkStream};
 
 pub type HyperBodyReader<'a, 'b> =
-    self::HttpReader<&'a mut hyper::buffer::BufReader<&'b mut NetworkStream>>;
+    self::HttpReader<&'a mut hyper::buffer::BufReader<&'b mut dyn NetworkStream>>;
 
 //                              |---- from hyper ----|
 pub type BodyReader = HttpReader<Chain<Cursor<Vec<u8>>, NetStream>>;
@@ -94,7 +94,7 @@ impl Data {
     crate fn from_hyp(mut body: HyperBodyReader) -> Result<Data, &'static str> {
         #[inline(always)]
         #[cfg(feature = "tls")]
-        fn concrete_stream(stream: &mut NetworkStream) -> Option<NetStream> {
+        fn concrete_stream(stream: &mut dyn NetworkStream) -> Option<NetStream> {
             stream.downcast_ref::<HttpsStream>()
                 .map(|s| NetStream::Https(s.clone()))
                 .or_else(|| {

--- a/core/lib/src/fairing/fairings.rs
+++ b/core/lib/src/fairing/fairings.rs
@@ -5,7 +5,7 @@ use yansi::Paint;
 
 #[derive(Default)]
 pub struct Fairings {
-    all_fairings: Vec<Box<Fairing>>,
+    all_fairings: Vec<Box<dyn Fairing>>,
     attach_failures: Vec<&'static str>,
     // The vectors below hold indices into `all_fairings`.
     launch: Vec<usize>,
@@ -19,7 +19,7 @@ impl Fairings {
         Fairings::default()
     }
 
-    pub fn attach(&mut self, fairing: Box<Fairing>, mut rocket: Rocket) -> Rocket {
+    pub fn attach(&mut self, fairing: Box<dyn Fairing>, mut rocket: Rocket) -> Rocket {
         // Run the `on_attach` callback if this is an 'attach' fairing.
         let kind = fairing.info().kind;
         let name = fairing.info().name;
@@ -32,7 +32,7 @@ impl Fairings {
         rocket
     }
 
-    fn add(&mut self, fairing: Box<Fairing>) {
+    fn add(&mut self, fairing: Box<dyn Fairing>) {
         let kind = fairing.info().kind;
         if !kind.is_exactly(Kind::Attach) {
             let index = self.all_fairings.len();

--- a/core/lib/src/handler.rs
+++ b/core/lib/src/handler.rs
@@ -152,19 +152,19 @@ pub trait Handler: Cloneable + Send + Sync + 'static {
 /// `Handler` automatically implement `Cloneable`.
 pub trait Cloneable {
     /// Clones `self`.
-    fn clone_handler(&self) -> Box<Handler>;
+    fn clone_handler(&self) -> Box<dyn Handler>;
 }
 
 impl<T: Handler + Clone> Cloneable for T {
     #[inline(always)]
-    fn clone_handler(&self) -> Box<Handler> {
+    fn clone_handler(&self) -> Box<dyn Handler> {
         Box::new(self.clone())
     }
 }
 
-impl Clone for Box<Handler> {
+impl Clone for Box<dyn Handler> {
     #[inline(always)]
-    fn clone(&self) -> Box<Handler> {
+    fn clone(&self) -> Box<dyn Handler> {
         self.clone_handler()
     }
 }

--- a/core/lib/src/response/response.rs
+++ b/core/lib/src/response/response.rs
@@ -560,7 +560,7 @@ impl<'r> ResponseBuilder<'r> {
 pub struct Response<'r> {
     status: Option<Status>,
     headers: HeaderMap<'r>,
-    body: Option<Body<Box<io::Read + 'r>>>,
+    body: Option<Body<Box<dyn io::Read + 'r>>>,
 }
 
 impl<'r> Response<'r> {
@@ -889,7 +889,7 @@ impl<'r> Response<'r> {
     /// assert_eq!(response.body_string(), Some("Hello, world!".to_string()));
     /// ```
     #[inline(always)]
-    pub fn body(&mut self) -> Option<Body<&mut io::Read>> {
+    pub fn body(&mut self) -> Option<Body<&mut dyn io::Read>> {
         // Looks crazy, right? Needed so Rust infers lifetime correctly. Weird.
         match self.body.as_mut() {
             Some(body) => Some(match body.as_mut() {
@@ -966,7 +966,7 @@ impl<'r> Response<'r> {
     /// assert!(response.body().is_none());
     /// ```
     #[inline(always)]
-    pub fn take_body(&mut self) -> Option<Body<Box<io::Read + 'r>>> {
+    pub fn take_body(&mut self) -> Option<Body<Box<dyn io::Read + 'r>>> {
         self.body.take()
     }
 

--- a/core/lib/src/router/route.rs
+++ b/core/lib/src/router/route.rs
@@ -19,7 +19,7 @@ pub struct Route {
     /// The method this route matches against.
     pub method: Method,
     /// The function that should be called when the route matches.
-    pub handler: Box<Handler>,
+    pub handler: Box<dyn Handler>,
     /// The base mount point of this `Route`.
     pub base: Origin<'static>,
     /// The uri (in Rocket's route format) that should be matched against. This

--- a/examples/handlebars_templates/src/main.rs
+++ b/examples/handlebars_templates/src/main.rs
@@ -58,7 +58,7 @@ fn wow_helper(
     _: &Handlebars,
     _: &Context,
     _: &mut RenderContext,
-    out: &mut Output
+    out: &mut dyn Output
 ) -> HelperResult {
     if let Some(param) = h.param(0) {
         out.write("<b><i>")?;


### PR DESCRIPTION
Implicit dynamic return is going to be deprecated.