### PR TITLE
Remove `label_break_value` feature

### DIFF
--- a/core/lib/src/lib.rs
+++ b/core/lib/src/lib.rs
@@ -2,7 +2,6 @@
 #![feature(try_trait)]
 #![feature(proc_macro_hygiene)]
 #![feature(crate_visibility_modifier)]
-#![feature(label_break_value)]
 
 #![recursion_limit="256"]
 


### PR DESCRIPTION
This amounts to creating a `loop` that only runs once through.

If this feature ever stabilizes (which seems unlikely at this point), it
will be trivial to revert this to the previous state.