### PR TITLE
Prefer async-std over tokio

### DIFF
--- a/core/lib/Cargo.toml
+++ b/core/lib/Cargo.toml
@@ -28,7 +28,7 @@ rocket_codegen = { version = "0.5.0-dev", path = "../codegen" }
 rocket_http = { version = "0.5.0-dev", path = "../http" }
 futures-preview = "0.3.0-alpha.18"
 futures-tokio-compat = { git = "https://github.com/Nemo157/futures-tokio-compat", rev = "8a93702" }
-tokio = "0.2.0-alpha.2"
+tokio = "=0.2.0-alpha.2"
 yansi = "0.5"
 log = { version = "0.4", features = ["std"] }
 toml = "0.4.7"
@@ -39,6 +39,7 @@ memchr = "2" # TODO: Use pear instead.
 base64 = "0.10"
 pear = "0.1"
 atty = "0.2"
+async-std = "0.99.4"
 
 [build-dependencies]
 yansi = "0.5"

--- a/core/lib/src/data/data.rs
+++ b/core/lib/src/data/data.rs
@@ -3,7 +3,6 @@ use std::path::Path;
 use futures::io::{self, AsyncRead, AsyncReadExt as _, AsyncWrite};
 use futures::future::Future;
 use futures::stream::TryStreamExt;
-use futures_tokio_compat::Compat as TokioCompat;
 
 use super::data_stream::DataStream;
 
@@ -171,7 +170,7 @@ impl Data {
     #[inline(always)]
     pub fn stream_to_file<P: AsRef<Path> + Send + Unpin + 'static>(self, path: P) -> impl Future<Output = io::Result<u64>> {
         Box::pin(async move {
-            let mut file = TokioCompat::new(tokio::fs::File::create(path).await?);
+            let mut file = async_std::fs::File::create(path).await?;
             self.stream_to(&mut file).await
         })
     }

--- a/core/lib/src/response/responder.rs
+++ b/core/lib/src/response/responder.rs
@@ -3,7 +3,6 @@ use std::io::Cursor;
 use std::fmt;
 
 use futures::io::BufReader;
-use futures_tokio_compat::Compat as TokioCompat;
 
 use crate::http::{Status, ContentType, StatusClass};
 use crate::response::{self, Response, Body};
