### PR TITLE
Implement fmt::display for Json<T>

### DIFF
--- a/contrib/lib/src/json.rs
+++ b/contrib/lib/src/json.rs
@@ -14,6 +14,7 @@
 //! features = ["json"]
 //! ```
 
+use std::fmt;
 use std::ops::{Deref, DerefMut};
 use std::io::{self, Read};
 use std::iter::FromIterator;
@@ -169,6 +170,26 @@ impl<'a, T: Serialize> Responder<'a> for Json<T> {
             error_!("JSON failed to serialize: {:?}", e);
             Status::InternalServerError
         })
+    }
+}
+
+/// Serializes the wrapped value as a string
+/// ```rust
+/// #[post("/entities", format = "application/json", data = "<entity>")]
+/// fn user(entity: Json<Entity>) -> ... {
+///     log::info!("Received {}", entity.to_string());
+///     /* ... */
+/// }
+/// ```
+impl<T: Serialize> fmt::Display for Json<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match serde_json::to_string(&self.0) {
+            Ok(s) => write!(f, "{}", s),
+            Err(e) => {
+                error_!("JSON failed to serialize: {:?}", e);
+                write!(f, "{}", e.to_string())
+            },
+        }
     }
 }
 


### PR DESCRIPTION
First submission so I'm sure there is room for improvement here, definitely not sure if the error condition should be handled the way it is but I'm pretty new to Rust still so...

This simply implements fit::display for Json<T> allowing you to use to_string to convert the data structure back to a string.

In my use case I'm receiving Json data from the front end, have Rocket parse it so I know I'm receiving valid data, then do additional validation checks on the data, and finally send the JSON to a stored function in PostgreSQL. It is here where I need the data as a string again so being able to just call to_string is a nice convenience here. 