### PR TITLE
Update to Tokio 0.2 Hyper 0.13

### DIFF
--- a/contrib/codegen/src/database.rs
+++ b/contrib/codegen/src/database.rs
@@ -73,7 +73,7 @@ pub fn database_attr(attr: TokenStream, input: TokenStream) -> Result<TokenStrea
     let databases = quote_spanned!(span => ::rocket_contrib::databases);
     let Poolable = quote_spanned!(span => #databases::Poolable);
     let r2d2 = quote_spanned!(span => #databases::r2d2);
-    let tokio_executor = quote_spanned!(span => #databases::tokio_executor);
+    let tokio = quote_spanned!(span => #databases::tokio);
     let request = quote!(::rocket::request);
 
     let generated_types = quote_spanned! { span =>
@@ -149,12 +149,12 @@ pub fn database_attr(attr: TokenStream, input: TokenStream) -> Result<TokenStrea
                 Box::pin(async move {
                     let pool = ::rocket::try_outcome!(request.guard::<::rocket::State<'_, #pool_type>>()).0.clone();
 
-                    #tokio_executor::blocking::run(move || {
+                    #tokio::task::spawn_blocking(move || {
                         match pool.get() {
                             Ok(conn) => Outcome::Success(#guard_type(conn)),
                             Err(_) => Outcome::Failure((Status::ServiceUnavailable, ())),
                         }
-                    }).await
+                    }).await.unwrap_or(Outcome::Failure((Status::ServiceUnavailable, ())))
                 })
             }
         }

--- a/contrib/lib/Cargo.toml
+++ b/contrib/lib/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 [features]
 # Internal use only.
 templates = ["serde", "serde_json", "glob"]
-databases = ["r2d2", "tokio-executor", "rocket_contrib_codegen/database_attribute"]
+databases = ["r2d2", "tokio/blocking", "rocket_contrib_codegen/database_attribute"]
 
 # User-facing features.
 default = ["json", "serve"]
@@ -65,7 +65,6 @@ uuid = { version = "0.7", optional = true }
 diesel = { version = "1.0", default-features = false, optional = true }
 postgres = { version = "0.15", optional = true }
 r2d2 = { version = "0.8", optional = true }
-tokio-executor = { version = "0.2.0-alpha.6", optional = true }
 r2d2_postgres = { version = "0.14", optional = true }
 mysql = { version = "16.0", optional = true }
 r2d2_mysql = { version = "16.0", optional = true }

--- a/contrib/lib/Cargo.toml
+++ b/contrib/lib/Cargo.toml
@@ -42,8 +42,8 @@ memcache_pool = ["databases", "memcache", "r2d2-memcache"]
 
 [dependencies]
 # Global dependencies.
-futures-util-preview = "0.3.0-alpha.19"
-tokio-io = "=0.2.0-alpha.6"
+futures-util = "0.3"
+tokio = "0.2"
 rocket_contrib_codegen = { version = "0.5.0-dev", path = "../codegen", optional = true }
 rocket = { version = "0.5.0-dev", path = "../../core/lib/", default-features = false }
 log = "0.4"
@@ -91,7 +91,7 @@ flate2 = { version = "1.0", optional = true }
 notify = { version = "^4.0.6" }
 
 [dev-dependencies]
-tokio-timer = "=0.3.0-alpha.6"
+tokio = { version = "0.2", features = ["time"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/contrib/lib/src/databases.rs
+++ b/contrib/lib/src/databases.rs
@@ -399,7 +399,7 @@
 pub extern crate r2d2;
 
 #[doc(hidden)]
-pub extern crate tokio_executor;
+pub extern crate tokio;
 
 #[cfg(any(feature = "diesel_sqlite_pool",
           feature = "diesel_postgres_pool",

--- a/contrib/lib/src/json.rs
+++ b/contrib/lib/src/json.rs
@@ -18,7 +18,7 @@ use std::ops::{Deref, DerefMut};
 use std::io;
 use std::iter::FromIterator;
 
-use tokio_io::AsyncReadExt;
+use tokio::io::AsyncReadExt;
 
 use rocket::request::Request;
 use rocket::outcome::Outcome::*;

--- a/contrib/lib/src/msgpack.rs
+++ b/contrib/lib/src/msgpack.rs
@@ -16,7 +16,7 @@
 
 use std::ops::{Deref, DerefMut};
 
-use tokio_io::AsyncReadExt;
+use tokio::io::AsyncReadExt;
 
 use rocket::request::Request;
 use rocket::outcome::Outcome::*;

--- a/contrib/lib/tests/templates.rs
+++ b/contrib/lib/tests/templates.rs
@@ -169,7 +169,7 @@ mod templates_tests {
                 }
 
                 // otherwise, retry a few times, waiting 250ms in between
-                tokio_timer::delay_for(Duration::from_millis(250)).await;
+                tokio::time::delay_for(Duration::from_millis(250)).await;
             }
 
             panic!("failed to reload modified template in 1.5s");

--- a/core/codegen/Cargo.toml
+++ b/core/codegen/Cargo.toml
@@ -27,6 +27,5 @@ version_check = "0.9.1"
 
 [dev-dependencies]
 rocket = { version = "0.5.0-dev", path = "../lib" }
-futures-preview = "0.3.0-alpha.19"
-tokio-io = "0.2.0-alpha.6"
+tokio = "0.2"
 compiletest_rs = { version = "0.3", features = ["stable"] }

--- a/core/codegen/tests/route-data.rs
+++ b/core/codegen/tests/route-data.rs
@@ -22,7 +22,7 @@ impl FromDataSimple for Simple {
 
     fn from_data(_: &Request<'_>, data: Data) -> data::FromDataFuture<'static, Self, ()> {
         Box::pin(async {
-            use tokio_io::AsyncReadExt;
+            use tokio::io::AsyncReadExt;
 
             let mut string = String::new();
             let mut stream = data.open().take(64);

--- a/core/codegen/tests/route.rs
+++ b/core/codegen/tests/route.rs
@@ -30,7 +30,7 @@ impl FromDataSimple for Simple {
 
     fn from_data(_: &Request<'_>, data: Data) -> data::FromDataFuture<'static, Self, ()> {
         Box::pin(async move {
-            use tokio_io::AsyncReadExt;
+            use tokio::io::AsyncReadExt;
 
             let mut string = String::new();
             let mut stream = data.open().take(64);

--- a/core/http/Cargo.toml
+++ b/core/http/Cargo.toml
@@ -23,16 +23,14 @@ private-cookies = ["cookie/secure"]
 smallvec = "0.6"
 percent-encoding = "1"
 # TODO.async: stop using stream-unstable
-hyper = { version = "=0.13.0-alpha.4", default-features = false, features = ["unstable-stream"] }
-http = "0.1.17"
+hyper = { version = "0.13", default-features = false, features = ["stream"] }
+http = "0.2"
 mime = "0.3.13"
 time = "0.1"
 indexmap = "1.0"
 state = "0.4"
-tokio-rustls = { version = "0.12.0-alpha.4", optional = true }
-tokio-io = "=0.2.0-alpha.6"
-tokio-net = { version = "=0.2.0-alpha.6", features = ["tcp"] }
-tokio-timer = "=0.3.0-alpha.6"
+tokio-rustls = { version = "0.12", optional = true }
+tokio = { version = "0.2", features = ["net", "time"] }
 cookie = { git = "https://github.com/SergioBenitez/cookie-rs", rev = "e0f3e6c", features = ["percent-encode"] }
 pear = "0.1"
 unicode-xid = "0.1"

--- a/core/http/Cargo.toml
+++ b/core/http/Cargo.toml
@@ -34,7 +34,7 @@ tokio = { version = "0.2", features = ["net", "time"] }
 cookie = { git = "https://github.com/SergioBenitez/cookie-rs", rev = "e0f3e6c", features = ["percent-encode"] }
 pear = "0.1"
 unicode-xid = "0.1"
-futures-core-preview = "0.3.0-alpha.19"
+futures-core = "0.3"
 log = "0.4"
 
 [dev-dependencies]

--- a/core/http/src/hyper.rs
+++ b/core/http/src/hyper.rs
@@ -5,11 +5,10 @@
 //! while necessary.
 
 #[doc(hidden)] pub use hyper::{Body, Request, Response, Server};
-#[doc(hidden)] pub use hyper::body::{Payload, Sender as BodySender};
+#[doc(hidden)] pub use hyper::body::{Bytes, HttpBody, Sender as BodySender};
 #[doc(hidden)] pub use hyper::error::Error;
-#[doc(hidden)] pub use hyper::service::{make_service_fn, service_fn, MakeService, Service};
+#[doc(hidden)] pub use hyper::service::{make_service_fn, service_fn, Service};
 
-#[doc(hidden)] pub use hyper::Chunk;
 #[doc(hidden)] pub use http::header::HeaderMap;
 #[doc(hidden)] pub use http::header::HeaderName as HeaderName;
 #[doc(hidden)] pub use http::header::HeaderValue as HeaderValue;

--- a/core/http/src/hyper.rs
+++ b/core/http/src/hyper.rs
@@ -43,3 +43,15 @@ pub mod header {
         VARY
     }
 }
+
+#[derive(Clone, Copy, Debug)]
+pub struct Executor;
+
+impl<F> hyper::rt::Executor<F> for Executor
+where
+    F: futures_core::future::Future<Output = ()> + Send + 'static,
+{
+    fn execute(&self, fut: F) {
+        tokio::spawn(fut);
+    }
+}

--- a/core/http/src/listener.rs
+++ b/core/http/src/listener.rs
@@ -4,15 +4,15 @@ use std::io;
 use std::net::SocketAddr;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use hyper::server::accept::Accept;
 
 use log::{debug, error};
 
-use tokio_io::{AsyncRead, AsyncWrite};
-use tokio_timer::Delay;
-use tokio_net::tcp::{TcpListener, TcpStream};
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::time::Delay;
+use tokio::net::{TcpListener, TcpStream};
 
 // TODO.async: 'Listener' and 'Connection' provide common enough functionality
 // that they could be introduced in upstream libraries.
@@ -100,8 +100,7 @@ impl<L: Listener> Incoming<L> {
                         error!("accept error: {}", e);
 
                         // Sleep for the specified duration
-                        let delay = Instant::now() + duration;
-                        let mut error_delay = tokio_timer::delay(delay);
+                        let mut error_delay = tokio::time::delay_for(duration);
 
                         match Pin::new(&mut error_delay).poll(cx) {
                             Poll::Ready(()) => {

--- a/core/http/src/tls.rs
+++ b/core/http/src/tls.rs
@@ -7,7 +7,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use tokio_net::tcp::{TcpListener, TcpStream};
+use tokio::net::{TcpListener, TcpStream};
 
 use tokio_rustls::{TlsAcceptor, server::TlsStream};
 use tokio_rustls::rustls;
@@ -91,7 +91,7 @@ impl Listener for TlsListener {
                 TlsListenerState::Listening => {
                     match self.listener.poll_accept(cx) {
                         Poll::Pending => return Poll::Pending,
-                        Poll::Ready(Ok(stream)) => {
+                        Poll::Ready(Ok((stream, _))) => {
                             self.state = TlsListenerState::Accepting(Box::pin(self.acceptor.accept(stream)));
                         }
                         Poll::Ready(Err(e)) => {

--- a/core/lib/Cargo.toml
+++ b/core/lib/Cargo.toml
@@ -30,7 +30,7 @@ rocket_http = { version = "0.5.0-dev", path = "../http" }
 futures-core = "0.3"
 futures-channel = "0.3"
 futures-util = "0.3"
-tokio = { version = "0.2", features = ["fs", "signal", "io-util", "rt-threaded", "rt-util"] }
+tokio = { version = "0.2", features = ["fs", "signal", "io-util", "rt-threaded"] }
 yansi = "0.5"
 log = { version = "0.4", features = ["std"] }
 toml = "0.4.7"

--- a/core/lib/Cargo.toml
+++ b/core/lib/Cargo.toml
@@ -30,7 +30,7 @@ rocket_http = { version = "0.5.0-dev", path = "../http" }
 futures-core = "0.3"
 futures-channel = "0.3"
 futures-util = "0.3"
-tokio = { version = "0.2", features = ["fs", "signal", "io-util"] }
+tokio = { version = "0.2", features = ["fs", "signal", "io-util", "rt-threaded", "rt-util"] }
 yansi = "0.5"
 log = { version = "0.4", features = ["std"] }
 toml = "0.4.7"

--- a/core/lib/Cargo.toml
+++ b/core/lib/Cargo.toml
@@ -47,6 +47,6 @@ yansi = "0.5"
 version_check = "0.9.1"
 
 [dev-dependencies]
-tokio = { version = "0.2", features = ["io-std"] }
+tokio = { version = "0.2", features = ["io-std", "io-util"] }
 # TODO: Find a way to not depend on this.
 lazy_static = "1.0"

--- a/core/lib/Cargo.toml
+++ b/core/lib/Cargo.toml
@@ -27,11 +27,10 @@ ctrl_c_shutdown = ["tokio/signal"]
 [dependencies]
 rocket_codegen = { version = "0.5.0-dev", path = "../codegen" }
 rocket_http = { version = "0.5.0-dev", path = "../http" }
-futures-core-preview = "0.3.0-alpha.19"
-futures-channel-preview = "0.3.0-alpha.19"
-futures-util-preview = "0.3.0-alpha.19"
-tokio = "=0.2.0-alpha.6"
-tokio-io = "=0.2.0-alpha.6"
+futures-core = "0.3"
+futures-channel = "0.3"
+futures-util = "0.3"
+tokio = { version = "0.2", features = ["fs", "signal", "io-util"] }
 yansi = "0.5"
 log = { version = "0.4", features = ["std"] }
 toml = "0.4.7"
@@ -48,7 +47,5 @@ yansi = "0.5"
 version_check = "0.9.1"
 
 [dev-dependencies]
-futures-preview = "0.3.0-alpha.19"
-futures-tokio-compat = { git = "https://github.com/Nemo157/futures-tokio-compat", rev = "8a93702" }
 # TODO: Find a way to not depend on this.
 lazy_static = "1.0"

--- a/core/lib/Cargo.toml
+++ b/core/lib/Cargo.toml
@@ -47,5 +47,6 @@ yansi = "0.5"
 version_check = "0.9.1"
 
 [dev-dependencies]
+tokio = { version = "0.2", features = ["io-std"] }
 # TODO: Find a way to not depend on this.
 lazy_static = "1.0"

--- a/core/lib/src/data/data.rs
+++ b/core/lib/src/data/data.rs
@@ -2,7 +2,7 @@ use std::future::Future;
 use std::io;
 use std::path::Path;
 
-use tokio_io::{AsyncRead, AsyncWrite, AsyncReadExt as _};
+use tokio::io::{AsyncRead, AsyncWrite};
 
 use super::data_stream::DataStream;
 
@@ -146,7 +146,7 @@ impl Data {
     pub fn stream_to<'w, W: AsyncWrite + Unpin + 'w>(self, mut writer: W) -> impl Future<Output = io::Result<u64>> + 'w {
         Box::pin(async move {
             let mut stream = self.open();
-            stream.copy(&mut writer).await
+            tokio::io::copy(&mut stream, &mut writer).await
         })
     }
 

--- a/core/lib/src/data/data_stream.rs
+++ b/core/lib/src/data/data_stream.rs
@@ -1,7 +1,7 @@
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use tokio_io::AsyncRead;
+use tokio::io::AsyncRead;
 
 // TODO.async: Consider storing the real type here instead of a Box to avoid
 // the dynamic dispatch

--- a/core/lib/src/data/from_data.rs
+++ b/core/lib/src/data/from_data.rs
@@ -2,7 +2,7 @@ use std::borrow::Borrow;
 
 use futures_core::future::BoxFuture;
 use futures_util::future::{ready, FutureExt};
-use tokio_io::AsyncReadExt;
+use tokio::io::AsyncReadExt;
 
 use crate::outcome::{self, IntoOutcome};
 use crate::outcome::Outcome::*;

--- a/core/lib/src/ext.rs
+++ b/core/lib/src/ext.rs
@@ -3,22 +3,22 @@ use std::pin::Pin;
 use std::task::{Poll, Context};
 
 use futures_core::{ready, future::BoxFuture, stream::Stream};
-use tokio_io::{AsyncRead, AsyncReadExt as _};
+use tokio::io::{AsyncRead, AsyncReadExt as _};
 
 use crate::http::hyper;
-use hyper::{Chunk, Payload};
+use hyper::{Bytes, HttpBody};
 
-pub struct IntoChunkStream<R> {
+pub struct IntoBytesStream<R> {
     inner: R,
     buf_size: usize,
     buffer: Vec<u8>,
 }
 
 // TODO.async: Verify correctness of this implementation.
-impl<R> Stream for IntoChunkStream<R>
+impl<R> Stream for IntoBytesStream<R>
     where R: AsyncRead + Unpin
 {
-    type Item = Result<Chunk, io::Error>;
+    type Item = Result<Bytes, io::Error>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>>{
         assert!(self.buffer.len() == self.buf_size);
@@ -32,15 +32,15 @@ impl<R> Stream for IntoChunkStream<R>
             Poll::Ready(Ok(n)) => {
                 let mut next = std::mem::replace(buffer, vec![0; buf_size]);
                 next.truncate(n);
-                Poll::Ready(Some(Ok(Chunk::from(next))))
+                Poll::Ready(Some(Ok(Bytes::from(next))))
             }
         }
     }
 }
 
 pub trait AsyncReadExt: AsyncRead {
-    fn into_chunk_stream(self, buf_size: usize) -> IntoChunkStream<Self> where Self: Sized {
-        IntoChunkStream { inner: self, buf_size, buffer: vec![0; buf_size] }
+    fn into_bytes_stream(self, buf_size: usize) -> IntoBytesStream<Self> where Self: Sized {
+        IntoBytesStream { inner: self, buf_size, buffer: vec![0; buf_size] }
     }
 
     // TODO.async: Verify correctness of this implementation.
@@ -72,7 +72,7 @@ pub struct AsyncReadBody {
 
 enum AsyncReadBodyState {
     Pending,
-    Partial(Cursor<Chunk>),
+    Partial(Cursor<Bytes>),
     Done,
 }
 
@@ -88,7 +88,7 @@ impl AsyncRead for AsyncReadBody {
             match self.state {
                 AsyncReadBodyState::Pending => {
                     match ready!(Pin::new(&mut self.inner).poll_data(cx)) {
-                        Some(Ok(chunk)) => self.state = AsyncReadBodyState::Partial(Cursor::new(chunk)),
+                        Some(Ok(bytes)) => self.state = AsyncReadBodyState::Partial(Cursor::new(bytes)),
                         Some(Err(e)) => return Poll::Ready(Err(io::Error::new(io::ErrorKind::Other, e))),
                         None => self.state = AsyncReadBodyState::Done,
                     }

--- a/core/lib/src/lib.rs
+++ b/core/lib/src/lib.rs
@@ -156,5 +156,5 @@ pub fn custom(config: config::Config) -> Rocket {
 /// WARNING: This is unstable! Do not use this method outside of Rocket!
 #[doc(hidden)]
 pub fn async_test<R>(fut: impl std::future::Future<Output = R> + Send) -> R {
-    tokio::runtime::current_thread::Runtime::new().expect("create tokio runtime").block_on(fut)
+    tokio::runtime::Builder::new().basic_scheduler().build().expect("create tokio runtime").block_on(fut)
 }

--- a/core/lib/src/request/form/form.rs
+++ b/core/lib/src/request/form/form.rs
@@ -1,6 +1,6 @@
 use std::ops::Deref;
 
-use tokio_io::AsyncReadExt;
+use tokio::io::AsyncReadExt;
 
 use crate::outcome::Outcome::*;
 use crate::request::{Request, form::{FromForm, FormItems, FormDataError}};

--- a/core/lib/src/response/responder.rs
+++ b/core/lib/src/response/responder.rs
@@ -2,7 +2,7 @@ use std::fs::File;
 use std::io::Cursor;
 
 use futures_util::future::ready;
-use tokio_io::BufReader;
+use tokio::io::BufReader;
 
 use crate::http::{Status, ContentType, StatusClass};
 use crate::response::{self, Response, Body};

--- a/core/lib/src/response/response.rs
+++ b/core/lib/src/response/response.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use std::future::Future;
 use std::pin::Pin;
 
-use tokio_io::{AsyncRead, AsyncReadExt};
+use tokio::io::{AsyncRead, AsyncReadExt};
 use futures_util::future::FutureExt;
 
 use crate::response::{Responder, ResultFuture};

--- a/core/lib/src/response/response.rs
+++ b/core/lib/src/response/response.rs
@@ -1057,14 +1057,12 @@ impl<'r> Response<'r> {
     /// # Example
     ///
     /// ```rust
-    /// use futures::io::repeat;
-    /// use futures_tokio_compat::Compat;
-    /// use tokio::io::AsyncReadExt;
+    /// use tokio::io::{repeat, AsyncReadExt};
     /// use rocket::Response;
     ///
     /// # rocket::async_test(async {
     /// let mut response = Response::new();
-    /// response.set_streamed_body(Compat::new(repeat(97)).take(5));
+    /// response.set_streamed_body(repeat(97).take(5));
     /// assert_eq!(response.body_string().await, Some("aaaaa".to_string()));
     /// # })
     /// ```
@@ -1079,14 +1077,12 @@ impl<'r> Response<'r> {
     /// # Example
     ///
     /// ```rust
-    /// use futures::io::repeat;
-    /// use futures_tokio_compat::Compat;
-    /// use tokio::io::AsyncReadExt;
+    /// use tokio::io::{repeat, AsyncReadExt};
     /// use rocket::Response;
     ///
     /// # rocket::async_test(async {
     /// let mut response = Response::new();
-    /// response.set_chunked_body(Compat::new(repeat(97)).take(5), 10);
+    /// response.set_chunked_body(repeat(97).take(5), 10);
     /// assert_eq!(response.body_string().await, Some("aaaaa".to_string()));
     /// # })
     /// ```

--- a/core/lib/src/response/stream.rs
+++ b/core/lib/src/response/stream.rs
@@ -1,6 +1,6 @@
 use std::fmt::{self, Debug};
 
-use tokio_io::AsyncRead;
+use tokio::io::AsyncRead;
 
 use crate::request::Request;
 use crate::response::{Response, Responder, ResultFuture, DEFAULT_CHUNK_SIZE};

--- a/core/lib/src/rocket.rs
+++ b/core/lib/src/rocket.rs
@@ -738,9 +738,8 @@ impl Rocket {
             }
         });
 
-        // NB: executor must be passed manually here, see hyperium/hyper#1537
         hyper::Server::builder(Incoming::from_listener(listener))
-            .executor(tokio::executor::DefaultExecutor::current())
+            .executor(hyper::Executor)
             .serve(service)
             .with_graceful_shutdown(async move { shutdown_receiver.next().await; })
             .await
@@ -869,6 +868,8 @@ impl Rocket {
         // TODO.async What meaning should config.workers have now?
         // Initialize the tokio runtime
         let mut runtime = tokio::runtime::Builder::new()
+            .threaded_scheduler()
+            .enable_all()
             .num_threads(self.config.workers as usize)
             .build()
             .expect("Cannot build runtime!");

--- a/core/lib/src/rocket.rs
+++ b/core/lib/src/rocket.rs
@@ -755,11 +755,9 @@ impl Rocket {
     /// # Example
     ///
     /// ```rust
-    /// use futures::future::FutureExt;
-    ///
     /// // This gives us the default behavior. Alternatively, we could use a
     /// // `tokio::runtime::Builder` to configure with greater detail.
-    /// let runtime = tokio::runtime::Runtime::new().expect("error creating runtime");
+    /// let mut runtime = tokio::runtime::Runtime::new().expect("error creating runtime");
     ///
     /// # if false {
     /// let server_done = rocket::ignite().spawn_on(&runtime);

--- a/core/lib/tests/head_handling.rs
+++ b/core/lib/tests/head_handling.rs
@@ -22,7 +22,7 @@ fn other() -> content::Json<&'static str> {
 mod head_handling_tests {
     use super::*;
 
-    use tokio_io::{AsyncRead, AsyncReadExt};
+    use tokio::io::{AsyncRead, AsyncReadExt};
 
     use rocket::Route;
     use rocket::local::Client;

--- a/examples/manual_routes/Cargo.toml
+++ b/examples/manual_routes/Cargo.toml
@@ -7,4 +7,4 @@ publish = false
 
 [dependencies]
 rocket = { path = "../../core/lib" }
-tokio = "=0.2.0-alpha.6"
+tokio = "0.2"

--- a/examples/stream/src/main.rs
+++ b/examples/stream/src/main.rs
@@ -6,17 +6,15 @@
 
 use rocket::response::{content, Stream};
 
-use futures::io::repeat;
-use futures_tokio_compat::Compat;
 use tokio::fs::File;
-use tokio::io::{AsyncRead, AsyncReadExt};
+use tokio::io::{repeat, AsyncRead, AsyncReadExt};
 
 // Generate this file using: head -c BYTES /dev/random > big_file.dat
 const FILENAME: &str = "big_file.dat";
 
 #[get("/")]
 fn root() -> content::Plain<Stream<impl AsyncRead>> {
-    content::Plain(Stream::from(Compat::new(repeat('a' as u8)).take(25000)))
+    content::Plain(Stream::from(repeat('a' as u8).take(25000)))
 }
 
 #[get("/big_file")]


### PR DESCRIPTION
WIP on updating to Tokio 0.2, Hyper 0.13

Currently the `ctrl_c_shutdown` feature makes my compiler crash, and I have to figure out how the new Hyper runtime api works (currently the docs.rs build of hyper fails so I'll have to dig in to the code).
Commenting out the line with `.executor(tokio::executor::DefaultExecutor::current())` in `core/lib/src/rocket.rs` makes the code build but it won't run.