### PR TITLE
Add support for rusqlite bundled via sqlite_bundled

### DIFF
--- a/contrib/lib/Cargo.toml
+++ b/contrib/lib/Cargo.toml
@@ -35,6 +35,7 @@ diesel_mysql_pool = ["databases", "diesel/mysql", "diesel/r2d2"]
 postgres_pool = ["databases", "postgres", "r2d2_postgres"]
 mysql_pool = ["databases", "mysql", "r2d2_mysql"]
 sqlite_pool = ["databases", "rusqlite", "r2d2_sqlite"]
+sqlite_bundled_pool = ["databases", "rusqlite", "rusqlite/bundled", "r2d2_sqlite"]
 cypher_pool = ["databases", "rusted_cypher", "r2d2_cypher"]
 redis_pool = ["databases", "redis", "r2d2_redis"]
 mongodb_pool = ["databases", "mongodb", "r2d2-mongodb"]
@@ -66,8 +67,8 @@ r2d2 = { version = "0.8", optional = true }
 r2d2_postgres = { version = "0.14", optional = true }
 mysql = { version = "16.0", optional = true }
 r2d2_mysql = { version = "16.0", optional = true }
-rusqlite = { version = "0.16.0", optional = true }
-r2d2_sqlite = { version = "0.8", optional = true }
+rusqlite = { version = "0.20.0", optional = true }
+r2d2_sqlite = { version = "0.12.0", optional = true }
 rusted_cypher = { version = "1", optional = true }
 r2d2_cypher = { version = "0.4", optional = true }
 redis = { version = "0.10", optional = true }

--- a/contrib/lib/src/databases.rs
+++ b/contrib/lib/src/databases.rs
@@ -353,7 +353,8 @@
 //! | Postgres | [Diesel]              | `1`       | [`diesel::PgConnection`]       | `diesel_postgres_pool` |
 //! | Postgres | [Rust-Postgres]       | `0.15`    | [`postgres::Connection`]       | `postgres_pool`        |
 //! | Sqlite   | [Diesel]              | `1`       | [`diesel::SqliteConnection`]   | `diesel_sqlite_pool`   |
-//! | Sqlite   | [`Rustqlite`]         | `0.16`    | [`rusqlite::Connection`]       | `sqlite_pool`          |
+//! | Sqlite   | [`Rustqlite`]         | `0.20`    | [`rusqlite::Connection`]       | `sqlite_pool`          |
+//! | Sqlite   | [`Rustqlite`]         | `0.20`    | [`rusqlite::Connection`]       | `sqlite_bundled_pool`  |
 //! | Neo4j    | [`rusted_cypher`]     | `1`       | [`rusted_cypher::GraphClient`] | `cypher_pool`          |
 //! | Redis    | [`redis-rs`]          | `0.10`    | [`redis::Connection`]          | `redis_pool`           |
 //! | MongoDB  | [`mongodb`]           | `0.3.12`  | [`mongodb::db::Database`]      | `mongodb_pool`         |

--- a/examples/raw_sqlite/Cargo.toml
+++ b/examples/raw_sqlite/Cargo.toml
@@ -7,4 +7,4 @@ publish = false
 
 [dependencies]
 rocket = { path = "../../core/lib" }
-rusqlite = "0.16"
+rusqlite = "0.20"

--- a/site/guide/6-state.md
+++ b/site/guide/6-state.md
@@ -185,7 +185,8 @@ Presently, Rocket provides built-in support for the following databases:
 | Postgres | [Diesel]              | `1`       | [`diesel::PgConnection`]       | `diesel_postgres_pool` |
 | Postgres | [Rust-Postgres]       | `0.15`    | [`postgres::Connection`]       | `postgres_pool`        |
 | Sqlite   | [Diesel]              | `1`       | [`diesel::SqliteConnection`]   | `diesel_sqlite_pool`   |
-| Sqlite   | [`Rustqlite`]         | `0.16`    | [`rusqlite::Connection`]       | `sqlite_pool`          |
+| Sqlite   | [`Rustqlite`]         | `0.20`    | [`rusqlite::Connection`]       | `sqlite_pool`          |
+| Sqlite   | [`Rustqlite`]         | `0.20`    | [`rusqlite::Connection`]       | `sqlite_bundled_pool`  |
 | Neo4j    | [`rusted_cypher`]     | `1`       | [`rusted_cypher::GraphClient`] | `cypher_pool`          |
 | Redis    | [`redis-rs`]          | `0.10`    | [`redis::Connection`]          | `redis_pool`           |
 | MongoDB  | [`mongodb`]           | `0.3.12`  | [`mongodb::db::Database`]      | `mongodb_pool`         |


### PR DESCRIPTION
[Rusqlite](https://github.com/jgallagher/rusqlite/releases) provides `bundled` feature to use bundles SQLite source, instead of requiring user to install SQLite development library.
It is very convenient (especially for Windows users) to use it.

Unfortunately Cargo does not support enabling features for transitive dependencies, therefore bundled option should be re-exported from `rocket_contrib`.