### PR TITLE
Add support for RON format

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,4 +41,5 @@ members = [
   "examples/tls",
   "examples/fairings",
   "examples/hello_2018",
+  "examples/ron",
 ]

--- a/contrib/lib/Cargo.toml
+++ b/contrib/lib/Cargo.toml
@@ -20,6 +20,7 @@ databases = ["r2d2", "tokio/blocking", "tokio/rt-threaded", "rocket_contrib_code
 default = ["json", "serve"]
 json = ["serde", "serde_json", "tokio/io-util"]
 msgpack = ["serde", "rmp-serde", "tokio/io-util"]
+ron = ["serde", "ron_crate"]
 tera_templates = ["tera", "templates"]
 handlebars_templates = ["handlebars", "templates"]
 helmet = ["time"]
@@ -51,6 +52,7 @@ log = "0.4"
 serde = { version = "1.0", optional = true }
 serde_json = { version = "1.0.26", optional = true }
 rmp-serde = { version = "0.14.0", optional = true }
+ron_crate = { version = "0.5.1", optional = true, package = "ron" }
 
 # Templating dependencies.
 handlebars = { version = "2.0", optional = true }

--- a/contrib/lib/Cargo.toml
+++ b/contrib/lib/Cargo.toml
@@ -52,7 +52,7 @@ log = "0.4"
 serde = { version = "1.0", optional = true }
 serde_json = { version = "1.0.26", optional = true }
 rmp-serde = { version = "0.14.0", optional = true }
-ron_crate = { version = "0.5.1", optional = true, package = "ron" }
+ron_crate = { version = "0.6.0", optional = true, package = "ron" }
 
 # Templating dependencies.
 handlebars = { version = "2.0", optional = true }

--- a/contrib/lib/src/lib.rs
+++ b/contrib/lib/src/lib.rs
@@ -44,6 +44,7 @@
 #[allow(unused_imports)] #[macro_use] extern crate rocket;
 
 #[cfg(feature="json")] #[macro_use] pub mod json;
+#[cfg(feature="serde_ron")] pub mod ron;
 #[cfg(feature="serve")] pub mod serve;
 #[cfg(feature="msgpack")] pub mod msgpack;
 #[cfg(feature="templates")] pub mod templates;

--- a/contrib/lib/src/lib.rs
+++ b/contrib/lib/src/lib.rs
@@ -44,7 +44,7 @@
 #[allow(unused_imports)] #[macro_use] extern crate rocket;
 
 #[cfg(feature="json")] #[macro_use] pub mod json;
-#[cfg(feature="serde_ron")] pub mod ron;
+#[cfg(feature="ron")] pub mod ron;
 #[cfg(feature="serve")] pub mod serve;
 #[cfg(feature="msgpack")] pub mod msgpack;
 #[cfg(feature="templates")] pub mod templates;

--- a/contrib/lib/src/ron.rs
+++ b/contrib/lib/src/ron.rs
@@ -95,5 +95,3 @@ impl<T> DerefMut for Ron<T> {
         &mut self.0
     }
 }
-
-

