### PR TITLE
Updated catch_type_error Test Expectations

### DIFF
--- a/core/codegen/tests/ui-fail/catch_type_errors.rs
+++ b/core/codegen/tests/ui-fail/catch_type_errors.rs
@@ -15,8 +15,9 @@ fn f2(_request: &Request) -> bool {
 }
 
 #[catch(404)]
+//~^ ERROR mismatched types
 fn f3(_request: bool) -> usize {
-    //~^ ERROR mismatched types
+    //~^ ERROR usize: rocket::response::Responder
     10
 }
 

--- a/core/codegen/tests/ui-fail/catch_type_errors.stderr
+++ b/core/codegen/tests/ui-fail/catch_type_errors.stderr
@@ -18,10 +18,7 @@ error[E0308]: mismatched types
   --> $DIR/catch_type_errors.rs:17:1
    |
 17 | #[catch(404)]
-   | ^^^^^^^^^^^^^ expected bool, found reference
-   |
-   = note: expected type `bool`
-              found type `&'_b rocket::Request<'_>`
+   | ^^^^^^^^^^^^^ expected `bool`, found `&rocket::Request<'_>`
 
 error[E0277]: the trait bound `usize: rocket::response::Responder<'_>` is not satisfied
   --> $DIR/catch_type_errors.rs:18:26


### PR DESCRIPTION
Tests are failing on the async branch. This is the first step to fixing the failures.

It seems the errors from the rust compiler changed in a recent version, but the expectations for errors weren't updated. This PR updates the expectations.

This leaves two tests failing. It seems that sometimes environment specific file paths get used in the comparison of compiler errors causing it to always fail for a couple of tests:
* https://github.com/SergioBenitez/Rocket/blob/188b8d352863af5bd0e00f21c11fc5090e2abd01/core/codegen/tests/ui-fail/responder-types.stderr#L7

* https://github.com/SergioBenitez/Rocket/blob/188b8d352863af5bd0e00f21c11fc5090e2abd01/core/codegen/tests/ui-fail/typed-uri-bad-type.stderr#L114

* https://github.com/SergioBenitez/Rocket/blob/188b8d352863af5bd0e00f21c11fc5090e2abd01/core/codegen/tests/ui-fail/typed-uri-bad-type.stderr#L128

This is likely caused by an upstream bug in compiletest (the crate). They may be already fixed upstream (in the rust project) and could be fixed fixed when this lands (in the crate): https://github.com/laumann/compiletest-rs/pull/201