### PR TITLE
Remove `crate_visibility_modifier` feature

### DIFF
--- a/contrib/lib/src/helmet/policy.rs
+++ b/contrib/lib/src/helmet/policy.rs
@@ -63,7 +63,7 @@ pub trait Policy: Default + Send + Sync + 'static {
     fn header(&self) -> Header<'static>;
 }
 
-crate trait SubPolicy: Send + Sync {
+pub(crate) trait SubPolicy: Send + Sync {
     fn name(&self) -> &'static UncasedStr;
     fn header(&self) -> Header<'static>;
 }

--- a/contrib/lib/src/lib.rs
+++ b/contrib/lib/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(crate_visibility_modifier)]
-
 #![doc(html_root_url = "https://api.rocket.rs/v0.5")]
 #![doc(html_favicon_url = "https://rocket.rs/v0.5/images/favicon.ico")]
 #![doc(html_logo_url = "https://rocket.rs/v0.5/images/logo-boxed.png")]

--- a/contrib/lib/src/templates/context.rs
+++ b/contrib/lib/src/templates/context.rs
@@ -5,13 +5,13 @@ use crate::templates::{Engines, TemplateInfo};
 
 use rocket::http::ContentType;
 
-crate struct Context {
+pub(crate) struct Context {
     /// The root of the template directory.
-    crate root: PathBuf,
+    pub root: PathBuf,
     /// Mapping from template name to its information.
-    crate templates: HashMap<String, TemplateInfo>,
+    pub templates: HashMap<String, TemplateInfo>,
     /// Loaded template engines
-    crate engines: Engines,
+    pub engines: Engines,
 }
 
 impl Context {

--- a/contrib/lib/src/templates/engine.rs
+++ b/contrib/lib/src/templates/engine.rs
@@ -7,7 +7,7 @@ use crate::templates::TemplateInfo;
 #[cfg(feature = "tera_templates")] use crate::templates::tera::Tera;
 #[cfg(feature = "handlebars_templates")] use crate::templates::handlebars::Handlebars;
 
-crate trait Engine: Send + Sync + 'static {
+pub(crate) trait Engine: Send + Sync + 'static {
     const EXT: &'static str;
 
     fn init(templates: &[(&str, &TemplateInfo)]) -> Option<Self> where Self: Sized;
@@ -60,12 +60,12 @@ pub struct Engines {
 }
 
 impl Engines {
-    crate const ENABLED_EXTENSIONS: &'static [&'static str] = &[
+    pub(crate) const ENABLED_EXTENSIONS: &'static [&'static str] = &[
         #[cfg(feature = "tera_templates")] Tera::EXT,
         #[cfg(feature = "handlebars_templates")] Handlebars::EXT,
     ];
 
-    crate fn init(templates: &HashMap<String, TemplateInfo>) -> Option<Engines> {
+    pub(crate) fn init(templates: &HashMap<String, TemplateInfo>) -> Option<Engines> {
         fn inner<E: Engine>(templates: &HashMap<String, TemplateInfo>) -> Option<E> {
             let named_templates = templates.iter()
                 .filter(|&(_, i)| i.extension == E::EXT)
@@ -89,7 +89,7 @@ impl Engines {
         })
     }
 
-    crate fn render<C: Serialize>(
+    pub(crate) fn render<C: Serialize>(
         &self,
         name: &str,
         info: &TemplateInfo,

--- a/contrib/lib/src/templates/fairing.rs
+++ b/contrib/lib/src/templates/fairing.rs
@@ -4,7 +4,7 @@ use rocket::Rocket;
 use rocket::config::ConfigError;
 use rocket::fairing::{Fairing, Info, Kind};
 
-crate use self::context::ContextManager;
+pub(crate) use self::context::ContextManager;
 
 #[cfg(not(debug_assertions))]
 mod context {
@@ -13,18 +13,18 @@ mod context {
 
     /// Wraps a Context. With `cfg(debug_assertions)` active, this structure
     /// additionally provides a method to reload the context at runtime.
-    crate struct ContextManager(Context);
+    pub(crate) struct ContextManager(Context);
 
     impl ContextManager {
-        crate fn new(ctxt: Context) -> ContextManager {
+        pub fn new(ctxt: Context) -> ContextManager {
             ContextManager(ctxt)
         }
 
-        crate fn context<'a>(&'a self) -> impl Deref<Target=Context> + 'a {
+        pub fn context<'a>(&'a self) -> impl Deref<Target=Context> + 'a {
             &self.0
         }
 
-        crate fn is_reloading(&self) -> bool {
+        pub fn is_reloading(&self) -> bool {
             false
         }
     }
@@ -42,7 +42,7 @@ mod context {
 
     /// Wraps a Context. With `cfg(debug_assertions)` active, this structure
     /// additionally provides a method to reload the context at runtime.
-    crate struct ContextManager {
+    pub(crate) struct ContextManager {
         /// The current template context, inside an RwLock so it can be updated.
         context: RwLock<Context>,
         /// A filesystem watcher and the receive queue for its events.
@@ -50,7 +50,7 @@ mod context {
     }
 
     impl ContextManager {
-        crate fn new(ctxt: Context) -> ContextManager {
+        pub fn new(ctxt: Context) -> ContextManager {
             let (tx, rx) = channel();
             let watcher = raw_watcher(tx).and_then(|mut watcher| {
                 watcher.watch(ctxt.root.canonicalize()?, RecursiveMode::Recursive)?;
@@ -73,11 +73,11 @@ mod context {
             }
         }
 
-        crate fn context(&self) -> impl Deref<Target=Context> + '_ {
+        pub fn context(&self) -> impl Deref<Target=Context> + '_ {
             self.context.read().unwrap()
         }
 
-        crate fn is_reloading(&self) -> bool {
+        pub fn is_reloading(&self) -> bool {
             self.watcher.is_some()
         }
 
@@ -89,7 +89,7 @@ mod context {
         /// have been changes since the last reload, all templates are
         /// reinitialized from disk and the user's customization callback is run
         /// again.
-        crate fn reload_if_needed<F: Fn(&mut Engines)>(&self, custom_callback: F) {
+        pub fn reload_if_needed<F: Fn(&mut Engines)>(&self, custom_callback: F) {
             self.watcher.as_ref().map(|w| {
                 let rx_lock = w.lock().expect("receive queue lock");
                 let mut changed = false;
@@ -121,7 +121,7 @@ pub struct TemplateFairing {
     /// The user-provided customization callback, allowing the use of
     /// functionality specific to individual template engines. In debug mode,
     /// this callback might be run multiple times as templates are reloaded.
-    crate custom_callback: Box<dyn Fn(&mut Engines) + Send + Sync + 'static>,
+    pub custom_callback: Box<dyn Fn(&mut Engines) + Send + Sync + 'static>,
 }
 
 impl Fairing for TemplateFairing {

--- a/contrib/lib/src/templates/mod.rs
+++ b/contrib/lib/src/templates/mod.rs
@@ -129,8 +129,8 @@ mod metadata;
 
 pub use self::engine::Engines;
 pub use self::metadata::Metadata;
-crate use self::context::Context;
-crate use self::fairing::ContextManager;
+pub(crate) use self::context::Context;
+pub(crate) use self::fairing::ContextManager;
 
 use self::engine::Engine;
 use self::fairing::TemplateFairing;
@@ -209,7 +209,7 @@ pub struct Template {
 }
 
 #[derive(Debug)]
-crate struct TemplateInfo {
+pub(crate) struct TemplateInfo {
     /// The complete path, including `template_dir`, to this template.
     path: PathBuf,
     /// The extension for the engine of this template.

--- a/core/codegen/src/attribute/segments.rs
+++ b/core/codegen/src/attribute/segments.rs
@@ -7,15 +7,15 @@ use crate::http::uri::{UriPart, Path};
 use crate::http::route::RouteSegment;
 use crate::proc_macro_ext::{Diagnostics, StringLit, PResult, DResult};
 
-crate use crate::http::route::{Error, Kind, Source};
+pub use crate::http::route::{Error, Kind, Source};
 
 #[derive(Debug, Clone)]
-crate struct Segment {
-    crate span: Span,
-    crate kind: Kind,
-    crate source: Source,
-    crate name: String,
-    crate index: Option<usize>,
+pub struct Segment {
+    pub span: Span,
+    pub kind: Kind,
+    pub source: Source,
+    pub name: String,
+    pub index: Option<usize>,
 }
 
 impl Segment {
@@ -115,7 +115,7 @@ fn into_diagnostic(
     }
 }
 
-crate fn parse_data_segment(segment: &str, span: Span) -> PResult<Segment> {
+pub fn parse_data_segment(segment: &str, span: Span) -> PResult<Segment> {
     <RouteSegment<'_, Path>>::parse_one(segment)
         .map(|segment| {
             let mut seg = Segment::from(segment, span);
@@ -126,7 +126,7 @@ crate fn parse_data_segment(segment: &str, span: Span) -> PResult<Segment> {
         .map_err(|e| into_diagnostic(segment, segment, span, &e))
 }
 
-crate fn parse_segments<P: UriPart>(
+pub fn parse_segments<P: UriPart>(
     string: &str,
     span: Span
 ) -> DResult<Vec<Segment>> {

--- a/core/codegen/src/bang/mod.rs
+++ b/core/codegen/src/bang/mod.rs
@@ -9,7 +9,7 @@ use crate::{ROUTE_STRUCT_PREFIX, CATCH_STRUCT_PREFIX};
 mod uri;
 mod uri_parsing;
 
-crate fn prefix_last_segment(path: &mut Path, prefix: &str) {
+pub fn prefix_last_segment(path: &mut Path, prefix: &str) {
     let mut last_seg = path.segments.last_mut().expect("syn::Path has segments");
     last_seg.ident = last_seg.ident.prepend(prefix);
 }

--- a/core/codegen/src/bang/uri.rs
+++ b/core/codegen/src/bang/uri.rs
@@ -23,7 +23,7 @@ macro_rules! p {
     ($n:expr, "parameter") => (p!(@go $n, "1 parameter", format!("{} parameters", $n)));
 }
 
-crate fn _uri_macro(input: TokenStream) -> Result<TokenStream> {
+pub fn _uri_macro(input: TokenStream) -> Result<TokenStream> {
     let input2: TokenStream2 = input.clone().into();
     let mut params = syn::parse::<UriParams>(input).map_err(syn_to_diag)?;
     prefix_last_segment(&mut params.route_path, URI_MACRO_PREFIX);
@@ -212,7 +212,7 @@ fn build_origin(internal: &InternalUriParams) -> Origin<'static> {
     Origin::new(path, query).to_normalized().into_owned()
 }
 
-crate fn _uri_internal_macro(input: TokenStream) -> Result<TokenStream> {
+pub fn _uri_internal_macro(input: TokenStream) -> Result<TokenStream> {
     // Parse the internal invocation and the user's URI param expressions.
     let internal = syn::parse::<InternalUriParams>(input).map_err(syn_to_diag)?;
     let (path_params, query_params) = extract_exprs(&internal)?;

--- a/core/codegen/src/derive/from_form.rs
+++ b/core/codegen/src/derive/from_form.rs
@@ -2,13 +2,13 @@ use proc_macro::{Span, TokenStream};
 use devise::{*, ext::{TypeExt, Split3}};
 
 #[derive(FromMeta)]
-crate struct Form {
-    crate field: FormField,
+pub struct Form {
+    pub field: FormField,
 }
 
-crate struct FormField {
-    crate span: Span,
-    crate name: String
+pub struct FormField {
+    pub span: Span,
+    pub name: String
 }
 
 fn is_valid_field_name(s: &str) -> bool {

--- a/core/codegen/src/http_codegen.rs
+++ b/core/codegen/src/http_codegen.rs
@@ -8,25 +8,25 @@ use crate::attribute::segments::{parse_segments, parse_data_segment, Segment, Ki
 use crate::proc_macro_ext::StringLit;
 
 #[derive(Debug)]
-crate struct ContentType(crate http::ContentType);
+pub struct ContentType(pub http::ContentType);
 
 #[derive(Debug)]
-crate struct Status(crate http::Status);
+pub struct Status(pub http::Status);
 
 #[derive(Debug)]
-crate struct MediaType(crate http::MediaType);
+pub struct MediaType(pub http::MediaType);
 
 #[derive(Debug)]
-crate struct Method(crate http::Method);
+pub struct Method(pub http::Method);
 
 #[derive(Debug)]
-crate struct Origin(crate http::uri::Origin<'static>);
+pub struct Origin(pub http::uri::Origin<'static>);
 
 #[derive(Clone, Debug)]
-crate struct DataSegment(crate Segment);
+pub struct DataSegment(pub Segment);
 
 #[derive(Clone, Debug)]
-crate struct Optional<T>(crate Option<T>);
+pub struct Optional<T>(pub Option<T>);
 
 impl FromMeta for StringLit {
     fn from_meta(meta: MetaItem<'_>) -> Result<Self> {
@@ -35,10 +35,10 @@ impl FromMeta for StringLit {
 }
 
 #[derive(Debug)]
-crate struct RoutePath {
-    crate origin: Origin,
-    crate path: Vec<Segment>,
-    crate query: Option<Vec<Segment>>,
+pub struct RoutePath {
+    pub origin: Origin,
+    pub path: Vec<Segment>,
+    pub query: Option<Vec<Segment>>,
 }
 
 impl FromMeta for Status {

--- a/core/codegen/src/lib.rs
+++ b/core/codegen/src/lib.rs
@@ -1,5 +1,4 @@
 #![feature(proc_macro_diagnostic, proc_macro_span)]
-#![feature(crate_visibility_modifier)]
 #![recursion_limit="128"]
 
 #![doc(html_root_url = "https://api.rocket.rs/v0.5")]
@@ -114,14 +113,14 @@ mod syn_ext;
 
 use crate::http::Method;
 use proc_macro::TokenStream;
-crate use devise::proc_macro2;
+pub(crate) use devise::proc_macro2;
 
-crate static ROUTE_STRUCT_PREFIX: &str = "static_rocket_route_info_for_";
-crate static CATCH_STRUCT_PREFIX: &str = "static_rocket_catch_info_for_";
-crate static CATCH_FN_PREFIX: &str = "rocket_catch_fn_";
-crate static ROUTE_FN_PREFIX: &str = "rocket_route_fn_";
-crate static URI_MACRO_PREFIX: &str = "rocket_uri_macro_";
-crate static ROCKET_PARAM_PREFIX: &str = "__rocket_param_";
+pub(crate) static ROUTE_STRUCT_PREFIX: &str = "static_rocket_route_info_for_";
+pub(crate) static CATCH_STRUCT_PREFIX: &str = "static_rocket_catch_info_for_";
+pub(crate) static CATCH_FN_PREFIX: &str = "rocket_catch_fn_";
+pub(crate) static ROUTE_FN_PREFIX: &str = "rocket_route_fn_";
+pub(crate) static URI_MACRO_PREFIX: &str = "rocket_uri_macro_";
+pub(crate) static ROCKET_PARAM_PREFIX: &str = "__rocket_param_";
 
 macro_rules! emit {
     ($tokens:expr) => ({

--- a/core/codegen/src/lib.rs
+++ b/core/codegen/src/lib.rs
@@ -115,12 +115,12 @@ use crate::http::Method;
 use proc_macro::TokenStream;
 use devise::proc_macro2;
 
-pub(crate) static ROUTE_STRUCT_PREFIX: &str = "static_rocket_route_info_for_";
-pub(crate) static CATCH_STRUCT_PREFIX: &str = "static_rocket_catch_info_for_";
-pub(crate) static CATCH_FN_PREFIX: &str = "rocket_catch_fn_";
-pub(crate) static ROUTE_FN_PREFIX: &str = "rocket_route_fn_";
-pub(crate) static URI_MACRO_PREFIX: &str = "rocket_uri_macro_";
-pub(crate) static ROCKET_PARAM_PREFIX: &str = "__rocket_param_";
+static ROUTE_STRUCT_PREFIX: &str = "static_rocket_route_info_for_";
+static CATCH_STRUCT_PREFIX: &str = "static_rocket_catch_info_for_";
+static CATCH_FN_PREFIX: &str = "rocket_catch_fn_";
+static ROUTE_FN_PREFIX: &str = "rocket_route_fn_";
+static URI_MACRO_PREFIX: &str = "rocket_uri_macro_";
+static ROCKET_PARAM_PREFIX: &str = "__rocket_param_";
 
 macro_rules! emit {
     ($tokens:expr) => ({

--- a/core/codegen/src/lib.rs
+++ b/core/codegen/src/lib.rs
@@ -113,7 +113,7 @@ mod syn_ext;
 
 use crate::http::Method;
 use proc_macro::TokenStream;
-pub(crate) use devise::proc_macro2;
+use devise::proc_macro2;
 
 pub(crate) static ROUTE_STRUCT_PREFIX: &str = "static_rocket_route_info_for_";
 pub(crate) static CATCH_STRUCT_PREFIX: &str = "static_rocket_catch_info_for_";

--- a/core/codegen/src/proc_macro_ext.rs
+++ b/core/codegen/src/proc_macro_ext.rs
@@ -63,7 +63,7 @@ impl From<Vec<Diagnostic>> for Diagnostics {
 
 use std::ops::Deref;
 
-pub struct StringLit(crate String, crate Literal);
+pub struct StringLit(pub String, pub Literal);
 
 impl Deref for StringLit {
     type Target = str;

--- a/core/http/src/accept.rs
+++ b/core/http/src/accept.rs
@@ -162,7 +162,7 @@ impl PartialEq for AcceptParams {
 /// let response = Response::build().header(Accept::JSON).finalize();
 /// ```
 #[derive(Debug, Clone, PartialEq)]
-pub struct Accept(crate AcceptParams);
+pub struct Accept(pub(crate) AcceptParams);
 
 macro_rules! accept_constructor {
     ($($name:ident ($check:ident): $str:expr, $t:expr,

--- a/core/http/src/lib.rs
+++ b/core/http/src/lib.rs
@@ -1,5 +1,4 @@
 #![feature(proc_macro_hygiene)]
-#![feature(crate_visibility_modifier)]
 #![recursion_limit="512"]
 
 #![warn(rust_2018_idioms)]
@@ -38,7 +37,7 @@ mod header;
 mod accept;
 mod raw_str;
 
-crate mod parse;
+pub(crate) mod parse;
 
 pub mod uncased;
 

--- a/core/http/src/lib.rs
+++ b/core/http/src/lib.rs
@@ -36,8 +36,7 @@ mod status;
 mod header;
 mod accept;
 mod raw_str;
-
-pub(crate) mod parse;
+mod parse;
 
 pub mod uncased;
 

--- a/core/http/src/parse/uri/error.rs
+++ b/core/http/src/parse/uri/error.rs
@@ -25,7 +25,7 @@ enum Or<L, R> {
 }
 
 impl<'a> Error<'a> {
-    pub fn from(src: &'a str, pear_error: ParseErr<RawInput<'a>>) -> Error<'a> {
+    pub(crate) fn from(src: &'a str, pear_error: ParseErr<RawInput<'a>>) -> Error<'a> {
         let new_expected = pear_error.expected.map(|token| {
             if token.is_ascii() && !token.is_ascii_control() {
                 Or::A(token as char)

--- a/core/http/src/parse/uri/error.rs
+++ b/core/http/src/parse/uri/error.rs
@@ -25,7 +25,7 @@ enum Or<L, R> {
 }
 
 impl<'a> Error<'a> {
-    crate fn from(src: &'a str, pear_error: ParseErr<RawInput<'a>>) -> Error<'a> {
+    pub fn from(src: &'a str, pear_error: ParseErr<RawInput<'a>>) -> Error<'a> {
         let new_expected = pear_error.expected.map(|token| {
             if token.is_ascii() && !token.is_ascii_control() {
                 Or::A(token as char)

--- a/core/http/src/parse/uri/mod.rs
+++ b/core/http/src/parse/uri/mod.rs
@@ -8,7 +8,7 @@ use crate::uri::{Uri, Origin, Absolute, Authority};
 use crate::parse::indexed::IndexedInput;
 use self::parser::{uri, origin, authority_only, absolute_only, rocket_route_origin};
 
-crate use self::tables::is_pchar;
+pub use self::tables::is_pchar;
 pub use self::error::Error;
 
 type RawInput<'a> = IndexedInput<'a, [u8]>;

--- a/core/http/src/parse/uri/parser.rs
+++ b/core/http/src/parse/uri/parser.rs
@@ -9,7 +9,7 @@ use crate::parse::IndexedBytes;
 type Result<'a, T> = pear::Result<T, RawInput<'a>>;
 
 #[parser]
-crate fn uri<'a>(input: &mut RawInput<'a>) -> Result<'a, Uri<'a>> {
+pub fn uri<'a>(input: &mut RawInput<'a>) -> Result<'a, Uri<'a>> {
     match input.len() {
         0 => return Err(pear_error!("empty URI")),
         1 => switch! {
@@ -29,12 +29,12 @@ crate fn uri<'a>(input: &mut RawInput<'a>) -> Result<'a, Uri<'a>> {
 }
 
 #[parser]
-crate fn origin<'a>(input: &mut RawInput<'a>) -> Result<'a, Origin<'a>> {
+pub fn origin<'a>(input: &mut RawInput<'a>) -> Result<'a, Origin<'a>> {
     (peek(b'/')?, path_and_query(is_pchar)?).1
 }
 
 #[parser]
-crate fn rocket_route_origin<'a>(input: &mut RawInput<'a>) -> Result<'a, Origin<'a>> {
+pub fn rocket_route_origin<'a>(input: &mut RawInput<'a>) -> Result<'a, Origin<'a>> {
     (peek(b'/')?, path_and_query(is_pchar_or_rchar)?).1
 }
 
@@ -128,7 +128,7 @@ fn absolute<'a>(
 }
 
 #[parser]
-crate fn authority_only<'a>(input: &mut RawInput<'a>) -> Result<'a, Authority<'a>> {
+pub fn authority_only<'a>(input: &mut RawInput<'a>) -> Result<'a, Authority<'a>> {
     if let Uri::Authority(authority) = absolute_or_authority()? {
         Ok(authority)
     } else {
@@ -137,7 +137,7 @@ crate fn authority_only<'a>(input: &mut RawInput<'a>) -> Result<'a, Authority<'a
 }
 
 #[parser]
-crate fn absolute_only<'a>(input: &mut RawInput<'a>) -> Result<'a, Absolute<'a>> {
+pub fn absolute_only<'a>(input: &mut RawInput<'a>) -> Result<'a, Absolute<'a>> {
     if let Uri::Absolute(absolute) = absolute_or_authority()? {
         Ok(absolute)
     } else {

--- a/core/http/src/uri/absolute.rs
+++ b/core/http/src/uri/absolute.rs
@@ -44,7 +44,7 @@ impl IntoOwned for Absolute<'_> {
 
 impl<'a> Absolute<'a> {
     #[inline]
-    crate unsafe fn raw(
+    pub(crate) unsafe fn raw(
         source: Cow<'a, [u8]>,
         scheme: Indexed<'a, [u8]>,
         authority: Option<Authority<'a>>,
@@ -59,7 +59,7 @@ impl<'a> Absolute<'a> {
     }
 
     #[cfg(test)]
-    crate fn new(
+    pub(crate) fn new(
         scheme: &'a str,
         authority: Option<Authority<'a>>,
         origin: Option<Origin<'a>>

--- a/core/http/src/uri/authority.rs
+++ b/core/http/src/uri/authority.rs
@@ -28,7 +28,7 @@ pub struct Authority<'a> {
 }
 
 #[derive(Debug, Clone)]
-crate enum Host<T> {
+pub(crate) enum Host<T> {
     Bracketed(T),
     Raw(T)
 }
@@ -55,7 +55,7 @@ impl IntoOwned for Authority<'_> {
 }
 
 impl<'a> Authority<'a> {
-    crate unsafe fn raw(
+    pub(crate) unsafe fn raw(
         source: Cow<'a, [u8]>,
         user_info: Option<Indexed<'a, [u8]>>,
         host: Host<Indexed<'a, [u8]>>,
@@ -70,7 +70,7 @@ impl<'a> Authority<'a> {
     }
 
     #[cfg(test)]
-    crate fn new(
+    pub(crate) fn new(
         user_info: Option<&'a str>,
         host: Host<&'a str>,
         port: Option<u16>

--- a/core/http/src/uri/encoding.rs
+++ b/core/http/src/uri/encoding.rs
@@ -8,7 +8,7 @@ use crate::parse::uri::is_pchar;
 
 #[derive(Clone, Copy)]
 #[allow(non_camel_case_types)]
-crate struct UNSAFE_ENCODE_SET<P: UriPart>(PhantomData<P>);
+pub struct UNSAFE_ENCODE_SET<P: UriPart>(PhantomData<P>);
 
 impl<P: UriPart> Default for UNSAFE_ENCODE_SET<P> {
     #[inline(always)]
@@ -31,7 +31,7 @@ impl EncodeSet for UNSAFE_ENCODE_SET<Query> {
 
 #[derive(Clone, Copy)]
 #[allow(non_camel_case_types)]
-crate struct ENCODE_SET<P: UriPart>(PhantomData<P>);
+pub struct ENCODE_SET<P: UriPart>(PhantomData<P>);
 
 impl EncodeSet for ENCODE_SET<Path> {
     #[inline(always)]
@@ -52,7 +52,7 @@ impl EncodeSet for ENCODE_SET<Query> {
 
 #[derive(Default, Clone, Copy)]
 #[allow(non_camel_case_types)]
-crate struct DEFAULT_ENCODE_SET;
+pub struct DEFAULT_ENCODE_SET;
 
 impl EncodeSet for DEFAULT_ENCODE_SET {
     #[inline(always)]
@@ -62,7 +62,7 @@ impl EncodeSet for DEFAULT_ENCODE_SET {
     }
 }
 
-crate fn unsafe_percent_encode<P: UriPart>(string: &str) -> Cow<'_, str> {
+pub fn unsafe_percent_encode<P: UriPart>(string: &str) -> Cow<'_, str> {
     match P::DELIMITER {
         '/' => percent_encode::<UNSAFE_ENCODE_SET<Path>>(string),
         '&' => percent_encode::<UNSAFE_ENCODE_SET<Query>>(string),
@@ -70,6 +70,6 @@ crate fn unsafe_percent_encode<P: UriPart>(string: &str) -> Cow<'_, str> {
     }
 }
 
-crate fn percent_encode<S: EncodeSet + Default>(string: &str) -> Cow<'_, str> {
+pub fn percent_encode<S: EncodeSet + Default>(string: &str) -> Cow<'_, str> {
     utf8_percent_encode(string, S::default()).into()
 }

--- a/core/http/src/uri/formatter.rs
+++ b/core/http/src/uri/formatter.rs
@@ -158,7 +158,7 @@ pub struct Formatter<'i, P: UriPart> {
 
 impl<'i, P: UriPart> Formatter<'i, P> {
     #[inline(always)]
-    crate fn new(inner: &'i mut (dyn Write + 'i)) -> Self {
+    pub(crate) fn new(inner: &'i mut (dyn Write + 'i)) -> Self {
         Formatter {
             inner,
             prefixes: SmallVec::new(),

--- a/core/http/src/uri/mod.rs
+++ b/core/http/src/uri/mod.rs
@@ -9,7 +9,7 @@ mod authority;
 mod absolute;
 mod segments;
 
-crate mod encoding;
+pub(crate) mod encoding;
 
 pub use crate::parse::uri::Error;
 

--- a/core/http/src/uri/origin.rs
+++ b/core/http/src/uri/origin.rs
@@ -85,10 +85,10 @@ use state::Storage;
 /// ```
 #[derive(Clone, Debug)]
 pub struct Origin<'a> {
-    crate source: Option<Cow<'a, str>>,
-    crate path: IndexedStr<'a>,
-    crate query: Option<IndexedStr<'a>>,
-    crate segment_count: Storage<usize>,
+    pub(crate) source: Option<Cow<'a, str>>,
+    pub(crate) path: IndexedStr<'a>,
+    pub(crate) query: Option<IndexedStr<'a>>,
+    pub(crate) segment_count: Storage<usize>,
 }
 
 impl<'b> PartialEq<Origin<'b>> for Origin<'_> {
@@ -112,7 +112,7 @@ impl IntoOwned for Origin<'_> {
 
 impl<'a> Origin<'a> {
     #[inline]
-    crate unsafe fn raw(
+    pub(crate) unsafe fn raw(
         source: Cow<'a, [u8]>,
         path: Indexed<'a, [u8]>,
         query: Option<Indexed<'a, [u8]>>

--- a/core/http/src/uri/uri.rs
+++ b/core/http/src/uri/uri.rs
@@ -62,7 +62,7 @@ pub enum Uri<'a> {
 
 impl<'a> Uri<'a> {
     #[inline]
-    crate unsafe fn raw_absolute(
+    pub(crate) unsafe fn raw_absolute(
         source: Cow<'a, [u8]>,
         scheme: Indexed<'a, [u8]>,
         path: Indexed<'a, [u8]>,
@@ -212,7 +212,7 @@ impl<'a> Uri<'a> {
     }
 }
 
-crate unsafe fn as_utf8_unchecked(input: Cow<'_, [u8]>) -> Cow<'_, str> {
+pub(crate) unsafe fn as_utf8_unchecked(input: Cow<'_, [u8]>) -> Cow<'_, str> {
     match input {
         Cow::Borrowed(bytes) => Cow::Borrowed(std::str::from_utf8_unchecked(bytes)),
         Cow::Owned(bytes) => Cow::Owned(String::from_utf8_unchecked(bytes))

--- a/core/lib/src/catcher.rs
+++ b/core/lib/src/catcher.rs
@@ -64,7 +64,7 @@ pub struct Catcher {
     pub code: u16,
     /// The catcher's associated handler.
     pub handler: ErrorHandler,
-    crate is_default: bool,
+    pub(crate) is_default: bool,
 }
 
 impl Catcher {
@@ -98,7 +98,7 @@ impl Catcher {
     }
 
     #[inline(always)]
-    crate fn handle<'r>(&self, req: &'r Request<'_>) -> response::Result<'r> {
+    pub(crate) fn handle<'r>(&self, req: &'r Request<'_>) -> response::Result<'r> {
         (self.handler)(req)
     }
 

--- a/core/lib/src/config/config.rs
+++ b/core/lib/src/config/config.rs
@@ -49,17 +49,17 @@ pub struct Config {
     /// How much information to log.
     pub log_level: LoggingLevel,
     /// The secret key.
-    crate secret_key: SecretKey,
+    pub(crate) secret_key: SecretKey,
     /// TLS configuration.
-    crate tls: Option<TlsConfig>,
+    pub(crate) tls: Option<TlsConfig>,
     /// Streaming read size limits.
     pub limits: Limits,
     /// Extra parameters that aren't part of Rocket's core config.
     pub extras: HashMap<String, Value>,
     /// The path to the configuration file this config was loaded from, if any.
-    crate config_file_path: Option<PathBuf>,
+    pub(crate) config_file_path: Option<PathBuf>,
     /// The path root-relative files will be rooted from.
-    crate root_path: Option<PathBuf>,
+    pub(crate) root_path: Option<PathBuf>,
 }
 
 macro_rules! config_from_raw {
@@ -192,7 +192,7 @@ impl Config {
     /// # Panics
     ///
     /// Panics if randomness cannot be retrieved from the OS.
-    crate fn default_from<P>(env: Environment, path: P) -> Result<Config>
+    pub(crate) fn default_from<P>(env: Environment, path: P) -> Result<Config>
         where P: AsRef<Path>
     {
         let mut config = Config::default(env);
@@ -214,7 +214,7 @@ impl Config {
     /// # Panics
     ///
     /// Panics if randomness cannot be retrieved from the OS.
-    crate fn default(env: Environment) -> Config {
+    pub(crate) fn default(env: Environment) -> Config {
         // Note: This may truncate if num_cpus::get() / 2 > u16::max. That's okay.
         let default_workers = (num_cpus::get() * 2) as u16;
 
@@ -276,7 +276,7 @@ impl Config {
     /// Constructs a `BadType` error given the entry `name`, the invalid `val`
     /// at that entry, and the `expect`ed type name.
     #[inline(always)]
-    crate fn bad_type(&self,
+    pub(crate) fn bad_type(&self,
                            name: &str,
                            actual: &'static str,
                            expect: &'static str) -> ConfigError {
@@ -300,7 +300,7 @@ impl Config {
     ///   * **log**: String
     ///   * **secret_key**: String (256-bit base64)
     ///   * **tls**: Table (`certs` (path as String), `key` (path as String))
-    crate fn set_raw(&mut self, name: &str, val: &Value) -> Result<()> {
+    pub(crate) fn set_raw(&mut self, name: &str, val: &Value) -> Result<()> {
         let (id, ok) = (|val| val, |_| Ok(()));
         config_from_raw!(self, name, val,
             address => (str, set_address, id),
@@ -616,7 +616,7 @@ impl Config {
 
     /// Retrieves the secret key from `self`.
     #[inline]
-    crate fn secret_key(&self) -> &Key {
+    pub(crate) fn secret_key(&self) -> &Key {
         self.secret_key.inner()
     }
 

--- a/core/lib/src/config/custom_values.rs
+++ b/core/lib/src/config/custom_values.rs
@@ -13,14 +13,14 @@ pub enum SecretKey {
 
 impl SecretKey {
     #[inline]
-    crate fn inner(&self) -> &Key {
+    pub(crate) fn inner(&self) -> &Key {
         match *self {
             SecretKey::Generated(ref key) | SecretKey::Provided(ref key) => key
         }
     }
 
     #[inline]
-    crate fn is_generated(&self) -> bool {
+    pub(crate) fn is_generated(&self) -> bool {
         match *self {
             #[cfg(feature = "private-cookies")]
             SecretKey::Generated(_) => true,
@@ -82,7 +82,7 @@ pub struct TlsConfig;
 #[derive(Debug, Clone)]
 pub struct Limits {
     // We cache this internally but don't share that fact in the API.
-    crate forms: u64,
+    pub(crate) forms: u64,
     extra: Vec<(String, u64)>
 }
 

--- a/core/lib/src/config/environment.rs
+++ b/core/lib/src/config/environment.rs
@@ -21,10 +21,10 @@ pub enum Environment {
 
 impl Environment {
     /// List of all of the possible environments.
-    crate const ALL: [Environment; 3] = [Development, Staging, Production];
+    pub(crate) const ALL: [Environment; 3] = [Development, Staging, Production];
 
     /// String of all valid environments.
-    crate const VALID: &'static str = "development, staging, production";
+    pub(crate) const VALID: &'static str = "development, staging, production";
 
     /// Retrieves the "active" environment as determined by the `ROCKET_ENV`
     /// environment variable. If `ROCKET_ENV` is not set, returns `Development`

--- a/core/lib/src/config/mod.rs
+++ b/core/lib/src/config/mod.rs
@@ -204,7 +204,7 @@ pub use self::environment::Environment;
 pub use self::config::Config;
 pub use self::builder::ConfigBuilder;
 pub use crate::logger::LoggingLevel;
-crate use self::toml_ext::LoggedValue;
+pub(crate) use self::toml_ext::LoggedValue;
 
 use crate::logger;
 use self::Environment::*;
@@ -443,7 +443,7 @@ impl RocketConfig {
 /// # Panics
 ///
 /// If there is a problem, prints a nice error message and bails.
-crate fn init() -> Config {
+pub(crate) fn init() -> Config {
     let bail = |e: ConfigError| -> ! {
         logger::init(LoggingLevel::Debug);
         e.pretty_print();

--- a/core/lib/src/config/toml_ext.rs
+++ b/core/lib/src/config/toml_ext.rs
@@ -81,7 +81,7 @@ pub fn parse_simple_toml_value(mut input: &str) -> StdResult<Value, String> {
 
 /// A simple wrapper over a `Value` reference with a custom implementation of
 /// `Display`. This is used to log config values at initialization.
-crate struct LoggedValue<'a>(pub &'a Value);
+pub struct LoggedValue<'a>(pub &'a Value);
 
 impl fmt::Display for LoggedValue<'_> {
     #[inline]

--- a/core/lib/src/data/data.rs
+++ b/core/lib/src/data/data.rs
@@ -91,7 +91,7 @@ impl Data {
     }
 
     // FIXME: This is absolutely terrible (downcasting!), thanks to Hyper.
-    crate fn from_hyp(mut body: HyperBodyReader<'_, '_>) -> Result<Data, &'static str> {
+    pub(crate) fn from_hyp(mut body: HyperBodyReader<'_, '_>) -> Result<Data, &'static str> {
         #[inline(always)]
         #[cfg(feature = "tls")]
         fn concrete_stream(stream: &mut dyn NetworkStream) -> Option<NetStream> {
@@ -230,7 +230,7 @@ impl Data {
     // bytes `vec[pos..cap]` are buffered and unread. The remainder of the data
     // bytes can be read from `stream`.
     #[inline(always)]
-    crate fn new(mut stream: BodyReader) -> Data {
+    pub(crate) fn new(mut stream: BodyReader) -> Data {
         trace_!("Data::new({:?})", stream);
         let mut peek_buf: Vec<u8> = vec![0; PEEK_BYTES];
 
@@ -260,7 +260,7 @@ impl Data {
 
     /// This creates a `data` object from a local data source `data`.
     #[inline]
-    crate fn local(data: Vec<u8>) -> Data {
+    pub(crate) fn local(data: Vec<u8>) -> Data {
         let empty_stream = Cursor::new(vec![]).chain(NetStream::Empty);
 
         Data {

--- a/core/lib/src/data/data_stream.rs
+++ b/core/lib/src/data/data_stream.rs
@@ -14,7 +14,7 @@ pub type InnerStream = Chain<Cursor<Vec<u8>>, BodyReader>;
 /// [`Data::open()`](crate::data::Data::open()). The stream contains all of the data
 /// in the body of the request. It exposes no methods directly. Instead, it must
 /// be used as an opaque [`Read`] structure.
-pub struct DataStream(crate InnerStream);
+pub struct DataStream(pub(crate) InnerStream);
 
 // TODO: Have a `BufRead` impl for `DataStream`. At the moment, this isn't
 // possible since Hyper's `HttpReader` doesn't implement `BufRead`.

--- a/core/lib/src/error.rs
+++ b/core/lib/src/error.rs
@@ -87,7 +87,7 @@ pub struct LaunchError {
 
 impl LaunchError {
     #[inline(always)]
-    crate fn new(kind: LaunchErrorKind) -> LaunchError {
+    pub(crate) fn new(kind: LaunchErrorKind) -> LaunchError {
         LaunchError { handled: AtomicBool::new(false), kind }
     }
 

--- a/core/lib/src/fairing/mod.rs
+++ b/core/lib/src/fairing/mod.rs
@@ -53,7 +53,7 @@ mod fairings;
 mod ad_hoc;
 mod info_kind;
 
-crate use self::fairings::Fairings;
+pub(crate) use self::fairings::Fairings;
 pub use self::ad_hoc::AdHoc;
 pub use self::info_kind::{Info, Kind};
 

--- a/core/lib/src/lib.rs
+++ b/core/lib/src/lib.rs
@@ -1,5 +1,4 @@
 #![feature(proc_macro_hygiene)]
-#![feature(crate_visibility_modifier)]
 
 #![recursion_limit="256"]
 

--- a/core/lib/src/local/client.rs
+++ b/core/lib/src/local/client.rs
@@ -69,7 +69,7 @@ use crate::error::LaunchError;
 /// [`post()`]: #method.post
 pub struct Client {
     rocket: Rocket,
-    crate cookies: Option<RwLock<CookieJar>>,
+    pub(crate) cookies: Option<RwLock<CookieJar>>,
 }
 
 impl Client {

--- a/core/lib/src/local/request.rs
+++ b/core/lib/src/local/request.rs
@@ -101,7 +101,7 @@ pub struct LocalRequest<'c> {
 
 impl<'c> LocalRequest<'c> {
     #[inline(always)]
-    crate fn new(
+    pub(crate) fn new(
         client: &'c Client,
         method: Method,
         uri: Cow<'c, str>

--- a/core/lib/src/logger.rs
+++ b/core/lib/src/logger.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 use log;
 use yansi::Paint;
 
-crate const COLORS_ENV: &str = "ROCKET_CLI_COLORS";
+pub(crate) const COLORS_ENV: &str = "ROCKET_CLI_COLORS";
 
 struct RocketLogger(LoggingLevel);
 
@@ -145,7 +145,7 @@ impl log::Log for RocketLogger {
     }
 }
 
-crate fn try_init(level: LoggingLevel, verbose: bool) -> bool {
+pub(crate) fn try_init(level: LoggingLevel, verbose: bool) -> bool {
     if level == LoggingLevel::Off {
         return false;
     }
@@ -198,13 +198,13 @@ fn usize_to_filter(num: usize) -> log::LevelFilter {
     }
 }
 
-crate fn push_max_level(level: LoggingLevel) {
+pub(crate) fn push_max_level(level: LoggingLevel) {
     LAST_LOG_FILTER.store(filter_to_usize(log::max_level()), Ordering::Release);
     PUSHED.store(true, Ordering::Release);
     log::set_max_level(level.to_level_filter());
 }
 
-crate fn pop_max_level() {
+pub(crate) fn pop_max_level() {
     if PUSHED.load(Ordering::Acquire) {
         log::set_max_level(usize_to_filter(LAST_LOG_FILTER.load(Ordering::Acquire)));
     }

--- a/core/lib/src/request/form/form.rs
+++ b/core/lib/src/request/form/form.rs
@@ -148,7 +148,7 @@ impl<T> Deref for Form<T> {
 }
 
 impl<'f, T: FromForm<'f>> Form<T> {
-    crate fn from_data(
+    pub(crate) fn from_data(
         form_str: &'f str,
         strict: bool
     ) -> Outcome<T, FormDataError<'f, T::Error>> {

--- a/core/lib/src/request/request.rs
+++ b/core/lib/src/request/request.rs
@@ -32,24 +32,24 @@ pub struct Request<'r> {
     uri: Origin<'r>,
     headers: HeaderMap<'r>,
     remote: Option<SocketAddr>,
-    crate state: RequestState<'r>,
+    pub(crate) state: RequestState<'r>,
 }
 
 #[derive(Clone)]
-crate struct RequestState<'r> {
-    crate config: &'r Config,
-    crate managed: &'r Container,
-    crate path_segments: SmallVec<[Indices; 12]>,
-    crate query_items: Option<SmallVec<[IndexedFormItem; 6]>>,
-    crate route: Cell<Option<&'r Route>>,
-    crate cookies: RefCell<CookieJar>,
-    crate accept: Storage<Option<Accept>>,
-    crate content_type: Storage<Option<ContentType>>,
-    crate cache: Rc<Container>,
+pub(crate) struct RequestState<'r> {
+    pub config: &'r Config,
+    pub managed: &'r Container,
+    pub path_segments: SmallVec<[Indices; 12]>,
+    pub query_items: Option<SmallVec<[IndexedFormItem; 6]>>,
+    pub route: Cell<Option<&'r Route>>,
+    pub cookies: RefCell<CookieJar>,
+    pub accept: Storage<Option<Accept>>,
+    pub content_type: Storage<Option<ContentType>>,
+    pub cache: Rc<Container>,
 }
 
 #[derive(Clone)]
-crate struct IndexedFormItem {
+pub(crate) struct IndexedFormItem {
     raw: Indices,
     key: Indices,
     value: Indices
@@ -58,7 +58,7 @@ crate struct IndexedFormItem {
 impl<'r> Request<'r> {
     /// Create a new `Request` with the given `method` and `uri`.
     #[inline(always)]
-    crate fn new<'s: 'r>(
+    pub(crate) fn new<'s: 'r>(
         rocket: &'r Rocket,
         method: Method,
         uri: Origin<'s>
@@ -740,7 +740,7 @@ impl<'r> Request<'r> {
     // Returns an iterator over the raw segments of the path URI. Does not take
     // into account the current route. This is used during routing.
     #[inline]
-    crate fn raw_path_segments(&self) -> impl Iterator<Item = &RawStr> {
+    pub(crate) fn raw_path_segments(&self) -> impl Iterator<Item = &RawStr> {
         let path = self.uri.path();
         self.state.path_segments.iter().cloned()
             .map(move |(i, j)| path[i..j].into())
@@ -769,19 +769,19 @@ impl<'r> Request<'r> {
     /// Set `self`'s parameters given that the route used to reach this request
     /// was `route`. Use during routing when attempting a given route.
     #[inline(always)]
-    crate fn set_route(&self, route: &'r Route) {
+    pub(crate) fn set_route(&self, route: &'r Route) {
         self.state.route.set(Some(route));
     }
 
     /// Set the method of `self`, even when `self` is a shared reference. Used
     /// during routing to override methods for re-routing.
     #[inline(always)]
-    crate fn _set_method(&self, method: Method) {
+    pub(crate) fn _set_method(&self, method: Method) {
         self.method.set(method);
     }
 
     /// Convert from Hyper types into a Rocket Request.
-    crate fn from_hyp(
+    pub(crate) fn from_hyp(
         rocket: &'r Rocket,
         h_method: hyper::Method,
         h_headers: hyper::header::Headers,

--- a/core/lib/src/response/mod.rs
+++ b/core/lib/src/response/mod.rs
@@ -27,7 +27,7 @@ mod stream;
 mod response;
 mod debug;
 
-crate mod flash;
+pub(crate) mod flash;
 
 pub mod content;
 pub mod status;

--- a/core/lib/src/response/response.rs
+++ b/core/lib/src/response/response.rs
@@ -973,7 +973,7 @@ impl<'r> Response<'r> {
     // Makes the `Read`er in the body empty but leaves the size of the body if
     // it exists. Only meant to be used to handle HEAD requests automatically.
     #[inline(always)]
-    crate fn strip_body(&mut self) {
+    pub(crate) fn strip_body(&mut self) {
         if let Some(body) = self.take_body() {
             self.body = match body {
                 Body::Sized(_, n) => Some(Body::Sized(Box::new(io::empty()), n)),

--- a/core/lib/src/rocket.rs
+++ b/core/lib/src/rocket.rs
@@ -29,11 +29,11 @@ use crate::http::uri::Origin;
 /// The main `Rocket` type: used to mount routes and catchers and launch the
 /// application.
 pub struct Rocket {
-    crate config: Config,
+    pub(crate) config: Config,
     router: Router,
     default_catchers: HashMap<u16, Catcher>,
     catchers: HashMap<u16, Catcher>,
-    crate state: Container,
+    pub(crate) state: Container,
     fairings: Fairings,
 }
 
@@ -197,7 +197,7 @@ impl Rocket {
     }
 
     #[inline]
-    crate fn dispatch<'s, 'r>(
+    pub(crate) fn dispatch<'s, 'r>(
         &'s self,
         request: &'r mut Request<'s>,
         data: Data
@@ -277,7 +277,7 @@ impl Rocket {
     // (ensuring `handler` takes an immutable borrow), any caller to `route`
     // should be able to supply an `&mut` and retain an `&` after the call.
     #[inline]
-    crate fn route<'s, 'r>(
+    pub(crate) fn route<'s, 'r>(
         &'s self,
         request: &'r Request<'s>,
         mut data: Data,
@@ -310,7 +310,7 @@ impl Rocket {
     // catcher is called. If the catcher fails to return a good response, the
     // 500 catcher is executed. If there is no registered catcher for `status`,
     // the default catcher is used.
-    crate fn handle_error<'r>(
+    pub(crate) fn handle_error<'r>(
         &self,
         status: Status,
         req: &'r Request<'_>
@@ -648,7 +648,7 @@ impl Rocket {
         self
     }
 
-    crate fn prelaunch_check(mut self) -> Result<Rocket, LaunchError> {
+    pub(crate) fn prelaunch_check(mut self) -> Result<Rocket, LaunchError> {
         self.router = match self.router.collisions() {
             Ok(router) => router,
             Err(e) => return Err(LaunchError::new(LaunchErrorKind::Collision(e)))

--- a/core/lib/src/router/mod.rs
+++ b/core/lib/src/router/mod.rs
@@ -12,7 +12,7 @@ use crate::http::Method;
 type Selector = Method;
 
 // A handler to use when one is needed temporarily.
-crate fn dummy_handler<'r>(r: &'r crate::Request<'_>, _: crate::Data) -> crate::handler::Outcome<'r> {
+pub(crate) fn dummy_handler<'r>(r: &'r crate::Request<'_>, _: crate::Data) -> crate::handler::Outcome<'r> {
     crate::Outcome::from(r, ())
 }
 
@@ -48,7 +48,7 @@ impl Router {
         matches
     }
 
-    crate fn collisions(mut self) -> Result<Router, Vec<(Route, Route)>> {
+    pub(crate) fn collisions(mut self) -> Result<Router, Vec<(Route, Route)>> {
         let mut collisions = vec![];
         for routes in self.routes.values_mut() {
             for i in 0..routes.len() {

--- a/core/lib/src/router/route.rs
+++ b/core/lib/src/router/route.rs
@@ -30,14 +30,14 @@ pub struct Route {
     /// The media type this route matches against, if any.
     pub format: Option<MediaType>,
     /// Cached metadata that aids in routing later.
-    crate metadata: Metadata
+    pub(crate) metadata: Metadata
 }
 
 #[derive(Debug, Default, Clone)]
-crate struct Metadata {
-    crate path_segments: Vec<RouteSegment<'static, Path>>,
-    crate query_segments: Option<Vec<RouteSegment<'static, Query>>>,
-    crate fully_dynamic_query: bool,
+pub(crate) struct Metadata {
+    pub path_segments: Vec<RouteSegment<'static, Path>>,
+    pub query_segments: Option<Vec<RouteSegment<'static, Query>>>,
+    pub fully_dynamic_query: bool,
 }
 
 impl Metadata {


### PR DESCRIPTION
In some situations, `pub(crate)` wasn't strictly necessary, as it was
within a context where it would not be exposed regardless of scope. In
these situations, `pub` is used per request.

Pinging @SergioBenitez and @jebrosen for review. This should be looked through carefully to ensure nothing is inadvertently exposed or hidden. Checking the documentation should be sufficient for this.