### PR TITLE
Fix typo in query documentation

### DIFF
--- a/core/lib/src/request/query.rs
+++ b/core/lib/src/request/query.rs
@@ -142,7 +142,7 @@ impl<'q> Iterator for Query<'q> {
 ///
 ///     _This implementation always returns successfully._
 ///
-///     The path segment is parsed by `T`'s `FromQuery` mplementation. The
+///     The path segment is parsed by `T`'s `FromQuery` implementation. The
 ///     returned `Result` value is returned.
 ///
 /// # Example


### PR DESCRIPTION
This is a minor fix to a documentation typo.

`mplementation` -> `implementation`

Fixes #1304 