### PR TITLE
Use Results instead of booleans in the todo example's error handling

### DIFF
--- a/examples/todo/src/main.rs
+++ b/examples/todo/src/main.rs
@@ -32,7 +32,7 @@ struct Context<'a>{ msg: Option<(&'a str, &'a str)>, tasks: Vec<Task> }
 
 impl<'a> Context<'a> {
     pub fn err(conn: &DbConn, msg: &'a str) -> Context<'a> {
-         Context{msg: Some(("error", msg)), tasks: Task::all(conn).unwrap_or_default()} 
+         Context{msg: Some(("error", msg)), tasks: Task::all(conn).unwrap_or_default()}
     }
 
     pub fn raw(conn: &DbConn, msg: Option<(&'a str, &'a str)>) -> Context<'a> {

--- a/examples/todo/src/main.rs
+++ b/examples/todo/src/main.rs
@@ -32,7 +32,7 @@ struct Context<'a>{ msg: Option<(&'a str, &'a str)>, tasks: Vec<Task> }
 
 impl<'a> Context<'a> {
     pub fn err(conn: &DbConn, msg: &'a str) -> Context<'a> {
-        Self::raw(conn, Some(("error", msg)))
+         Context{msg: Some(("error", msg)), tasks: Task::all(conn).unwrap_or_default()} 
     }
 
     pub fn raw(conn: &DbConn, msg: Option<(&'a str, &'a str)>) -> Context<'a> {
@@ -51,10 +51,10 @@ fn new(todo_form: Form<Todo>, conn: DbConn) -> Flash<Redirect> {
     let todo = todo_form.into_inner();
     if todo.description.is_empty() {
         Flash::error(Redirect::to("/"), "Description cannot be empty.")
-    } else if Task::insert(todo, &conn).is_ok() {
-        Flash::success(Redirect::to("/"), "Todo successfully added.")
+    } else if let Err(e) = Task::insert(todo, &conn) {
+        Flash::error(Redirect::to("/"), &format!("Database error: {}", e))
     } else {
-        Flash::error(Redirect::to("/"), "Whoops! The server failed.")
+        Flash::success(Redirect::to("/"), "Todo successfully added.")
     }
 }
 

--- a/examples/todo/src/main.rs
+++ b/examples/todo/src/main.rs
@@ -31,12 +31,18 @@ pub struct DbConn(SqliteConnection);
 struct Context<'a, 'b>{ msg: Option<(&'a str, &'b str)>, tasks: Vec<Task> }
 
 impl<'a, 'b> Context<'a, 'b> {
-    pub fn err(conn: &DbConn, msg: &'a str) -> Context<'static, 'a> {
-        Context{msg: Some(("error", msg)), tasks: Task::all(conn).unwrap()}
+    pub fn err(conn: &DbConn, msg: &'b str) -> Context<'static, 'b> {
+        Self::raw(conn, Some(("error", msg)))
     }
 
-    pub fn raw(conn: &DbConn, msg: Option<(&'a str, &'b str)>) -> Context<'a, 'b> {
-        Context{msg: msg, tasks: Task::all(conn).unwrap()}
+    pub fn raw<'x, 'y>(conn: &DbConn, msg: Option<(&'x str, &'y str)>) -> Context<'x, 'y> {
+        match Task::all(conn) {
+            Ok(tasks) => Context{msg: msg, tasks},
+            Err(_) => Context{
+                msg: Some(("error", "Couldn't access the task database.")),
+                tasks: vec![]
+            }
+        }
     }
 }
 

--- a/examples/todo/src/task.rs
+++ b/examples/todo/src/task.rs
@@ -1,4 +1,5 @@
-use diesel::{self, prelude::*};
+use diesel::{self, result::Error as DieselError, prelude::*};
+type Result<T> = std::result::Result<T, DieselError>;
 
 mod schema {
     table! {
@@ -27,32 +28,35 @@ pub struct Todo {
 }
 
 impl Task {
-    pub fn all(conn: &SqliteConnection) -> Vec<Task> {
-        all_tasks.order(tasks::id.desc()).load::<Task>(conn).unwrap()
+    pub fn all(conn: &SqliteConnection) -> Result<Vec<Task>> {
+        all_tasks.order(tasks::id.desc()).load::<Task>(conn)
     }
 
-    pub fn insert(todo: Todo, conn: &SqliteConnection) -> bool {
+    pub fn insert(todo: Todo, conn: &SqliteConnection) -> Result<()> {
         let t = Task { id: None, description: todo.description, completed: false };
-        diesel::insert_into(tasks::table).values(&t).execute(conn).is_ok()
+        diesel::insert_into(tasks::table).values(&t).execute(conn)?;
+
+        Ok(())
     }
 
-    pub fn toggle_with_id(id: i32, conn: &SqliteConnection) -> bool {
-        let task = all_tasks.find(id).get_result::<Task>(conn);
-        if task.is_err() {
-            return false;
-        }
+    pub fn toggle_with_id(id: i32, conn: &SqliteConnection) -> Result<()> {
+        let task = all_tasks.find(id).get_result::<Task>(conn)?;
 
-        let new_status = !task.unwrap().completed;
+        let new_status = !task.completed;
         let updated_task = diesel::update(all_tasks.find(id));
-        updated_task.set(task_completed.eq(new_status)).execute(conn).is_ok()
+        updated_task.set(task_completed.eq(new_status)).execute(conn)?;
+
+        Ok(())
     }
 
-    pub fn delete_with_id(id: i32, conn: &SqliteConnection) -> bool {
-        diesel::delete(all_tasks.find(id)).execute(conn).is_ok()
+    pub fn delete_with_id(id: i32, conn: &SqliteConnection) -> Result<()> {
+        diesel::delete(all_tasks.find(id)).execute(conn)?;
+        Ok(())
     }
 
     #[cfg(test)]
-    pub fn delete_all(conn: &SqliteConnection) -> bool {
-        diesel::delete(all_tasks).execute(conn).is_ok()
+    pub fn delete_all(conn: &SqliteConnection) -> Result<()> {
+        diesel::delete(all_tasks).execute(conn)?;
+        Ok(())
     }
 }

--- a/examples/todo/src/task.rs
+++ b/examples/todo/src/task.rs
@@ -50,13 +50,17 @@ impl Task {
     }
 
     pub fn delete_with_id(id: i32, conn: &SqliteConnection) -> Result<()> {
-        diesel::delete(all_tasks.find(id))
-            .execute(conn)
-            .map(|_| ())
+        match diesel::delete(all_tasks.find(id)).execute(conn) {
+            Ok(_) => Ok(()),
+            Err(e) => Err(e)
+        }
     }
 
     #[cfg(test)]
     pub fn delete_all(conn: &SqliteConnection) -> Result<()> {
-        diesel::delete(all_tasks).execute(conn)
+        match diesel::delete(all_tasks).execute(conn) {
+            Ok(_) => Ok(()),
+            Err(e) => Err(e),
+        }
     }
 }

--- a/examples/todo/src/task.rs
+++ b/examples/todo/src/task.rs
@@ -50,11 +50,16 @@ impl Task {
     }
 
     pub fn delete_with_id(id: i32, conn: &SqliteConnection) -> Result<()> {
+        // `.execute` returns a usize representing the number of
+        // database rows affected by this modification.
+        // In a larger app these metrics may be useful,
+        // but for a simple example we'll ignore them.
         diesel::delete(all_tasks.find(id)).execute(conn).map(|_| ())
     }
 
     #[cfg(test)]
     pub fn delete_all(conn: &SqliteConnection) -> Result<()> {
+        // see comment in `.delete_with_id`.
         diesel::delete(all_tasks).execute(conn).map(|_| ())
     }
 }

--- a/examples/todo/src/task.rs
+++ b/examples/todo/src/task.rs
@@ -50,13 +50,13 @@ impl Task {
     }
 
     pub fn delete_with_id(id: i32, conn: &SqliteConnection) -> Result<()> {
-        diesel::delete(all_tasks.find(id)).execute(conn)?;
-        Ok(())
+        diesel::delete(all_tasks.find(id))
+            .execute(conn)
+            .map(|_| ())
     }
 
     #[cfg(test)]
     pub fn delete_all(conn: &SqliteConnection) -> Result<()> {
-        diesel::delete(all_tasks).execute(conn)?;
-        Ok(())
+        diesel::delete(all_tasks).execute(conn)
     }
 }

--- a/examples/todo/src/task.rs
+++ b/examples/todo/src/task.rs
@@ -50,17 +50,11 @@ impl Task {
     }
 
     pub fn delete_with_id(id: i32, conn: &SqliteConnection) -> Result<()> {
-        match diesel::delete(all_tasks.find(id)).execute(conn) {
-            Ok(_) => Ok(()),
-            Err(e) => Err(e)
-        }
+        diesel::delete(all_tasks.find(id)).execute(conn).map(|_| ())
     }
 
     #[cfg(test)]
     pub fn delete_all(conn: &SqliteConnection) -> Result<()> {
-        match diesel::delete(all_tasks).execute(conn) {
-            Ok(_) => Ok(()),
-            Err(e) => Err(e),
-        }
+        diesel::delete(all_tasks).execute(conn).map(|_| ())
     }
 }


### PR DESCRIPTION
Using Booleans to convey success is often very verbose and not particularly idiomatic. Using Results to express the possible failure is much more explicit and lends the error handling impetus to the callee.

One part of this I'm not particularly happy with is the new need for `.unwrap()` on many places where `Task::all` was used previously; perhaps we also want to bubble errors in these areas? `.unwrap()` in the tests is simply unavoidable, as far as I can see.