--- a/contrib/lib/src/ron.rs
+++ b/contrib/lib/src/ron.rs
@@ -69,10 +69,10 @@ impl<'a, T: Deserialize<'a>> FromData<'a> for Ron<T> {
 
 impl<'r, T: Serialize> Responder<'r> for Ron<T> {
     fn respond_to(self, req: &'r Request<'_>) -> response::ResultFuture<'r> {
-        match ron::ser::to_string(&self.0) {
+        match ron::ser::to_string_pretty(&self.0, ron::ser::PrettyConfig::default()) {
             Ok(string) => Box::pin(async move { Ok(content::Ron(string).respond_to(req).await.unwrap()) }),
             Err(e) => Box::pin (async move {
-                error_!("JSON failed to serialize: {:?}", e);
+                error_!("RON failed to serialize: {:?}", e);
                 Err(Status::InternalServerError)
             })
         }

--- a/contrib/lib/src/ron.rs
+++ b/contrib/lib/src/ron.rs
@@ -47,7 +47,7 @@ use serde::de::Deserialize;
 /// use rocket_contrib::ron::Ron;
 ///
 /// #[post("/users", data = "<user>")]
-/// fn new_user(user: Json<User>) {
+/// fn new_user(user: Ron<User>) {
 ///     /* ... */
 /// }
 /// ```
@@ -79,7 +79,7 @@ use serde::de::Deserialize;
 /// protects your application from denial of service (DoS) attacks and from
 /// resource exhaustion through high memory consumption. The limit can be
 /// increased by setting the `limits.ron` configuration parameter. For
-/// instance, to increase the JSON limit to 5MiB for all environments, you may
+/// instance, to increase the RON limit to 5MiB for all environments, you may
 /// add the following to your `Rocket.toml`:
 ///
 /// ```toml
@@ -95,7 +95,7 @@ impl<T> Ron<T> {
     /// # Example
     /// ```rust
     /// # use rocket_contrib::ron::Ron;
-    /// let sring = "Hello".to_string();
+    /// let string = "Hello".to_string();
     /// let my_ron = Ron(string);
     /// assert_eq!(my_ron.into_inner(), "Hello".to_string());
     /// ```

--- a/contrib/lib/src/ron.rs
+++ b/contrib/lib/src/ron.rs
@@ -1,0 +1,99 @@
+use std::ops::{Deref, DerefMut};
+use std::io;
+use std::iter::FromIterator;
+
+use tokio_io::AsyncReadExt;
+
+use rocket::request::Request;
+use rocket::outcome::Outcome::*;
+use rocket::data::{Transform::*, Transformed, Data, FromData, TransformFuture, FromDataFuture};
+use rocket::response::{self, Responder, content};
+use rocket::http::Status;
+
+use serde::{Serialize, Serializer};
+use serde::de::{Deserialize, Deserializer};
+
+
+#[derive(Debug)]
+pub struct Ron<T>(pub T);
+
+impl<T> Ron<T> {
+    #[inline(always)]
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+}
+
+
+/// Default limit for RON is 1MB.
+const LIMIT: u64 = 1 << 20;
+
+#[derive(Debug)]
+pub enum RonError<'a> {
+    Io(io::Error),
+
+    Parse(&'a str, ron::de::Error),
+}
+
+impl<'a, T: Deserialize<'a>> FromData<'a> for Ron<T> {
+    type Error = RonError<'a>;
+    type Owned = String;
+    type Borrowed= str;
+ 
+    fn transform(r: &Request<'_>, d: Data) -> TransformFuture<'a, Self::Owned, Self::Error> {
+        let size_limit = r.limits().get("ron").unwrap_or(LIMIT);
+        Box::pin(async move {
+            let mut s = String::with_capacity(512);
+            let mut reader = d.open().take(size_limit);
+            match reader.read_to_string(&mut s).await {
+                Ok(_) => Borrowed(Success(s)),
+                Err(e) => Borrowed(Failure((Status::BadRequest, RonError::Io(e))))
+            }
+        })
+    }
+
+    fn from_data(_: &Request<'_>, o: Transformed<'a, Self>) -> FromDataFuture<'a, Self, Self::Error> {
+        Box::pin(async move {
+            let string = try_outcome!(o.borrowed());
+            match ron::de::from_str(&string) {
+                Ok(v) => Success(Ron(v)),
+                Err(e) => {
+                    error_!("Couldn't parse RON body: {:?}", e);
+                    Failure((Status::BadRequest, RonError::Parse(string, e)))
+                }
+            }
+        })
+    }
+}
+
+
+impl<'r, T: Serialize> Responder<'r> for Ron<T> {
+    fn respond_to(self, req: &'r Request<'_>) -> response::ResultFuture<'r> {
+        match ron::ser::to_string(&self.0) {
+            Ok(string) => Box::pin(async move { Ok(content::Ron(string).respond_to(req).await.unwrap()) }),
+            Err(e) => Box::pin (async move {
+                error_!("JSON failed to serialize: {:?}", e);
+                Err(Status::InternalServerError)
+            })
+        }
+    }
+}
+
+
+impl<T> Deref for Ron<T> {
+    type Target = T;
+
+    #[inline(always)]
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}
+
+impl<T> DerefMut for Ron<T> {
+    #[inline(always)]
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.0
+    }
+}
+
+

--- a/examples/ron/Cargo.toml
+++ b/examples/ron/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "ron"
+version = "0.0.0"
+workspace = "../../"
+edition = "2018"
+publish = false
+
+[dependencies]
+rocket = { path = "../../core/lib" }
+serde = "1.0"
+ron = "0.5.1"
+serde_derive = "1.0"
+
+[dependencies.rocket_contrib]
+path = "../../contrib/lib"
+default-features = false
+features = ["ron"]

