### PR TITLE
WIP Cors support, fixing #25

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,4 +42,5 @@ members = [
   "examples/fairings",
   "examples/hello_2018",
   "examples/hello_2015",
+  "examples/cors"
 ]

--- a/contrib/lib/Cargo.toml
+++ b/contrib/lib/Cargo.toml
@@ -27,6 +27,7 @@ serve = []
 compression = ["brotli_compression", "gzip_compression"]
 brotli_compression = ["brotli"]
 gzip_compression = ["flate2"]
+cors = []
 
 # The barage of user-facing database features.
 diesel_sqlite_pool = ["databases", "diesel/sqlite", "diesel/r2d2"]

--- a/contrib/lib/src/cors/config.rs
+++ b/contrib/lib/src/cors/config.rs
@@ -1,0 +1,28 @@
+#[derive(Debug, Clone)]
+pub struct CorsFairingConfig {
+    pub headers: Vec<String>,
+    pub origin: String
+}
+
+impl CorsFairingConfig {
+    pub fn new(headers: Vec<String>, origin: String) -> CorsFairingConfig {
+        CorsFairingConfig {
+            headers: headers,
+            origin: origin
+        }
+    }
+
+    pub fn with_any_origin() -> CorsFairingConfig {
+        CorsFairingConfig {
+            headers: Vec::new(),
+            origin: "*".to_owned()
+        }
+    }
+
+    pub fn with_origin(origin: String) -> CorsFairingConfig {
+        CorsFairingConfig {
+            headers: Vec::new(),
+            origin: origin
+        }
+    }
+}

