### PR TITLE
Fix and update benchmarks.

### DIFF
--- a/core/lib/benches/format-routing.rs
+++ b/core/lib/benches/format-routing.rs
@@ -1,3 +1,4 @@
+#![feature(test)]
 #![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;

--- a/core/lib/benches/ranked-routing.rs
+++ b/core/lib/benches/ranked-routing.rs
@@ -1,16 +1,17 @@
+#![feature(test)]
 #![feature(proc_macro_hygiene)]
 
 #[macro_use] extern crate rocket;
 
 use rocket::config::{Environment, Config, LoggingLevel};
 
-#[get("/", format = "application/json")]
+#[get("/", format = "application/json", rank = 1)]
 fn get() -> &'static str { "json" }
 
-#[get("/", format = "text/html")]
+#[get("/", format = "text/html", rank = 2)]
 fn get2() -> &'static str { "html" }
 
-#[get("/", format = "text/plain")]
+#[get("/", format = "text/plain", rank = 3)]
 fn get3() -> &'static str { "plain" }
 
 #[post("/", format = "application/json")]

--- a/core/lib/benches/simple-routing.rs
+++ b/core/lib/benches/simple-routing.rs
@@ -1,6 +1,5 @@
+#![feature(test)]
 #![feature(proc_macro_hygiene)]
-// #![feature(alloc_system)]
-// extern crate alloc_system;
 
 #[macro_use] extern crate rocket;
 
@@ -28,8 +27,8 @@ fn index_b() -> &'static str { "index" }
 #[get("/c")]
 fn index_c() -> &'static str { "index" }
 
-#[get("/<a>")]
-fn index_dyn_a(a: &RawStr) -> &'static str { "index" }
+#[get("/<_a>")]
+fn index_dyn_a(_a: &RawStr) -> &'static str { "index" }
 
 fn hello_world_rocket() -> rocket::Rocket {
     let config = Config::build(Environment::Production).log_level(LoggingLevel::Off);


### PR DESCRIPTION
These have been broken since 61f107f when `#![feature(test)]` was inadvertently removed. That same commit changed collision rules for `format = ` on `get` routes.