--- a/examples/ron/Cargo.toml
+++ b/examples/ron/Cargo.toml
@@ -8,7 +8,6 @@ publish = false
 [dependencies]
 rocket = { path = "../../core/lib" }
 serde = "1.0"
-ron = "0.5.1"
 serde_derive = "1.0"
 
 [dependencies.rocket_contrib]

--- a/examples/ron/src/main.rs
+++ b/examples/ron/src/main.rs
@@ -1,0 +1,83 @@
+#![feature(proc_macro_hygiene)]
+
+#[macro_use] extern crate rocket;
+#[macro_use] extern crate serde_derive;
+
+#[cfg(test)] mod tests;
+
+use std::sync::Mutex;
+use std::collections::HashMap;
+
+use rocket::State;
+use rocket_contrib::ron::{Ron};
+
+// The type to represent the ID of a message.
+type ID = usize;
+
+// We're going to store all of the messages here. No need for a DB.
+type MessageMap = Mutex<HashMap<ID, String>>;
+
+#[derive(Serialize, Deserialize)]
+struct Message {
+    id: Option<ID>,
+    contents: String
+}
+
+#[derive(Serialize, Deserialize)]
+struct ErrorMessage {
+    status: String,
+    reason: Option<String>
+}
+
+// TODO: This example can be improved by using `route` with multiple HTTP verbs.
+#[post("/<id>", data = "<message>")]
+fn new(id: ID, message: Ron<Message>, map: State<'_, MessageMap>) -> Ron<ErrorMessage> {
+    let mut hashmap = map.lock().expect("map lock.");
+    if hashmap.contains_key(&id) {
+       Ron(ErrorMessage{status: "error".to_owned(), reason: Some("ID exists. Try put.".to_owned())})
+    } else {
+        hashmap.insert(id, message.0.contents);
+        Ron(ErrorMessage{status: "ok".to_owned(), reason: None})
+    }
+}
+
+#[put("/<id>", data = "<message>")]
+fn update(id: ID, message: Ron<Message>, map: State<'_, MessageMap>) -> Option<Ron<ErrorMessage>> {
+    let mut hashmap = map.lock().unwrap();
+    if hashmap.contains_key(&id) {
+        hashmap.insert(id, message.0.contents);
+        Some(Ron(ErrorMessage{status: "ok".to_owned(), reason: None}))
+    } else {
+        None
+    }
+}
+
+#[get("/<id>")]
+fn get(id: ID, map: State<'_, MessageMap>) -> Option<Ron<Message>> {
+    let hashmap = map.lock().unwrap();
+    hashmap.get(&id).map(|contents| {
+        Ron(Message {
+            id: Some(id),
+            contents: contents.clone()
+        })
+    })
+}
+
+#[catch(404)]
+fn not_found() -> Ron<ErrorMessage> {
+    Ron(ErrorMessage {
+        status: "error".to_owned(),
+        reason: Some("Resource was not found.".to_owned())
+    })
+}
+
+fn rocket() -> rocket::Rocket {
+    rocket::ignite()
+        .mount("/message", routes![new, update, get])
+        .register(catchers![not_found])
+        .manage(Mutex::new(HashMap::<ID, String>::new()))
+}
+
+fn main() {
+    let _ = rocket().launch();
+}

--- a/examples/ron/src/main.rs
+++ b/examples/ron/src/main.rs
@@ -23,30 +23,30 @@ struct Message {
     contents: String
 }
 
