### PR TITLE
Fix wrong year in changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Version 0.4.3 (Feb 29, 2019)
+# Version 0.4.3 (Feb 29, 2020)
 
 ## Core
 


### PR DESCRIPTION
Fixed wrong year in the latest changelog entry `2019 -> 2020`.