@@ -256,8 +255,9 @@ impl Responder<'_> for Vec<u8> {
 impl Responder<'_> for File {
     fn respond_to(self, _: &Request<'_>) -> response::ResultFuture<'static> {
         Box::pin(async move {
-            let metadata = self.metadata();
-            let stream = BufReader::new(TokioCompat::new(tokio::fs::File::from_std(self)));
+            let file = async_std::fs::File::from(self);
+            let metadata = file.metadata().await;
+            let stream = BufReader::new(file);
             match metadata {
                 Ok(md) => Response::build().raw_body(Body::Sized(stream, md.len())).ok(),
                 Err(_) => Response::build().streamed_body(stream).ok()

--- a/core/lib/src/response/response.rs
+++ b/core/lib/src/response/response.rs
@@ -346,15 +346,14 @@ impl<'r> ResponseBuilder<'r> {
     ///
     /// ```rust,ignore
     /// use rocket::Response;
-    /// use futures_tokio_compat::Compat as TokioCompat;
-    /// use tokio::fs::File;
+    /// use async_std::fs::File;
     /// # use std::io;
     ///
     /// # #[allow(dead_code)]
     /// # async fn test() -> io::Result<()> {
     /// # #[allow(unused_variables)]
     /// let response = Response::build()
-    ///     .sized_body(TokioCompat::new(File::open("body.txt").await?))
+    ///     .sized_body(File::open("body.txt").await?)
     ///     .finalize();
     /// # Ok(())
     /// # }
@@ -373,15 +372,14 @@ impl<'r> ResponseBuilder<'r> {
     ///
     /// ```rust
     /// use rocket::Response;
-    /// use futures_tokio_compat::Compat as TokioCompat;
-    /// use tokio::fs::File;
+    /// use async_std::fs::File;
     /// # use std::io;
     ///
     /// # #[allow(dead_code)]
     /// # async fn test() -> io::Result<()> {
     /// # #[allow(unused_variables)]
     /// let response = Response::build()
-    ///     .streamed_body(TokioCompat::new(File::open("body.txt").await?))
+    ///     .streamed_body(File::open("body.txt").await?)
     ///     .finalize();
     /// # Ok(())
     /// # }
@@ -401,15 +399,14 @@ impl<'r> ResponseBuilder<'r> {
     ///
     /// ```rust
     /// use rocket::Response;
-    /// use futures_tokio_compat::Compat as TokioCompat;
-    /// use tokio::fs::File;
+    /// use async_std::fs::File;
     /// # use std::io;
     ///
     /// # #[allow(dead_code)]
     /// # async fn test() -> io::Result<()> {
     /// # #[allow(unused_variables)]
     /// let response = Response::build()
-    ///     .chunked_body(TokioCompat::new(File::open("body.txt").await?), 8096)
+    ///     .chunked_body(File::open("body.txt").await?, 8096)
     ///     .finalize();
     /// # Ok(())
     /// # }

--- a/examples/manual_routes/Cargo.toml
+++ b/examples/manual_routes/Cargo.toml
@@ -7,5 +7,4 @@ publish = false
 
 [dependencies]
 rocket = { path = "../../core/lib" }
-tokio = "0.2.0-alpha.2"
-futures-tokio-compat = { git = "https://github.com/Nemo157/futures-tokio-compat" }
+async-std = "0.99.4"

--- a/examples/manual_routes/src/main.rs
+++ b/examples/manual_routes/src/main.rs
@@ -4,9 +4,7 @@ extern crate rocket;
 mod tests;
 
 use std::env;
-
-use futures_tokio_compat::Compat as TokioCompat;
-use tokio::fs::File;
+use async_std::fs::File;
 
 use rocket::{Request, Handler, Route, Data, Catcher};
 use rocket::http::{Status, RawStr};
@@ -52,7 +50,7 @@ fn upload<'r>(req: &'r Request, data: Data) -> HandlerFuture<'r> {
 
         let file = File::create(env::temp_dir().join("upload.txt")).await;
         if let Ok(file) = file {
-            if let Ok(n) = data.stream_to(TokioCompat::new(file)).await {
+            if let Ok(n) = data.stream_to(file).await {
                 return Outcome::from(req, format!("OK: {} bytes uploaded.", n)).await;
             }
 

--- a/examples/stream/Cargo.toml
+++ b/examples/stream/Cargo.toml
@@ -8,5 +8,4 @@ publish = false
 [dependencies]
 rocket = { path = "../../core/lib" }
 futures-preview = "0.3.0-alpha.18"
-tokio = "0.2.0-alpha.2"
-futures-tokio-compat = { git = "https://github.com/Nemo157/futures-tokio-compat" }
+async-std = "0.99.4"

--- a/examples/stream/src/main.rs
+++ b/examples/stream/src/main.rs
@@ -7,9 +7,7 @@
 use rocket::response::{content, Stream};
 
 use std::io::{self, repeat};
-
-use tokio::fs::File;
-use futures_tokio_compat::Compat as TokioCompat;
+use async_std::fs::File;
 
 use rocket::AsyncReadExt as _;
 
@@ -25,8 +23,8 @@ fn root() -> content::Plain<Stream<LimitedRepeat>> {
 }
 
 #[get("/big_file")]
-async fn file() -> io::Result<Stream<TokioCompat<File>>> {
-    File::open(FILENAME).await.map(|file| Stream::from(TokioCompat::new(file)))
+async fn file() -> io::Result<Stream<File>> {
+    File::open(FILENAME).await.map(Stream::from)
 }
 
 fn rocket() -> rocket::Rocket {


### PR DESCRIPTION
This currently only affects tests and simple APIs for files. It does let fetching file metadata be asynchronous, so it's not a completely trivial change.

This also mostly eliminates the need for the tokio compatibility layer (though it would've been temporary anyways), with the only usage now being in `rocket.rs` for wrapping the executor.

I have also pinned tokio to 0.2.0-alpha.2 to avoid breaking hyper. This can be removed in the future.