### PR TITLE
Add `RocketConfig::read_from()` that takes a file path

### DIFF
--- a/core/lib/src/config/config.rs
+++ b/core/lib/src/config/config.rs
@@ -182,7 +182,7 @@ impl Config {
     }
 
     /// Returns the default configuration for the environment `env` given that
-    /// the configuration was stored at `config_file_path`.
+    /// the configuration was stored at `path`.
     ///
     /// # Error
     ///

--- a/core/lib/src/config/mod.rs
+++ b/core/lib/src/config/mod.rs
@@ -246,6 +246,17 @@ impl RocketConfig {
         RocketConfig::parse(contents, &file)
     }
 
+    /// Read the configuration from the file at `path`.
+    pub fn read_from(path: &Path) -> Result<RocketConfig> {
+        // Read in file
+        let mut file = File::open(path).map_err(|_| ConfigError::IoError)?;
+        let mut contents = String::new();
+        file.read_to_string(&mut contents)
+            .map_err(|_| ConfigError::IoError)?;
+        // Parse contents
+        RocketConfig::parse(contents, &path)
+    }
+
     /// Return the default configuration for all environments and marks the
     /// active environment (via the CONFIG_ENV variable) as active.
     pub fn active_default_from(filename: Option<&Path>) -> Result<RocketConfig> {


### PR DESCRIPTION
This commit adds an alternative to `RocketConfig::read()`, that takes a path to the configuration file to read and parse. Being able to specify a configuration path programmatically gives users more flexibility on where they store configurations and in determining which file to read from.

Taking a single argument `path` seemed like a better interface than just [making `RocketConfig::parse` public](https://github.com/SergioBenitez/Rocket/issues/228).