--- a/contrib/lib/src/cors/mod.rs
+++ b/contrib/lib/src/cors/mod.rs
@@ -20,15 +20,8 @@ use rocket::http::Status;
 
 #[derive(Debug)]
 pub struct CorsFairing {
+    headers: Vec<String>,
     origins: Vec<String>
-}
-
-impl CorsFairing {
-    pub fn new() -> CorsFairing{
-        CorsFairing {
-            origins: Vec::new()
-        }
-    }
 }
 
 impl Fairing for CorsFairing {
@@ -40,7 +33,10 @@ impl Fairing for CorsFairing {
     }
 
     fn on_attach(&self, mut rocket:Rocket) -> Result<Rocket, Rocket> { 
-        let options_handler = OptionsHandler::new(vec![String::from("PATCH"), String::from("PUT"), String::from("POST")]);
+        let mthds = vec![String::from("PATCH"), String::from("PUT"), String::from("POST")];
+        //let hdrs = vec![String::from("content-type")];
+
+        let options_handler = OptionsHandler::new(mthds, self.headers.clone());
 
 
         let mut new_routes:Vec<Route> = Vec::new();
@@ -67,29 +63,48 @@ impl Fairing for CorsFairing {
     #[allow(unused_variables)]
     fn on_response(&self, request: &Request<'_>, response: &mut Response<'_>) {
         response.set_header(Header::new("Access-Control-Allow-Origin", "*"));
-        //response.set_header(Header::new("Access-Control-Allow-Methods", "POST, PATCH, DELETE"));
-        //response.set_header(Header::new("Access-Control-Allow-Headers", "content-type"));
     }
 }
 
 struct OptionsResponder {
-    allowed_methods: Vec<String>
+    allowed_methods: Vec<String>,
+    allowed_headers: Vec<String>
 }
 
-impl<'r> Responder<'r> for OptionsResponder {
-    fn respond_to(self, request: &Request) -> rocket::response::Result<'r> {
-        let mut methods = String::new();
-        for x in 0..self.allowed_methods.len() {
-            methods.push_str(&self.allowed_methods[x]);
-
-            if x < self.allowed_methods.len() - 1 {
-                methods.push_str(", ");
-            }
+fn comma_list(strings: &Vec<String>) -> String {
+    let mut list = String::new();
+    for x in 0..strings.len() {
+        list.push_str(&strings[x]);
+        if x < strings.len() - 1 {
+            list.push_str(", ");
         }
+    }
+
+    list
+}
+
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test1() {
+        assert_eq!(comma_list(&vec![String::from("Hello")]), "Hello");
+    }
+}
+
+
+impl<'r> Responder<'r> for OptionsResponder {
+    fn respond_to(self, _request: &Request<'_>) -> rocket::response::Result<'r> {
+
+        let methods = comma_list(&self.allowed_methods);
+        let headers = comma_list(&self.allowed_headers);
+
         let mut response = Response::build();
         
         response.raw_header("Access-Control-Allow-Methods", methods);
-        response.raw_header("Access-Control-Allow-Headers", "content-type");
+        response.raw_header("Access-Control-Allow-Headers", headers);
         response.status(Status::Ok)
         .ok()
     }
@@ -97,23 +112,53 @@ impl<'r> Responder<'r> for OptionsResponder {
 
 #[derive(Clone)]
 struct OptionsHandler {
-    allowed_methods: Vec<String>
+    allowed_methods: Vec<String>,
+    allowed_headers: Vec<String>
 }
 
 impl OptionsHandler {
-    pub fn new(allowed_methods: Vec<String>) -> OptionsHandler {
+    pub fn new(allowed_methods: Vec<String>, allowed_headers: Vec<String>) -> OptionsHandler {
         OptionsHandler { 
-            allowed_methods: allowed_methods
+            allowed_methods: allowed_methods,
+            allowed_headers: allowed_headers
         }
     }
 }
 
 impl Handler for OptionsHandler {
-    fn handle<'r>(&self, req: &'r Request, data: Data) -> Outcome<'r> {
+    fn handle<'r>(&self, req: &'r Request<'_>, _data: Data) -> Outcome<'r> {
         let responder = OptionsResponder{
-            allowed_methods: self.allowed_methods.clone()
+            allowed_methods: self.allowed_methods.clone(),
+            allowed_headers: self.allowed_headers.clone()
         };
 
         Outcome::from(req, responder)
+    }
+}
+
+
+pub struct CorsFairingBuilder {
+    headers: Vec<String>,
+    origins: Vec<String>
+}
+
+impl CorsFairingBuilder {
+    pub fn new() -> CorsFairingBuilder {
+        CorsFairingBuilder{
+            headers: Vec::new(),
+            origins: Vec::new()
+        }
+    }
+
+    pub fn build(self) -> CorsFairing {
+        CorsFairing{
+            headers: self.headers,
+            origins: self.origins
+        }
+    }
+
+    pub fn add_header(mut self, header: String) -> Self {
+        self.headers.push(header);
+        self
     }
 }

--- a/contrib/lib/src/cors/mod.rs
+++ b/contrib/lib/src/cors/mod.rs
@@ -1,6 +1,7 @@
 use rocket::fairing::Fairing;
 use rocket::fairing::Info;
 use rocket::fairing::Kind;
+use rocket::response::Responder;
 use rocket::Data;
 use rocket::Request;
 use rocket::Response;
@@ -10,6 +11,12 @@ use rocket::Handler;
 use rocket::handler::Outcome;
 use rocket::http::Header;
 use rocket::http::Method;
+use rocket::http::Status;
+
+// TODO Determine methods actually used and then only return them.
+// TODO Specify origins.
+// TODO Only set Access-Control-Allow-Methods, Access-Control-Allow-Headers headers on OPTIONS call
+// TODO Options should not return anything
 
 #[derive(Debug)]
 pub struct CorsFairing {
@@ -33,12 +40,16 @@ impl Fairing for CorsFairing {
     }
 
     fn on_attach(&self, mut rocket:Rocket) -> Result<Rocket, Rocket> { 
+        let options_handler = OptionsHandler::new(vec![String::from("PATCH"), String::from("PUT"), String::from("POST")]);
+
+
         let mut new_routes:Vec<Route> = Vec::new();
+
 
         for route in rocket.routes()
         {
             let uri_route = route.uri.path();
-            let preflight = Route::new(Method::Options, uri_route, OptionsHandler::new());
+            let preflight = Route::new(Method::Options, uri_route, options_handler.clone());
             new_routes.push(preflight);
         }
 
@@ -56,24 +67,53 @@ impl Fairing for CorsFairing {
     #[allow(unused_variables)]
     fn on_response(&self, request: &Request<'_>, response: &mut Response<'_>) {
         response.set_header(Header::new("Access-Control-Allow-Origin", "*"));
-        response.set_header(Header::new("Access-Control-Allow-Methods", "POST, PATCH, DELETE"));
-        response.set_header(Header::new("Access-Control-Allow-Headers", "content-type"));
+        //response.set_header(Header::new("Access-Control-Allow-Methods", "POST, PATCH, DELETE"));
+        //response.set_header(Header::new("Access-Control-Allow-Headers", "content-type"));
+    }
+}
+
+struct OptionsResponder {
+    allowed_methods: Vec<String>
+}
+
+impl<'r> Responder<'r> for OptionsResponder {
+    fn respond_to(self, request: &Request) -> rocket::response::Result<'r> {
+        let mut methods = String::new();
+        for x in 0..self.allowed_methods.len() {
+            methods.push_str(&self.allowed_methods[x]);
+
+            if x < self.allowed_methods.len() - 1 {
+                methods.push_str(", ");
+            }
+        }
+        let mut response = Response::build();
+        
+        response.raw_header("Access-Control-Allow-Methods", methods);
+        response.raw_header("Access-Control-Allow-Headers", "content-type");
+        response.status(Status::Ok)
+        .ok()
     }
 }
 
 #[derive(Clone)]
 struct OptionsHandler {
-    
+    allowed_methods: Vec<String>
 }
 
 impl OptionsHandler {
-    pub fn new() -> OptionsHandler {
-        OptionsHandler { }
+    pub fn new(allowed_methods: Vec<String>) -> OptionsHandler {
+        OptionsHandler { 
+            allowed_methods: allowed_methods
+        }
     }
 }
 
 impl Handler for OptionsHandler {
     fn handle<'r>(&self, req: &'r Request, data: Data) -> Outcome<'r> {
-        Outcome::from(req, "hello world")
+        let responder = OptionsResponder{
+            allowed_methods: self.allowed_methods.clone()
+        };
+
+        Outcome::from(req, responder)
     }
 }

--- a/contrib/lib/src/cors/mod.rs
+++ b/contrib/lib/src/cors/mod.rs
@@ -15,8 +15,9 @@ use rocket::http::Status;
 
 // TODO Determine methods actually used and then only return them.
 // TODO Specify origins.
-// TODO Only set Access-Control-Allow-Methods, Access-Control-Allow-Headers headers on OPTIONS call
-// TODO Options should not return anything
+// TODO Unit tests
+// TODO Documentation
+// TODO Good default values for headers, etc.
 
 #[derive(Debug)]
 pub struct CorsFairing {
@@ -34,7 +35,6 @@ impl Fairing for CorsFairing {
 
     fn on_attach(&self, mut rocket:Rocket) -> Result<Rocket, Rocket> { 
         let mthds = vec![String::from("PATCH"), String::from("PUT"), String::from("POST")];
-        //let hdrs = vec![String::from("content-type")];
 
         let options_handler = OptionsHandler::new(mthds, self.headers.clone());
 

--- a/contrib/lib/src/cors/mod.rs
+++ b/contrib/lib/src/cors/mod.rs
@@ -37,15 +37,12 @@ impl Fairing for CorsFairing {
 
         for route in rocket.routes()
         {
-            println!("{:?}", route.uri.path());
+            let uri_route = route.uri.path();
+            let preflight = Route::new(Method::Options, uri_route, OptionsHandler::new());
+            new_routes.push(preflight);
         }
 
-
-        let r = Route::new(Method::Options, "/foo", OptionsHandler::new());
-        new_routes.push(r);
-        //Route::new(..)
         rocket = rocket.mount("/", new_routes);
-
         Ok(rocket)
     }
 
@@ -59,7 +56,8 @@ impl Fairing for CorsFairing {
     #[allow(unused_variables)]
     fn on_response(&self, request: &Request<'_>, response: &mut Response<'_>) {
         response.set_header(Header::new("Access-Control-Allow-Origin", "*"));
-        //unimplemented!();
+        response.set_header(Header::new("Access-Control-Allow-Methods", "POST, PATCH, DELETE"));
+        response.set_header(Header::new("Access-Control-Allow-Headers", "content-type"));
     }
 }
 

--- a/contrib/lib/src/cors/mod.rs
+++ b/contrib/lib/src/cors/mod.rs
@@ -157,8 +157,8 @@ impl CorsFairingBuilder {
         }
     }
 
-    pub fn add_header(mut self, header: String) -> Self {
-        self.headers.push(header);
+    pub fn add_header(mut self, header: &str) -> Self {
+        self.headers.push(String::from(header));
         self
     }
 }

--- a/contrib/lib/src/cors/mod.rs
+++ b/contrib/lib/src/cors/mod.rs
@@ -13,7 +13,6 @@ use rocket::http::Header;
 use rocket::http::Method;
 use rocket::http::Status;
 
-// TODO Determine methods actually used and then only return them.
 // TODO Specify origins.
 // TODO Documentation
 // TODO Good default values for headers, etc.
@@ -140,7 +139,6 @@ impl Handler for OptionsHandler {
         Outcome::from(req, responder)
     }
 }
-
 
 pub struct CorsFairingBuilder {
     headers: Vec<String>,

--- a/contrib/lib/src/cors/mod.rs
+++ b/contrib/lib/src/cors/mod.rs
@@ -15,6 +15,14 @@
 //! features = ["cors"]
 //! ```
 //!
+//! Configure the allowed origin in your Rocket.toml file.
+//! 
+//! ```toml
+//! [development.cors]
+//! allow_origin = "https://example.com/"
+//! allow_headers = ["X-Foo", "X-Bar"]
+//! ```
+//! 
 //! Then add the fairing to your rocket before launching.
 //! 
 //! ```rust
@@ -22,7 +30,7 @@
 //! 
 //! #[macro_use] extern crate rocket;
 //! 
-//! use rocket_contrib::cors::CorsFairingBuilder;
+//! use rocket_contrib::cors::CorsFairing;
 //! 
 //! #[get("/")]
 //! fn index() -> &'static str {
@@ -33,15 +41,14 @@
 //!     let rocket = rocket::ignite()
 //!         .mount("/", routes![index])
 //!         // Add CorsFairing *after* your routes.
-//!         .attach(CorsFairingBuilder::new()
-//!             .explicit_origin("https://example.com/")
-//!             .build().unwrap());
+//!         .attach(CorsFairing::new());
 //! # if false { // We don't actually want to launch the server in an example.
 //!     rocket.launch();
 //! # }
 //! }
 //! ```
 //!
+use rocket::config::Value;
 use rocket::fairing::Fairing;
 use rocket::fairing::Info;
 use rocket::fairing::Kind;
@@ -57,12 +64,21 @@ use rocket::http::Header;
 use rocket::http::Method;
 use rocket::http::Status;
 
-
+struct CorsContext {
+    origin: String
+}
 
 #[derive(Debug)]
 pub struct CorsFairing {
-    headers: Vec<String>,
-    origin: Origin
+    config: Option<CorsFairingConfig>
+}
+
+impl CorsFairing {
+    pub fn new() -> CorsFairing {
+        CorsFairing {
+            config: None
+        }
+    }    
 }
 
 impl Fairing for CorsFairing {
@@ -76,6 +92,109 @@ impl Fairing for CorsFairing {
     fn on_attach(&self, mut rocket:Rocket) -> Result<Rocket, Rocket> { 
         use std::collections::HashMap;
 
+        // TODO Factor this configuration out.  I should be able to reuse most of this configuration within
+        // code between a test and the regular Rocket configuration.
+        let (origin, headers) = match &self.config {
+            Some(ref config) => {
+                let origin = match &config.origin {
+                    Some(ref origin) => match origin {
+                        Origin::Any => String::from("*"),
+                        Origin::Explicit(s) => s.clone()
+                    },
+                    None => {
+                        warn_!("Bad headers.");
+
+                        String::from("")
+                    }
+                };
+
+                (origin, config.headers.clone())
+            },
+            None => {
+                if let Ok(cors_table) = rocket.config().get_table("cors") {
+                    let origin = match cors_table.get("allow_origin") {
+                        Some(origin_value) => match origin_value {
+                            Value::String(s) => s.clone(),
+                            _ => {
+                                warn_!("\"allow_origin\" configuration entry is missing.");
+
+                                String::from("")
+                            }
+                        },
+                        None => {
+                            warn_!("Missing allow origin");
+
+                            String::from("")
+                        }
+                    };
+
+                    let headers = match cors_table.get("allow-headers") {
+                        Some(allow_headers_value) => {
+                            match allow_headers_value {
+                                Value::Array(x) => {
+                                    let result: Vec<String> = x.iter()
+                                        .filter_map(|val| match val { 
+                                            rocket::config::Value::String(s) => Some(s.clone()),
+                                            _ => None
+                                        })
+                                        .collect();
+
+                                    result
+                                },
+                                _ => {
+                                warn_!("Bad allow origin");
+
+                                    Vec::new()
+                                }
+                            }
+                            
+                        },
+                        _ => Vec::new()
+                    };
+                    
+                    (origin, headers)
+                } else {
+                    (String::from(""), Vec::new())
+                }
+            }
+        };
+
+        /*
+        let origin = match &self.config {
+            Some(ref config) => match config.origin {
+                Some(ref origin) => string_from_origin(&origin),
+                None => origin_from_config(&rocket)
+            },
+            None => {
+                origin_from_config(&rocket)
+            }
+        };        
+
+        let headers = match &self.config {
+            Some(ref config) => config.headers.clone(),
+            None => {
+                if let Ok(headers) = rocket.config().get_slice("allowed_cross_origin_headers") {
+                    let result: Vec<String> = headers.iter()
+                        .filter_map(|val| match val { 
+                            rocket::config::Value::String(s) => Some(s.clone()),
+                            _ => None
+                        })
+                        .collect();
+
+                    result
+                } else {
+                    warn_!("Bad headers.");
+
+                    Vec::new()
+                }
+            }
+        };
+        */
+
+        let ctx = CorsContext {
+            origin: origin
+        };
+        
         let mut uri_methods : HashMap<String, Vec<Method>> = HashMap::new();
         for route in rocket.routes()
         {
@@ -86,31 +205,30 @@ impl Fairing for CorsFairing {
 
         let mut new_routes:Vec<Route> = Vec::new();
         for (uri, methods) in uri_methods.iter() {
-            let options_handler = OptionsHandler::new(methods.clone(), self.headers.clone());
+            let options_handler = OptionsHandler::new(methods.clone(), headers.clone());
 
             let preflight = Route::new(Method::Options, uri, options_handler);
             new_routes.push(preflight);
         }
         
         rocket = rocket.mount("/", new_routes);
-        Ok(rocket)
+        Ok(rocket.manage(ctx))
     }
 
     
     #[allow(unused_variables)]
-    fn on_request(&self, request: &mut Request<'_>, data: &Data) {
+    fn on_request(&self, _: &mut Request<'_>, _: &Data) {
         unimplemented!();
     }
 
 
     #[allow(unused_variables)]
     fn on_response(&self, request: &Request<'_>, response: &mut Response<'_>) {
-        let origin_str = match self.origin {
-            Origin::Any => "*".to_string(),
-            Origin::Explicit(ref uri) => uri.to_string()
-        };
+        let context = request
+            .guard::<rocket::State<'_, CorsContext>>()
+            .expect("CorsContext registered in on_attach");
 
-        response.set_header(Header::new("Access-Control-Allow-Origin", origin_str));
+        response.set_header(Header::new("Access-Control-Allow-Origin", context.origin.clone()));
     }
 }
 
@@ -139,6 +257,7 @@ mod test {
     #[test]
     fn test1() {
         assert_eq!(comma_list(&vec![String::from("Hello")]), "Hello");
+        assert_eq!(comma_list(&vec![String::from("Hello"), String::from("World")]), "Hello, World");
     }
 }
 
@@ -191,34 +310,23 @@ enum Origin {
     Explicit(String)
 }
 
-pub struct CorsFairingBuilder {
+#[derive(Debug)]
+pub struct CorsFairingConfig {
     headers: Vec<String>,
     origin: Option<Origin>
 }
 
-#[derive(Debug, PartialEq)]
-pub enum CorsFairingError {
-    /// If the programmer has not chosen any origin then an error will be returned.
-    NoOrigin
-}
-
-impl CorsFairingBuilder {
-    pub fn new() -> CorsFairingBuilder {
-        CorsFairingBuilder{
+impl CorsFairingConfig {
+    pub fn new() -> CorsFairingConfig {
+        CorsFairingConfig{
             headers: Vec::new(),
             origin: None
         }
     }
 
-    pub fn build(self) -> Result<CorsFairing,CorsFairingError> {
-        match self.origin {
-            Some(origin) => {
-                Ok(CorsFairing{
-                    headers: self.headers,
-                    origin: origin
-                })
-            },
-            None => Result::Err(CorsFairingError::NoOrigin)
+    pub fn fairing(self) -> CorsFairing {
+        CorsFairing {
+            config: Some(self)
         }
     }
 

--- a/contrib/lib/src/cors/mod.rs
+++ b/contrib/lib/src/cors/mod.rs
@@ -15,9 +15,10 @@ use rocket::http::Status;
 
 // TODO Determine methods actually used and then only return them.
 // TODO Specify origins.
-// TODO Unit tests
 // TODO Documentation
 // TODO Good default values for headers, etc.
+// TODO Perhaps clone the settings or something.
+
 
 #[derive(Debug)]
 pub struct CorsFairing {

--- a/contrib/lib/src/cors/mod.rs
+++ b/contrib/lib/src/cors/mod.rs
@@ -1,0 +1,40 @@
+use rocket::fairing::Fairing;
+use rocket::fairing::Info;
+use rocket::Data;
+use rocket::Request;
+use rocket::Response;
+use rocket::Rocket;
+
+pub struct CorsFairing {
+    origins: Vec<String>
+}
+
+impl CorsFairing {
+    pub fn new() -> CorsFairing{
+        CorsFairing {
+            origins: Vec::new()
+        }
+    }
+}
+
+impl Fairing for CorsFairing {
+    fn info(&self) -> Info {
+        unimplemented!();
+    }
+
+    fn on_attach(&self, rocket: Rocket) -> Result<Rocket, Rocket> { 
+        unimplemented!();
+    }
+
+    
+    #[allow(unused_variables)]
+    fn on_request(&self, request: &mut Request<'_>, data: &Data) {
+        unimplemented!();
+    }
+
+
+    #[allow(unused_variables)]
+    fn on_response(&self, request: &Request<'_>, response: &mut Response<'_>) {
+        unimplemented!();
+    }
+}

--- a/contrib/lib/src/cors/mod.rs
+++ b/contrib/lib/src/cors/mod.rs
@@ -5,8 +5,13 @@ use rocket::Data;
 use rocket::Request;
 use rocket::Response;
 use rocket::Rocket;
+use rocket::Route;
+use rocket::Handler;
+use rocket::handler::Outcome;
 use rocket::http::Header;
+use rocket::http::Method;
 
+#[derive(Debug)]
 pub struct CorsFairing {
     origins: Vec<String>
 }
@@ -27,9 +32,20 @@ impl Fairing for CorsFairing {
         }
     }
 
-    fn on_attach(&self, rocket: Rocket) -> Result<Rocket, Rocket> { 
-        //println!("Failed at on_attach, ln 30");
-        //unimplemented!();
+    fn on_attach(&self, mut rocket:Rocket) -> Result<Rocket, Rocket> { 
+        let mut new_routes:Vec<Route> = Vec::new();
+
+        for route in rocket.routes()
+        {
+            println!("{:?}", route.uri.path());
+        }
+
+
+        let r = Route::new(Method::Options, "/foo", OptionsHandler::new());
+        new_routes.push(r);
+        //Route::new(..)
+        rocket = rocket.mount("/", new_routes);
+
         Ok(rocket)
     }
 
@@ -44,5 +60,22 @@ impl Fairing for CorsFairing {
     fn on_response(&self, request: &Request<'_>, response: &mut Response<'_>) {
         response.set_header(Header::new("Access-Control-Allow-Origin", "*"));
         //unimplemented!();
+    }
+}
+
+#[derive(Clone)]
+struct OptionsHandler {
+    
+}
+
+impl OptionsHandler {
+    pub fn new() -> OptionsHandler {
+        OptionsHandler { }
+    }
+}
+
+impl Handler for OptionsHandler {
+    fn handle<'r>(&self, req: &'r Request, data: Data) -> Outcome<'r> {
+        Outcome::from(req, "hello world")
     }
 }

--- a/contrib/lib/src/cors/mod.rs
+++ b/contrib/lib/src/cors/mod.rs
@@ -101,8 +101,9 @@ mod test {
 
 impl<'r> Responder<'r> for OptionsResponder {
     fn respond_to(self, _request: &Request<'_>) -> rocket::response::Result<'r> {
-
-        let methods = comma_list(&self.allowed_methods.iter().map(|x| format!("{}", x)).collect());
+        let mut meths: Vec<String> = self.allowed_methods.iter().map(|x| format!("{}", x)).collect();
+        meths.sort();
+        let methods = comma_list(&meths);
         let headers = comma_list(&self.allowed_headers);
 
         let mut response = Response::build();

--- a/contrib/lib/src/cors/mod.rs
+++ b/contrib/lib/src/cors/mod.rs
@@ -1,3 +1,47 @@
+//! A fairing to implement automatic [Cross-origin resource sharing](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing).
+//! 
+//! This fairing will automatically add appropriate Access-Control-* headers 
+//! to every route and generate preflight routes (OPTIONS) where required.
+//!
+//!
+//! # Enabling
+//!
+//! This module is only available when the 'cors' feature is enabled.  Enable
+//! cors in `Cargo.toml` as follows:
+//!
+//! ```toml
+//! [dependencies.rocket_contrib]
+//! version = "0.5.0-dev"
+//! features = ["cors"]
+//! ```
+//!
+//! Then add the fairing to your rocket before launching.
+//! 
+//! ```rust
+//! #![feature(proc_macro_hygiene)]
+//! 
+//! #[macro_use] extern crate rocket;
+//! 
+//! use rocket_contrib::cors::CorsFairingBuilder;
+//! 
+//! #[get("/")]
+//! fn index() -> &'static str {
+//!     "Hello, world!"
+//! }
+//!
+//! fn main() {
+//!     let rocket = rocket::ignite()
+//!         .mount("/", routes![index])
+//!         // Add CorsFairing *after* your routes.
+//!         .attach(CorsFairingBuilder::new()
+//!             .explicit_origin("https://example.com/")
+//!             .build().unwrap());
+//! # if false { // We don't actually want to launch the server in an example.
+//!     rocket.launch();
+//! # }
+//! }
+//! ```
+//!
 use rocket::fairing::Fairing;
 use rocket::fairing::Info;
 use rocket::fairing::Kind;
@@ -13,11 +57,7 @@ use rocket::http::Header;
 use rocket::http::Method;
 use rocket::http::Status;
 
-// TODO Specify origins.
-// TODO Documentation
-// TODO Good default values for headers, etc.
-// TODO Perhaps clone the settings or something.
-// TODO Add a marker parameter "AllowOrigin" or "DenyOrigin"?  See what other cors libraries (node, sprint) have done.  What is the default?  What is the verb?
+
 
 #[derive(Debug)]
 pub struct CorsFairing {

--- a/contrib/lib/src/cors/mod.rs
+++ b/contrib/lib/src/cors/mod.rs
@@ -1,5 +1,6 @@
 use rocket::fairing::Fairing;
 use rocket::fairing::Info;
+use rocket::fairing::Kind;
 use rocket::Data;
 use rocket::Request;
 use rocket::Response;
@@ -19,7 +20,10 @@ impl CorsFairing {
 
 impl Fairing for CorsFairing {
     fn info(&self) -> Info {
-        unimplemented!();
+        Info {
+            name: "Cors Fairing",
+            kind: Kind::Attach | Kind::Response
+        }
     }
 
     fn on_attach(&self, rocket: Rocket) -> Result<Rocket, Rocket> { 

--- a/contrib/lib/src/cors/mod.rs
+++ b/contrib/lib/src/cors/mod.rs
@@ -134,7 +134,7 @@ impl Fairing for CorsFairing {
                                 Value::Array(x) => {
                                     let result: Vec<String> = x.iter()
                                         .filter_map(|val| match val { 
-                                            rocket::config::Value::String(s) => Some(s.clone()),
+                                            Value::String(s) => Some(s.clone()),
                                             _ => None
                                         })
                                         .collect();
@@ -158,38 +158,6 @@ impl Fairing for CorsFairing {
                 }
             }
         };
-
-        /*
-        let origin = match &self.config {
-            Some(ref config) => match config.origin {
-                Some(ref origin) => string_from_origin(&origin),
-                None => origin_from_config(&rocket)
-            },
-            None => {
-                origin_from_config(&rocket)
-            }
-        };        
-
-        let headers = match &self.config {
-            Some(ref config) => config.headers.clone(),
-            None => {
-                if let Ok(headers) = rocket.config().get_slice("allowed_cross_origin_headers") {
-                    let result: Vec<String> = headers.iter()
-                        .filter_map(|val| match val { 
-                            rocket::config::Value::String(s) => Some(s.clone()),
-                            _ => None
-                        })
-                        .collect();
-
-                    result
-                } else {
-                    warn_!("Bad headers.");
-
-                    Vec::new()
-                }
-            }
-        };
-        */
 
         let ctx = CorsContext {
             origin: origin
@@ -345,5 +313,9 @@ impl CorsFairingConfig {
         self.origin = Some(Origin::Explicit(uri.to_string()));        
 
         self
+    }
+
+    pub fn foo() -> () {
+        
     }
 }

--- a/contrib/lib/src/cors/mod.rs
+++ b/contrib/lib/src/cors/mod.rs
@@ -5,6 +5,7 @@ use rocket::Data;
 use rocket::Request;
 use rocket::Response;
 use rocket::Rocket;
+use rocket::http::Header;
 
 pub struct CorsFairing {
     origins: Vec<String>
@@ -27,7 +28,9 @@ impl Fairing for CorsFairing {
     }
 
     fn on_attach(&self, rocket: Rocket) -> Result<Rocket, Rocket> { 
-        unimplemented!();
+        //println!("Failed at on_attach, ln 30");
+        //unimplemented!();
+        Ok(rocket)
     }
 
     
@@ -39,6 +42,7 @@ impl Fairing for CorsFairing {
 
     #[allow(unused_variables)]
     fn on_response(&self, request: &Request<'_>, response: &mut Response<'_>) {
-        unimplemented!();
+        response.set_header(Header::new("Access-Control-Allow-Origin", "*"));
+        //unimplemented!();
     }
 }

--- a/contrib/lib/src/cors/responder.rs
+++ b/contrib/lib/src/cors/responder.rs
@@ -1,0 +1,53 @@
+
+use rocket::Request;
+
+use rocket::Response;
+use rocket::http::Method;
+use rocket::http::Status;
+use rocket::response::Responder;
+
+pub struct PreflightCors {
+    pub allowed_methods: Vec<Method>,
+    pub allowed_headers: Vec<String>
+}
+
+impl<'r> Responder<'r> for PreflightCors {
+    fn respond_to(self, _request: &Request<'_>) -> rocket::response::Result<'r> {
+        let mut meths: Vec<String> = self.allowed_methods.iter().map(|x| format!("{}", x)).collect();
+        meths.sort();
+        let methods = comma_list(&meths);
+        let headers = comma_list(&self.allowed_headers);
+
+        let mut response = Response::build();
+        
+        response.raw_header("Access-Control-Allow-Methods", methods);
+        response.raw_header("Access-Control-Allow-Headers", headers);
+        response.status(Status::Ok)
+        .ok()
+    }
+}
+
+
+
+fn comma_list(strings: &Vec<String>) -> String {
+    let mut list = String::new();
+    for x in 0..strings.len() {
+        list.push_str(&strings[x]);
+        if x < strings.len() - 1 {
+            list.push_str(", ");
+        }
+    }
+
+    list
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test1() {
+        assert_eq!(comma_list(&vec![String::from("Hello")]), "Hello");
+        assert_eq!(comma_list(&vec![String::from("Hello"), String::from("World")]), "Hello, World");
+    }
+}

--- a/contrib/lib/src/lib.rs
+++ b/contrib/lib/src/lib.rs
@@ -54,5 +54,5 @@
 #[cfg(feature="databases")] pub mod databases;
 #[cfg(feature = "helmet")] pub mod helmet;
 #[cfg(any(feature="brotli_compression", feature="gzip_compression"))] pub mod compression;
-
+#[cfg(feature="cors")] pub mod cors;
 #[cfg(feature="databases")] #[doc(hidden)] pub use rocket_contrib_codegen::*;

--- a/contrib/lib/src/lib.rs
+++ b/contrib/lib/src/lib.rs
@@ -27,7 +27,8 @@
 //! * [${database}_pool](databases) - Database Configuration and Pooling
 //! * [helmet](helmet) - Fairing for Security and Privacy Headers
 //! * [compression](compression) - Response compression
-//!
+//! * [cors](cors) - Automatic Cross-Origin Resource Sharing
+//! 
 //! The recommend way to include features from this crate via Cargo in your
 //! project is by adding a `[dependencies.rocket_contrib]` section to your
 //! `Cargo.toml` file, setting `default-features` to false, and specifying

--- a/contrib/lib/tests/cors.rs
+++ b/contrib/lib/tests/cors.rs
@@ -17,11 +17,6 @@ mod cors_tests {
     use rocket::local::*;
     use rocket::http::Status;
 
-    #[test]
-    pub fn test_basic() {
-        let _ = CorsFairingBuilder::new();
-    }
-
     #[get("/test")]
     pub fn sample_get_route() -> &'static str {
         "Hi"
@@ -31,6 +26,21 @@ mod cors_tests {
     pub fn sample_delete_route() -> &'static str {
         "Hi"
     }
+
+    // TODO name after Cross Origin.  Example CrossOrigin
+    
+    // Include on all responses 
+    //   Access-Control-Allow-Credentials
+    //   Access-Control-Allow-Origin
+    // Requested on preflight
+    //   `Access-Control-Request-Method` 
+    //   `Access-Control-Request-Headers` 
+    // Include on preflight
+    //   Access-Control-Allow-Methods` 
+    //   `Access-Control-Allow-Headers` 
+    //   `Access-Control-Max-Age` 
+    //   `Access-Control-Expose-Headers` 
+    
 
     #[test]
     pub fn test_one_method() {

--- a/contrib/lib/tests/cors.rs
+++ b/contrib/lib/tests/cors.rs
@@ -1,0 +1,18 @@
+
+// TODO Test with an allow-any origin
+// TODO Test with two origins
+// TODO Test with one origin
+// TODO Test a variety of methods (delete, put, post)
+// TODO Test with headers
+// TODO Test with no headers
+// TODO Test with multiple headers
+// note, I think all of these can be integration tests
+#[cfg(feature = "cors")]
+mod cors_tests {
+    use rocket_contrib::cors::*;
+
+    #[test]
+    pub fn test_basic() {
+        let _ = CorsFairingBuilder::new();
+    }
+}

--- a/contrib/lib/tests/cors.rs
+++ b/contrib/lib/tests/cors.rs
@@ -1,3 +1,5 @@
+#![feature(proc_macro_hygiene)]
+#[macro_use] extern crate rocket;
 
 // TODO Test with an allow-any origin
 // TODO Test with two origins
@@ -14,5 +16,31 @@ mod cors_tests {
     #[test]
     pub fn test_basic() {
         let _ = CorsFairingBuilder::new();
+    }
+
+    #[get("/test")]
+    pub fn test_get_route() -> &'static str {
+        "Hi"
+    }
+
+    #[test]
+    pub fn test_one_method() {
+        let rocket = rocket::ignite()
+            .mount("/", routes![test_get_route])
+            .attach(CorsFairingBuilder::new()
+                .build());
+
+        let mut count = 0;
+        for _ in rocket.routes() {
+            count = count + 1;
+        }
+        assert_eq!(2, count);
+
+    }
+
+    // Test to ensure the method names are collected when multiple
+    #[test]
+    pub fn test_many_method() {
+
     }
 }

--- a/contrib/lib/tests/cors.rs
+++ b/contrib/lib/tests/cors.rs
@@ -1,14 +1,6 @@
 #![feature(proc_macro_hygiene)]
 #[macro_use] extern crate rocket;
 
-// TODO Test with an allow-any origin
-// TODO Test with two origins
-// TODO Test with one origin
-// TODO Test a variety of methods (delete, put, post)
-// TODO Test with headers
-// TODO Test with no headers
-// TODO Test with multiple headers
-// note, I think all of these can be integration tests
 #[cfg(feature = "cors")]
 mod cors_tests {
     use rocket_contrib::cors::*;
@@ -25,27 +17,15 @@ mod cors_tests {
         "Hi"
     }
 
-    // TODO name after Cross Origin.  Example CrossOrigin
-    
-    // Include on all responses 
-    //   Access-Control-Allow-Credentials
-    //   Access-Control-Allow-Origin
-    // Requested on preflight
-    //   `Access-Control-Request-Method` 
-    //   `Access-Control-Request-Headers` 
-    // Include on preflight
-    //   Access-Control-Allow-Methods` 
-    //   `Access-Control-Allow-Headers` 
-    //   `Access-Control-Max-Age` 
-    //   `Access-Control-Expose-Headers` 
+
 
     #[test]
     pub fn test_one_method() {
         let rocket = rocket::ignite()
             .mount("/", routes![sample_delete_route])
-            .attach(CorsFairingBuilder::new()
+            .attach(CorsFairingConfig::new()
                 .any_origin()
-                .build().unwrap());
+                .fairing());
 
         let client = Client::new(rocket).expect("valid rocket instance");
 
@@ -59,9 +39,9 @@ mod cors_tests {
     pub fn test_many_method() {
         let rocket = rocket::ignite()
             .mount("/", routes![sample_get_route, sample_delete_route])
-            .attach(CorsFairingBuilder::new()
+            .attach(CorsFairingConfig::new()
                 .any_origin()
-                .build().unwrap());
+                .fairing());
 
         let client = Client::new(rocket).expect("valid rocket instance");
 
@@ -70,24 +50,14 @@ mod cors_tests {
         assert_eq!(response.headers().get_one("Access-Control-Allow-Methods"), Some("DELETE, GET".into()));
     }
 
-    // Ensure that the proper error is reported if the programmes does not select any origin.
-    #[test]
-    pub fn test_no_origin_error() {
-        let err = CorsFairingBuilder::new()
-            .build()
-            .expect_err("expected error");
-
-        assert_eq!(CorsFairingError::NoOrigin, err);
-    }
-
     /// Test that the any origin works correctly.
     #[test]
     pub fn test_any_origin() {
         let rocket = rocket::ignite()
             .mount("/", routes![sample_delete_route])
-            .attach(CorsFairingBuilder::new()
+            .attach(CorsFairingConfig::new()
                 .any_origin()
-                .build().unwrap());
+                .fairing());
 
         let client = Client::new(rocket).expect("valid rocket instance");
 
@@ -100,10 +70,9 @@ mod cors_tests {
     pub fn test_explicit_origin() {
         let rocket = rocket::ignite()
             .mount("/", routes![sample_delete_route])
-            .attach(CorsFairingBuilder::new()
+            .attach(CorsFairingConfig::new()
                 .explicit_origin("https://example.com/")
-                .build()
-                .unwrap());
+                .fairing());
 
         let client = Client::new(rocket).expect("valid rocket instance");
 

--- a/contrib/lib/tests/cors.rs
+++ b/contrib/lib/tests/cors.rs
@@ -11,8 +11,6 @@
 // note, I think all of these can be integration tests
 #[cfg(feature = "cors")]
 mod cors_tests {
-    use rocket::http::Method;
-    use rocket::Route;
     use rocket_contrib::cors::*;
     use rocket::local::*;
     use rocket::http::Status;
@@ -40,32 +38,32 @@ mod cors_tests {
     //   `Access-Control-Allow-Headers` 
     //   `Access-Control-Max-Age` 
     //   `Access-Control-Expose-Headers` 
-    
 
     #[test]
     pub fn test_one_method() {
         let rocket = rocket::ignite()
-            .mount("/", routes![sample_get_route, sample_delete_route])
+            .mount("/", routes![sample_delete_route])
             .attach(CorsFairingBuilder::new()
                 .build());
 
-        let routes : Vec<&Route> = rocket.routes()
-            .filter(|x| x.method == Method::Options)
-            .filter(|x| x.uri.path() == "/test")
-            .collect();
-        assert_eq!(1, routes.len());
-
         let client = Client::new(rocket).expect("valid rocket instance");
-
-        // Dispatch a request to 'GET /' and validate the response.
         let response = client.options("/test").dispatch();
         assert_eq!(response.status(), Status::Ok);
-        assert_eq!(response.headers().get_one("Access-Control-Allow-Methods"), Some("DELETE, GET".into()));
+        assert_eq!(response.headers().get_one("Access-Control-Allow-Methods"), Some("DELETE".into()));
     }
 
     // Test to ensure the method names are collected when multiple
     #[test]
     pub fn test_many_method() {
+        let rocket = rocket::ignite()
+            .mount("/", routes![sample_get_route, sample_delete_route])
+            .attach(CorsFairingBuilder::new()
+                .build());
 
+        let client = Client::new(rocket).expect("valid rocket instance");
+
+        let response = client.options("/test").dispatch();
+        assert_eq!(response.status(), Status::Ok);
+        assert_eq!(response.headers().get_one("Access-Control-Allow-Methods"), Some("DELETE, GET".into()));
     }
 }

--- a/contrib/lib/tests/cors.rs
+++ b/contrib/lib/tests/cors.rs
@@ -3,7 +3,8 @@
 
 #[cfg(feature = "cors")]
 mod cors_tests {
-    use rocket_contrib::cors::*;
+    use rocket_contrib::cors::CorsFairing;
+    use rocket_contrib::cors::config::*;
     use rocket::local::*;
     use rocket::http::Status;
 
@@ -23,9 +24,7 @@ mod cors_tests {
     pub fn test_one_method() {
         let rocket = rocket::ignite()
             .mount("/", routes![sample_delete_route])
-            .attach(CorsFairingConfig::new()
-                .any_origin()
-                .fairing());
+            .attach(CorsFairing::with_config(CorsFairingConfig::with_any_origin()));
 
         let client = Client::new(rocket).expect("valid rocket instance");
 
@@ -39,9 +38,8 @@ mod cors_tests {
     pub fn test_many_method() {
         let rocket = rocket::ignite()
             .mount("/", routes![sample_get_route, sample_delete_route])
-            .attach(CorsFairingConfig::new()
-                .any_origin()
-                .fairing());
+            .attach(CorsFairing::with_config(CorsFairingConfig::with_any_origin()));
+
 
         let client = Client::new(rocket).expect("valid rocket instance");
 
@@ -55,9 +53,8 @@ mod cors_tests {
     pub fn test_any_origin() {
         let rocket = rocket::ignite()
             .mount("/", routes![sample_delete_route])
-            .attach(CorsFairingConfig::new()
-                .any_origin()
-                .fairing());
+            .attach(CorsFairing::with_config(CorsFairingConfig::with_any_origin()));
+
 
         let client = Client::new(rocket).expect("valid rocket instance");
 
@@ -70,9 +67,8 @@ mod cors_tests {
     pub fn test_explicit_origin() {
         let rocket = rocket::ignite()
             .mount("/", routes![sample_delete_route])
-            .attach(CorsFairingConfig::new()
-                .explicit_origin("https://example.com/")
-                .fairing());
+            .attach(CorsFairing::with_config(CorsFairingConfig::with_origin("https://example.com/".to_owned())));
+
 
         let client = Client::new(rocket).expect("valid rocket instance");
 

--- a/examples/cors/Cargo.toml
+++ b/examples/cors/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "cors"
+version = "0.0.0"
+workspace = "../../"
+edition = "2018"
+publish = false
+
+[dependencies]
+rocket = { path = "../../core/lib" }
+
+[dependencies.rocket_contrib]
+path = "../../contrib/lib"
+default-features = false
+features = ["cors"]

--- a/examples/cors/Rocket.toml
+++ b/examples/cors/Rocket.toml
@@ -1,0 +1,6 @@
+[development]
+address = "examplea"
+port = 8000
+keep_alive = 5
+log = "normal"
+limits = { forms = 32768 }

--- a/examples/cors/Rocket.toml
+++ b/examples/cors/Rocket.toml
@@ -4,3 +4,7 @@ port = 8000
 keep_alive = 5
 log = "normal"
 limits = { forms = 32768 }
+
+[development.cors]
+allow_origin = "https://example.com/"
+allow_headers = ["X-Foo", "X-Bar"]

--- a/examples/cors/src/main.rs
+++ b/examples/cors/src/main.rs
@@ -4,6 +4,8 @@
 
 extern crate rocket_contrib;
 
+use rocket_contrib::cors::CorsFairingBuilder;
+
 #[get("/test")]
 fn get_index() -> &'static str {
     "Hi"
@@ -23,6 +25,8 @@ fn patch_notes(_id: u64, _input: String) -> &'static str {
 fn main() {
     rocket::ignite()
         .mount("/", routes![hello, get_index, patch_notes])
-        .attach(rocket_contrib::cors::CorsFairingBuilder::new().add_header(String::from("content-type")).build())
+        .attach(CorsFairingBuilder::new()
+            .add_header(String::from("content-type"))
+            .build())
         .launch();
 }

--- a/examples/cors/src/main.rs
+++ b/examples/cors/src/main.rs
@@ -1,0 +1,18 @@
+#![feature(proc_macro_hygiene)]
+
+#[macro_use] extern crate rocket;
+
+extern crate rocket_contrib;
+
+#[post("/")]
+fn hello() -> &'static str {
+    "Hello, world!"
+}
+
+
+fn main() {
+    rocket::ignite()
+        .mount("/", routes![hello])
+        .attach(rocket_contrib::cors::CorsFairing::new())
+        .launch();
+}

--- a/examples/cors/src/main.rs
+++ b/examples/cors/src/main.rs
@@ -4,6 +4,11 @@
 
 extern crate rocket_contrib;
 
+#[get("/")]
+fn get_index() -> &'static str {
+    "Hi"
+}
+
 #[post("/")]
 fn hello() -> &'static str {
     "Hello, world!"
@@ -12,7 +17,7 @@ fn hello() -> &'static str {
 
 fn main() {
     rocket::ignite()
-        .mount("/", routes![hello])
+        .mount("/", routes![hello, get_index])
         .attach(rocket_contrib::cors::CorsFairing::new())
         .launch();
 }

--- a/examples/cors/src/main.rs
+++ b/examples/cors/src/main.rs
@@ -26,7 +26,7 @@ fn main() {
     rocket::ignite()
         .mount("/", routes![hello, get_index, patch_notes])
         .attach(CorsFairingBuilder::new()
-            .add_header(String::from("content-type"))
+            .add_header(&"content-type")
             .build())
         .launch();
 }

--- a/examples/cors/src/main.rs
+++ b/examples/cors/src/main.rs
@@ -4,7 +4,7 @@
 
 extern crate rocket_contrib;
 
-#[get("/")]
+#[get("/test")]
 fn get_index() -> &'static str {
     "Hi"
 }

--- a/examples/cors/src/main.rs
+++ b/examples/cors/src/main.rs
@@ -23,6 +23,6 @@ fn patch_notes(_id: u64, _input: String) -> &'static str {
 fn main() {
     rocket::ignite()
         .mount("/", routes![hello, get_index, patch_notes])
-        .attach(rocket_contrib::cors::CorsFairing::new())
+        .attach(rocket_contrib::cors::CorsFairingBuilder::new().add_header(String::from("content-type")).build())
         .launch();
 }

--- a/examples/cors/src/main.rs
+++ b/examples/cors/src/main.rs
@@ -14,10 +14,15 @@ fn hello() -> &'static str {
     "Hello, world!"
 }
 
+#[patch("/notes/<_id>", data="<_input>")]
+fn patch_notes(_id: u64, _input: String) -> &'static str {
+    "Hello, world!"
+}
+
 
 fn main() {
     rocket::ignite()
-        .mount("/", routes![hello, get_index])
+        .mount("/", routes![hello, get_index, patch_notes])
         .attach(rocket_contrib::cors::CorsFairing::new())
         .launch();
 }

--- a/examples/cors/src/main.rs
+++ b/examples/cors/src/main.rs
@@ -4,6 +4,7 @@
 
 extern crate rocket_contrib;
 
+use rocket::Data;
 use rocket_contrib::cors::CorsFairingBuilder;
 
 #[get("/test")]
@@ -17,7 +18,7 @@ fn hello() -> &'static str {
 }
 
 #[patch("/notes/<_id>", data="<_input>")]
-fn patch_notes(_id: u64, _input: String) -> &'static str {
+fn patch_notes(_id: u64, _input: Data) -> &'static str {
     "Hello, world!"
 }
 

--- a/examples/cors/src/main.rs
+++ b/examples/cors/src/main.rs
@@ -5,7 +5,7 @@
 extern crate rocket_contrib;
 
 use rocket::Data;
-use rocket_contrib::cors::CorsFairingBuilder;
+use rocket_contrib::cors::CorsFairing;
 
 #[get("/test")]
 fn get_index() -> &'static str {
@@ -26,9 +26,6 @@ fn patch_notes(_id: u64, _input: Data) -> &'static str {
 fn main() {
     rocket::ignite()
         .mount("/", routes![hello, get_index, patch_notes])
-        .attach(CorsFairingBuilder::new()
-            .add_header(&"content-type")
-            .build()
-            .unwrap())
+        .attach(CorsFairing::new())
         .launch();
 }

--- a/examples/cors/src/main.rs
+++ b/examples/cors/src/main.rs
@@ -28,6 +28,7 @@ fn main() {
         .mount("/", routes![hello, get_index, patch_notes])
         .attach(CorsFairingBuilder::new()
             .add_header(&"content-type")
-            .build())
+            .build()
+            .unwrap())
         .launch();
 }


### PR DESCRIPTION
This commit is a work-in-progress pull request to add basic CORS support as a contrib feature to Rocket.

I was unsure what "basic cors support" would mean to most people.  We already have rocket_cors on crates.io.  I ended up deciding that basic support would allow a single origin and allow that origin on all endpoints.  This is done via a fairing and adding some configuration to Rocket.toml.

Does this approach seem reasonable?  Would you add/remove any functionality?

Otherwise i'm going to clean this up a lot before submitting it again.  Lots of issue with excessive allocation, poor organization and missing tests.