### PR TITLE
Remove [target.'cfg(debug_assertions)'.dependencies] in contrib Cargo.toml

### DIFF
--- a/contrib/lib/Cargo.toml
+++ b/contrib/lib/Cargo.toml
@@ -51,6 +51,7 @@ rmp-serde = { version = "^0.13", optional = true }
 handlebars = { version = "1.0", optional = true }
 glob = { version = "0.3", optional = true }
 tera = { version = "0.11", optional = true }
+notify = { version = "4.0.6" }
 
 # UUID dependencies.
 uuid = { version = "0.7", optional = true }
@@ -75,9 +76,6 @@ r2d2-memcache = { version = "0.3", optional = true }
 
 # SpaceHelmet dependencies
 time = { version = "0.1.40", optional = true }
-
-[target.'cfg(debug_assertions)'.dependencies]
-notify = { version = "^4.0.6" }
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
This is a PR **against the v0.4 branch** to backport 4151cd46db9a871bd2088fbecfea145582edca9e as a fix for https://github.com/SergioBenitez/Rocket/issues/1251.

Cargo used to always add that dependency anyway, so this changes nothing for older versions of cargo, and fixes the build for newer versions.