### PR TITLE
Add `#[doc(hidden)]` to more generated functions and structs.

### DIFF
--- a/core/codegen/src/attribute/catch.rs
+++ b/core/codegen/src/attribute/catch.rs
@@ -83,6 +83,7 @@ pub fn _catch(args: TokenStream, input: TokenStream) -> Result<TokenStream> {
         #user_catcher_fn
 
         /// Rocket code generated wrapping catch function.
+        #[doc(hidden)]
         #vis fn #generated_fn_name<'_b>(#req: &'_b #Request) -> #response::Result<'_b> {
             let __response = #catcher_response;
             #Response::build()
@@ -92,6 +93,7 @@ pub fn _catch(args: TokenStream, input: TokenStream) -> Result<TokenStream> {
         }
 
         /// Rocket code generated static catcher info.
+        #[doc(hidden)]
         #[allow(non_upper_case_globals)]
         #vis static #generated_struct_name: ::rocket::StaticCatchInfo =
             ::rocket::StaticCatchInfo {

--- a/core/codegen/src/attribute/route.rs
+++ b/core/codegen/src/attribute/route.rs
@@ -420,6 +420,7 @@ fn codegen_route(route: Route) -> Result<TokenStream> {
         #user_handler_fn
 
         /// Rocket code generated wrapping route function.
+        #[doc(hidden)]
         #vis fn #generated_fn_name<'_b>(
             #req: &'_b #Request,
             #data: #Data
@@ -435,6 +436,7 @@ fn codegen_route(route: Route) -> Result<TokenStream> {
         #generated_internal_uri_macro
 
         /// Rocket code generated static route info.
+        #[doc(hidden)]
         #[allow(non_upper_case_globals)]
         #vis static #generated_struct_name: #StaticRouteInfo =
             #StaticRouteInfo {


### PR DESCRIPTION
This PR hides items with names such as `static_rocket_route_info_for_index` from documentation. I *believe* this covers all generated top-level items that were not already `#[doc(hidden)]`.

It might be nicer to provide some sort of documentation (#297), but I think hiding it is preferable until something like that exists.

Hidden items can still be documented with the following command: `RUSTDOCFLAGS='-Z unstable-options --document-hidden-items' cargo doc [--open]`. It is expected that that command will be less cumbersome in the future (rust-lang/cargo#7766).