-#[derive(Serialize, Deserialize)]
-struct ErrorMessage {
-    status: String,
-    reason: Option<String>
+#[derive(Serialize)]
+struct StatusMessage {
+    status: &'static str,
+    reason: Option<&'static str>
 }
 
 // TODO: This example can be improved by using `route` with multiple HTTP verbs.
 #[post("/<id>", data = "<message>")]
-fn new(id: ID, message: Ron<Message>, map: State<'_, MessageMap>) -> Ron<ErrorMessage> {
+fn new(id: ID, message: Ron<Message>, map: State<'_, MessageMap>) -> Ron<StatusMessage> {
     let mut hashmap = map.lock().expect("map lock.");
     if hashmap.contains_key(&id) {
-       Ron(ErrorMessage{status: "error".to_owned(), reason: Some("ID exists. Try put.".to_owned())})
+       Ron(StatusMessage{status: "error", reason: Some("ID exists. Try put.")})
     } else {
         hashmap.insert(id, message.0.contents);
-        Ron(ErrorMessage{status: "ok".to_owned(), reason: None})
+        Ron(StatusMessage{status: "ok", reason: None})
     }
 }
 
 #[put("/<id>", data = "<message>")]
-fn update(id: ID, message: Ron<Message>, map: State<'_, MessageMap>) -> Option<Ron<ErrorMessage>> {
+fn update(id: ID, message: Ron<Message>, map: State<'_, MessageMap>) -> Option<Ron<StatusMessage>> {
     let mut hashmap = map.lock().unwrap();
     if hashmap.contains_key(&id) {
         hashmap.insert(id, message.0.contents);
-        Some(Ron(ErrorMessage{status: "ok".to_owned(), reason: None}))
+        Some(Ron(StatusMessage{status: "ok", reason: None}))
     } else {
         None
     }
@@ -64,10 +64,10 @@ fn get(id: ID, map: State<'_, MessageMap>) -> Option<Ron<Message>> {
 }
 
 #[catch(404)]
-fn not_found() -> Ron<ErrorMessage> {
-    Ron(ErrorMessage {
-        status: "error".to_owned(),
-        reason: Some("Resource was not found.".to_owned())
+fn not_found() -> Ron<StatusMessage> {
+    Ron(StatusMessage {
+        status: "error",
+        reason: Some("Resource was not found.")
     })
 }
 

--- a/examples/ron/src/tests.rs
+++ b/examples/ron/src/tests.rs
@@ -1,0 +1,70 @@
+use crate::rocket;
+use rocket::local::Client;
+use rocket::http::{Status, ContentType};
+
+#[rocket::async_test]
+async fn bad_get_put() {
+    let client = Client::new(rocket()).await.unwrap();
+
+    // Try to get a message with an ID that doesn't exist.
+    let mut res = client.get("/message/99").dispatch().await;
+    assert_eq!(res.status(), Status::NotFound);
+
+    let body = res.body_string().await.unwrap();
+    assert!(body.contains("error"));
+    assert!(body.contains("Resource was not found."));
+
+    // Try to get a message with an invalid ID.
+    let mut res = client.get("/message/hi").dispatch().await;
+    let body = res.body_string().await.unwrap();
+    assert_eq!(res.status(), Status::NotFound);
+    assert!(body.contains("error"));
+
+    // Try to put a message without a proper body.
+    let res = client.put("/message/80").dispatch().await;
+    assert_eq!(res.status(), Status::BadRequest);
+
+    // Try to put a message for an ID that doesn't exist.
+    let res = client.put("/message/80")
+        .body(r#"Message( contents: "Bye bye, world!" )"#)
+        .dispatch().await;
+
+    assert_eq!(res.status(), Status::NotFound);
+}
+
+#[rocket::async_test]
+async fn post_get_put_get() {
+    let client = Client::new(rocket()).await.unwrap();
+
+    // Check that a message with ID 1 doesn't exist.
+    let res = client.get("/message/1").dispatch().await;
+    assert_eq!(res.status(), Status::NotFound);
+
+    // Add a new message with ID 1.
+    let res = client.post("/message/1")
+        .body(r#"Message( contents: "Hello, world!" )"#)
+        .dispatch().await;
+
+    assert_eq!(res.status(), Status::Ok);
+
+    // Check that the message exists with the correct contents.
+    let mut res = client.get("/message/1").dispatch().await;
+    assert_eq!(res.status(), Status::Ok);
+    let body = res.body_string().await.unwrap();
+    assert!(body.contains("Hello, world!"));
+
+    // Change the message contents.
+    let res = client.put("/message/1")
+        .header(ContentType::JSON)
+        .body(r#"Message( contents: "Bye bye, world!" )"#)
+        .dispatch().await;
+
+    assert_eq!(res.status(), Status::Ok);
+
+    // Check that the message exists with the updated contents.
+    let mut res = client.get("/message/1").dispatch().await;
+    assert_eq!(res.status(), Status::Ok);
+    let body = res.body_string().await.unwrap();
+    assert!(!body.contains("Hello, world!"));
+    assert!(body.contains("Bye bye, world!"));
+}


### PR DESCRIPTION
This PR adds support for [RON](https://github.com/ron-rs/ron) as an alternative to JSON. I plan to add comments to the code asap, but wanted to have the code already here so if there's something that needs to be changed I don't have to write comments twice (especially because they wouldn't differ from the comments for JSON, except for the format itself). 

The whole code is very strictly oriented at the already existing JSON code, I tested its functionality in a hobby project (which is not yet released, if ever), but didn't write any tests, as I was not able to find any JSON specific tests either.