### PR TITLE
Minor documentation formatting fix

### DIFF
--- a/core/lib/src/request/state.rs
+++ b/core/lib/src/request/state.rs
@@ -13,7 +13,7 @@ use crate::http::Status;
 /// registered to be managed by Rocket via
 /// [`Rocket::manage()`]. The type being managed must be
 /// thread safe and sendable across thread boundaries. In other words, it must
-/// implement [`Send`] + [`Sync`] + 'static`.
+/// implement [`Send`] + [`Sync`] + `'static`.
 ///
 /// # Example
 ///


### PR DESCRIPTION
While reading the docs I ran across this tiny opportunity for a first contribution.
* Added missing backtick so `'static` get properly rendered.