### PR TITLE
Add initial local_cache_async implementation

### DIFF
--- a/core/lib/src/request/request.rs
+++ b/core/lib/src/request/request.rs
@@ -569,7 +569,23 @@ impl<'r> Request<'r> {
     /// state of `self`. If no such value has previously been cached for this
     /// request, `fut` is `await`ed to produce the value which is subsequently
     /// returned.
-    pub async fn local_cache_async<T, F>(&self, fut: F) -> &T
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use rocket::http::Method;
+    /// # use rocket::Request;
+    /// # type User = ();
+    /// async fn current_user<'r>(request: &Request<'r>) -> User {
+    ///     // Validate request for a given user, load from database, etc.
+    /// }
+    ///
+    /// # Request::example(Method::Get, "/uri", |request| rocket::async_test(async {
+    /// let user = request.local_cache_async(async {
+    ///     current_user(request).await
+    /// }).await;
+    /// # }));
+    pub async fn local_cache_async<'a, T, F>(&'a self, fut: F) -> &'a T
         where F: Future<Output = T>,
               T: Send + Sync + 'static
     {

--- a/examples/request_local_state/src/tests.rs
+++ b/examples/request_local_state/src/tests.rs
@@ -6,9 +6,15 @@ use rocket::local::Client;
 #[rocket::async_test]
 async fn test() {
     let client = Client::new(rocket()).unwrap();
-    client.get("/").dispatch().await;
+    client.get("/sync").dispatch().await;
 
     let atomics = client.rocket().state::<Atomics>().unwrap();
     assert_eq!(atomics.uncached.load(Ordering::Relaxed), 2);
     assert_eq!(atomics.cached.load(Ordering::Relaxed), 1);
+
+    client.get("/async").dispatch().await;
+
+    let atomics = client.rocket().state::<Atomics>().unwrap();
+    assert_eq!(atomics.uncached.load(Ordering::Relaxed), 4);
+    assert_eq!(atomics.cached.load(Ordering::Relaxed), 2);
 }


### PR DESCRIPTION
Hello!

This is just an initial working implementation as of now; two things need to be decided still:
1. How would I go about adding doc tests to this? Should there be an async `Request::example` as well? Since the Future returned by `local_cache_async` also has to be awaited, we have to show that in the usage example.
2. Should we keep the sync variant of local_cache or go for async only?
  My take here is that I would keep both, because while passing an async block which executes synchronously is easy, you have to then call `executor::block_on` to get a value from it, adding complexity to sync FromRequest impls.