### PR TITLE
Enable/disable the colorful log

### DIFF
--- a/core/lib/src/config/config.rs
+++ b/core/lib/src/config/config.rs
@@ -227,7 +227,7 @@ impl Config {
         // Use a generated secret key by default.
         let key = SecretKey::Generated(Key::generate());
 
-        let enable_colorful_logging = !(!atty::is(atty::Stream::Stdout)
+        let colorful_logging = !(!atty::is(atty::Stream::Stdout)
             || (cfg!(windows) && !Paint::enable_windows_ascii())
             || env::var_os(COLORS_ENV).map(|v| v == "0" || v == "off").unwrap_or(false));
 
@@ -246,7 +246,7 @@ impl Config {
                     extras: HashMap::new(),
                     config_file_path: None,
                     root_path: None,
-                    colorful_logging: enable_colorful_logging,
+                    colorful_logging,
                 }
             }
             Staging => {
@@ -263,7 +263,7 @@ impl Config {
                     extras: HashMap::new(),
                     config_file_path: None,
                     root_path: None,
-                    colorful_logging: enable_colorful_logging,
+                    colorful_logging,
                 }
             }
             Production => {
@@ -280,7 +280,7 @@ impl Config {
                     extras: HashMap::new(),
                     config_file_path: None,
                     root_path: None,
-                    colorful_logging: enable_colorful_logging,
+                    colorful_logging,
                 }
             }
         }

--- a/core/lib/src/config/config.rs
+++ b/core/lib/src/config/config.rs
@@ -227,9 +227,9 @@ impl Config {
         // Use a generated secret key by default.
         let key = SecretKey::Generated(Key::generate());
 
-        let enable_colorful_logging = if !atty::is(atty::Stream::Stdout)
+        let enable_colorful_logging = !(!atty::is(atty::Stream::Stdout)
             || (cfg!(windows) && !Paint::enable_windows_ascii())
-            || env::var_os(COLORS_ENV).map(|v| v == "0" || v == "off").unwrap_or(false) { false } else { true };
+            || env::var_os(COLORS_ENV).map(|v| v == "0" || v == "off").unwrap_or(false));
 
         match env {
             Development => {

--- a/core/lib/src/config/config.rs
+++ b/core/lib/src/config/config.rs
@@ -568,7 +568,7 @@ impl Config {
         { Ok(()) }
     }
 
-    /// Enables colorful logging.
+    /// Enables / disables the colorful logging output.
     ///
     /// # Example
     ///
@@ -576,26 +576,11 @@ impl Config {
     /// use rocket::config::{Config, LoggingLevel, Environment};
     ///
     /// let mut config = Config::new(Environment::Staging);
-    /// config.enable_colorful_logging();
+    /// config.set_colorful_logging(true);
     /// ```
     #[inline]
-    pub fn enable_colorful_logging(&mut self) {
-        self.colorful_logging = true;
-    }
-
-    /// Disables colorful logging.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use rocket::config::{Config, LoggingLevel, Environment};
-    ///
-    /// let mut config = Config::new(Environment::Staging);
-    /// config.enable_colorful_logging();
-    /// ```
-    #[inline]
-    pub fn disable_colorful_logging(&mut self) {
-        self.colorful_logging = false;
+    pub fn set_colorful_logging(&mut self, enable: bool) {
+        self.colorful_logging = enable;
     }
 
     /// Sets the extras for `self` to be the key/value pairs in `extras`.

--- a/core/lib/src/config/mod.rs
+++ b/core/lib/src/config/mod.rs
@@ -209,9 +209,9 @@ crate use self::toml_ext::LoggedValue;
 use crate::logger;
 use self::Environment::*;
 use self::environment::CONFIG_ENV;
-use crate::logger::COLORS_ENV;
 use self::toml_ext::parse_simple_toml_value;
 use crate::http::uncased::uncased_eq;
+use self::config::COLORS_ENV;
 
 const CONFIG_FILENAME: &str = "Rocket.toml";
 const GLOBAL_ENV_NAME: &str = "global";
@@ -445,7 +445,7 @@ impl RocketConfig {
 /// If there is a problem, prints a nice error message and bails.
 crate fn init() -> Config {
     let bail = |e: ConfigError| -> ! {
-        logger::init(LoggingLevel::Debug);
+        logger::init(LoggingLevel::Debug, true);
         e.pretty_print();
         process::exit(1)
     };

--- a/core/lib/src/logger.rs
+++ b/core/lib/src/logger.rs
@@ -6,8 +6,6 @@ use std::str::FromStr;
 use log;
 use yansi::Paint;
 
-crate const COLORS_ENV: &str = "ROCKET_CLI_COLORS";
-
 struct RocketLogger(LoggingLevel);
 
 /// Defines the different levels for log messages.
@@ -145,15 +143,12 @@ impl log::Log for RocketLogger {
     }
 }
 
-crate fn try_init(level: LoggingLevel, verbose: bool) -> bool {
+crate fn try_init(level: LoggingLevel, colorful: bool, verbose: bool) -> bool {
     if level == LoggingLevel::Off {
         return false;
     }
 
-    if !atty::is(atty::Stream::Stdout)
-        || (cfg!(windows) && !Paint::enable_windows_ascii())
-        || env::var_os(COLORS_ENV).map(|v| v == "0" || v == "off").unwrap_or(false)
-    {
+    if !colorful {
         Paint::disable();
     }
 
@@ -211,8 +206,8 @@ crate fn pop_max_level() {
 }
 
 #[doc(hidden)]
-pub fn init(level: LoggingLevel) -> bool {
-    try_init(level, true)
+pub fn init(level: LoggingLevel, colorful: bool) -> bool {
+    try_init(level, colorful, true)
 }
 
 // Expose logging macros as (hidden) funcions for use by core/contrib codegen.

--- a/core/lib/src/rocket.rs
+++ b/core/lib/src/rocket.rs
@@ -389,7 +389,7 @@ impl Rocket {
 
     #[inline]
     fn configured(config: Config) -> Rocket {
-        if logger::try_init(config.log_level, false) {
+        if logger::try_init(config.log_level, config.colorful_logging,false) {
             // Temporary weaken log level for launch info.
             logger::push_max_level(logger::LoggingLevel::Normal);
         }


### PR DESCRIPTION
This Pull-Request introduces a new way to enable/disable the colorful log output.
Instead of using the environment variable `ROCKET_CLI_COLORS` you can also use the Config itself to do so.

Example:

```
config.enable_colorful_logging();

// or

config.disable_colorful_logging();
```