### PR TITLE
Remove `doc_cfg` feature

### DIFF
--- a/contrib/lib/src/lib.rs
+++ b/contrib/lib/src/lib.rs
@@ -1,5 +1,4 @@
 #![feature(crate_visibility_modifier)]
-#![feature(doc_cfg)]
 
 #![doc(html_root_url = "https://api.rocket.rs/v0.5")]
 #![doc(html_favicon_url = "https://rocket.rs/v0.5/images/favicon.ico")]

--- a/core/http/src/lib.rs
+++ b/core/http/src/lib.rs
@@ -1,7 +1,6 @@
 #![feature(specialization)]
 #![feature(proc_macro_hygiene)]
 #![feature(crate_visibility_modifier)]
-#![feature(doc_cfg)]
 #![recursion_limit="512"]
 
 #![warn(rust_2018_idioms)]


### PR DESCRIPTION
I presume this is legacy, since it literally wasn't used anywhere.