### PR TITLE
Adding implementation of FromFormValue for Json type

### DIFF
--- a/examples/json/src/main.rs
+++ b/examples/json/src/main.rs
@@ -20,7 +20,7 @@ type MessageMap = Mutex<HashMap<ID, String>>;
 #[derive(Serialize, Deserialize)]
 struct Message {
     id: Option<ID>,
-    contents: String
+    contents: String,
 }
 
 // TODO: This example can be improved by using `route` with multiple HTTP verbs.
@@ -49,13 +49,13 @@ fn update(id: ID, message: Json<Message>, map: State<'_, MessageMap>) -> Option<
     }
 }
 
-#[get("/<id>", format = "json")]
-fn get(id: ID, map: State<'_, MessageMap>) -> Option<Json<Message>> {
+#[get("/<id>?<labels>", format = "json")]
+fn get(id: ID, labels: Option<Json<Vec<String>>>, map: State<'_, MessageMap>) -> Option<Json<Message>> {
     let hashmap = map.lock().unwrap();
     hashmap.get(&id).map(|contents| {
         Json(Message {
             id: Some(id),
-            contents: contents.clone()
+            contents: labels.map_or_else(|| contents.clone(), |labels| format!("{} with labels: {}", contents, labels.0.join(","))),
         })
     })
 }

--- a/examples/json/src/tests.rs
+++ b/examples/json/src/tests.rs
@@ -68,4 +68,11 @@ fn post_get_put_get() {
     let body = res.into_string().unwrap();
     assert!(!body.contains("Hello, world!"));
     assert!(body.contains("Bye bye, world!"));
+
+    // Check that the message exists with the updated contents.
+    let res = client.get("/message/1?labels=%5B%22label1%22%2C%20%22label2%22%5D").header(ContentType::JSON).dispatch();
+    assert_eq!(res.status(), Status::Ok);
+    let body = res.into_string().unwrap();
+    assert!(!body.contains("Hello, world!"));
+    assert!(body.contains("Bye bye, world! with labels: label1,label2"));
 }


### PR DESCRIPTION
This update is intended to use the ```Json``` type for request query parameters. One example could be this : ```GET /example?values=[0,1,2]``` which would be bound to the parameter ```Json<Vec<u8>>```.

On more complex cases it would be possible then to pass a full JSON object in a query param (not recommended but yet possible).