### PR TITLE
Update IRC location in the guide.

### DIFF
--- a/site/guide/11-conclusion.md
+++ b/site/guide/11-conclusion.md
@@ -8,12 +8,12 @@ we're happy to take the best ideas. If you have something in mind, please
 ## Getting Help
 
 If you find yourself having trouble developing Rocket applications, you can get
-help via the `#rocket` IRC channel on the [Mozilla IRC
-Server](https://wiki.mozilla.org/IRC) at `irc.mozilla.org` and the bridged
+help via the `#rocket` IRC channel on the [freenode IRC
+server](https://freenode.net/) at `irc.freenode.net` and the bridged
 [Rocket room on Matrix](https://riot.im/app/#/room/#mozilla_#rocket:matrix.org).
 If you're not familiar with IRC, we recommend chatting through [Matrix via
 Riot](https://riot.im/app/#/room/#mozilla_#rocket:matrix.org) or via the [Kiwi
-web IRC client](https://kiwiirc.com/client/irc.mozilla.org/#rocket). You can
+web IRC client](https://kiwiirc.com/client/irc.freenode.net/#rocket). You can
 learn more about IRC via Mozilla's [Getting Started with
 IRC](https://developer.mozilla.org/en-US/docs/Mozilla/QA/Getting_Started_with_IRC)
 guide.


### PR DESCRIPTION
I notice that the Mozilla IRC servers are shutting down, and `#rocket` is now on freenode. I'm proposing to update the guide so others have an easier time finding the IRC room.