### PR TITLE
Add Responder impl support for Either.

### DIFF
--- a/core/lib/Cargo.toml
+++ b/core/lib/Cargo.toml
@@ -19,7 +19,7 @@ edition = "2018"
 all-features = true
 
 [features]
-default = ["private-cookies"]
+default = ["private-cookies", "either"]
 tls = ["rocket_http/tls"]
 private-cookies = ["rocket_http/private-cookies"]
 
@@ -37,6 +37,7 @@ base64 = "0.11"
 base16 = "0.2"
 pear = "0.1"
 atty = "0.2"
+either = { version = "1.5", optional = true }
 
 [build-dependencies]
 yansi = "0.5"

--- a/core/lib/src/response/responder.rs
+++ b/core/lib/src/response/responder.rs
@@ -310,3 +310,10 @@ impl Responder<'_> for Status {
         }
     }
 }
+
+#[cfg(feature = "either")]
+impl<'r, L: Responder<'r>, R: Responder<'r>> Responder<'r> for either::Either<L, R> {
+    fn respond_to(self, req: &Request<'_>) -> response::Result<'r> {
+        self.either(|l|l.respond_to(req), |r|r.respond_to(req))
+    }
+}


### PR DESCRIPTION
Add optional support for Either. 

Some operation during their normal function want to return multiple different return types. E.g.: HTTP PUT can have several different result from 200, 204 or sometimes: 403, 404. 

Currently methods can return multiple types using Result. If the returned value is Result::Err(_) it gets logged. Also because of this the error type must implement Debug. Because of all these using Result is not optimal when you have multiple return types all of which are normal behaving results. 

Currently users can opt to implement their own Responder types but that is a little bit more boilerplate code. Using Either this can be avoided. 

Pls merge.