### PR TITLE
Hide emoji characters on Windows

### DIFF
--- a/core/lib/src/fairing/fairings.rs
+++ b/core/lib/src/fairing/fairings.rs
@@ -1,5 +1,6 @@
 use crate::{Rocket, Request, Response, Data};
 use crate::fairing::{Fairing, Kind};
+use crate::logger::PaintExt;
 
 use yansi::Paint;
 
@@ -93,7 +94,7 @@ impl Fairings {
 
     pub fn pretty_print_counts(&self) {
         if !self.all_fairings.is_empty() {
-            info!("{}{}:", Paint::masked("📡 "), Paint::magenta("Fairings"));
+            info!("{}{}:", Paint::emoji("📡 "), Paint::magenta("Fairings"));
             self.info_for("launch", &self.launch);
             self.info_for("request", &self.request);
             self.info_for("response", &self.response);

--- a/core/lib/src/logger.rs
+++ b/core/lib/src/logger.rs
@@ -210,6 +210,22 @@ pub(crate) fn pop_max_level() {
     }
 }
 
+pub(crate) trait PaintExt {
+    fn emoji(item: &str) -> Paint<&str>;
+}
+
+impl PaintExt for Paint<&str> {
+    /// Paint::masked but hidden on Windows due to broken output
+    /// https://github.com/SergioBenitez/Rocket/issues/1122
+    fn emoji(item: &str) -> Paint<&str> {
+        if cfg!(windows) {
+            Paint::masked("")
+        } else {
+            Paint::masked(item)
+        }
+    }
+}
+
 #[doc(hidden)]
 pub fn init(level: LoggingLevel) -> bool {
     try_init(level, true)

--- a/core/lib/src/rocket.rs
+++ b/core/lib/src/rocket.rs
@@ -21,6 +21,7 @@ use crate::catcher::{self, Catcher};
 use crate::outcome::Outcome;
 use crate::error::{LaunchError, LaunchErrorKind};
 use crate::fairing::{Fairing, Fairings};
+use crate::logger::PaintExt;
 
 use crate::http::{Method, Status, Header};
 use crate::http::hyper::{self, header};
@@ -403,7 +404,7 @@ impl Rocket {
             logger::push_max_level(logger::LoggingLevel::Normal);
         }
 
-        launch_info!("{}Configured for {}.", Paint::masked("🔧 "), config.environment);
+        launch_info!("{}Configured for {}.", Paint::emoji("🔧 "), config.environment);
         launch_info_!("address: {}", Paint::default(&config.address).bold());
         launch_info_!("port: {}", Paint::default(&config.port).bold());
         launch_info_!("log: {}", Paint::default(config.log_level).bold());
@@ -503,7 +504,7 @@ impl Rocket {
     #[inline]
     pub fn mount<R: Into<Vec<Route>>>(mut self, base: &str, routes: R) -> Self {
         info!("{}{} {}{}",
-              Paint::masked("🛰  "),
+              Paint::emoji("🛰  "),
               Paint::magenta("Mounting"),
               Paint::blue(base),
               Paint::magenta(":"));
@@ -562,7 +563,7 @@ impl Rocket {
     /// ```
     #[inline]
     pub fn register(mut self, catchers: Vec<Catcher>) -> Self {
-        info!("{}{}", Paint::masked("👾 "), Paint::magenta("Catchers:"));
+        info!("{}{}", Paint::emoji("👾 "), Paint::magenta("Catchers:"));
         for c in catchers {
             if self.catchers.get(&c.code).map_or(false, |e| !e.is_default) {
                 info_!("{} {}", c, Paint::yellow("(warning: duplicate catcher!)"));
@@ -721,7 +722,7 @@ impl Rocket {
 
             let full_addr = format!("{}:{}", self.config.address, self.config.port);
             launch_info!("{}{} {}{}",
-                         Paint::masked("🚀 "),
+                         Paint::emoji("🚀 "),
                          Paint::default("Rocket has launched from").bold(),
                          Paint::default(proto).bold().underline(),
                          Paint::default(&full_addr).bold().underline());


### PR DESCRIPTION
Fixes #1122

Behaviour for other platforms is unchanged, but on Windows anything that
would normally be masked is not shown, the nice colours still appear in
development.