### PR TITLE
Add `Options::RedirectDirs` to `StaticFiles`

### DIFF
--- a/contrib/lib/src/serve.rs
+++ b/contrib/lib/src/serve.rs
@@ -53,6 +53,15 @@ impl Options {
     /// directories beginning with `.`. This is _not_ enabled by default.
     pub const DotFiles: Options = Options(0b0010);
 
+    /// `Options` enabling redirecting requests for directories if necessary
+    /// to ensure the path has a trailing `/`. When this is enabled, the
+    /// [`StaticFiles`] handler will respond to requests for a directory
+    /// without a trailing `/` with a permanent redirect to the same path
+    /// with a trailing `/`. This ensures relative URLs within any document
+    /// served for that directory will be interpreted relative to that
+    /// directory, rather than its parent. This is _not_ enabled by default.
+    pub const RedirectDirs: Options = Options(0b0100);
+
     /// Returns `true` if `self` is a superset of `other`. In other words,
     /// returns `true` if all of the options in `other` are also in `self`.
     ///

--- a/contrib/lib/tests/static_files.rs
+++ b/contrib/lib/tests/static_files.rs
@@ -24,6 +24,8 @@ mod static_tests {
             .mount("/dots", StaticFiles::new(&root, Options::DotFiles))
             .mount("/index", StaticFiles::new(&root, Options::Index))
             .mount("/both", StaticFiles::new(&root, Options::DotFiles | Options::Index))
+            .mount("/redir", StaticFiles::new(&root, Options::RedirectDirs))
+            .mount("/redir_index", StaticFiles::new(&root, Options::RedirectDirs | Options::Index))
     }
 
     static REGULAR_FILES: &[&str] = &[
@@ -142,5 +144,49 @@ mod static_tests {
         assert_all(&client, "both", REGULAR_FILES, true);
         assert_all(&client, "both", HIDDEN_FILES, true);
         assert_all(&client, "both", INDEXED_DIRECTORIES, true);
+    }
+
+    #[test]
+
+    fn test_redirection() {
+        let client = Client::new(rocket()).expect("valid rocket");
+
+        // Redirection only happens if enabled,
+        // and doesn't affect index behaviour.
+        let response = client.get("/no_index/inner").dispatch();
+        assert_eq!(response.status(), Status::NotFound);
+
+        let response = client.get("/index/inner").dispatch();
+        assert_eq!(response.status(), Status::Ok);
+
+        let response = client.get("/redir/inner").dispatch();
+        assert_eq!(response.status(), Status::MovedPermanently);
+        assert_eq!(response.headers().get("Location").next(), Some("/redir/inner/"));
+
+        let response = client.get("/redir_index/inner").dispatch();
+        assert_eq!(response.status(), Status::MovedPermanently);
+        assert_eq!(response.headers().get("Location").next(), Some("/redir_index/inner/"));
+
+        // Paths with trailing slash are unaffected.
+        let response = client.get("/redir/inner/").dispatch();
+        assert_eq!(response.status(), Status::NotFound);
+
+        let response = client.get("/redir_index/inner/").dispatch();
+        assert_eq!(response.status(), Status::Ok);
+
+        // Root of route is also redirected.
+        let response = client.get("/no_index").dispatch();
+        assert_eq!(response.status(), Status::NotFound);
+
+        let response = client.get("/index").dispatch();
+        assert_eq!(response.status(), Status::Ok);
+
+        let response = client.get("/redir").dispatch();
+        assert_eq!(response.status(), Status::MovedPermanently);
+        assert_eq!(response.headers().get("Location").next(), Some("/redir/"));
+
+        let response = client.get("/redir_index").dispatch();
+        assert_eq!(response.status(), Status::MovedPermanently);
+        assert_eq!(response.headers().get("Location").next(), Some("/redir_index/"));
     }
 }


### PR DESCRIPTION
Closes #1198 .

There was some discussion in the issue about the option name; I've gone with `RedirectDirs` here but I'm happy to change if you have a better alternative. The other suggestions (`NakedDirs`, `UnterminatedDirs`) felt like they had the opposite sense.