### PR TITLE
[easy] remove tls warning in configuration guide

### DIFF
--- a/site/guide/9-configuration.md
+++ b/site/guide/9-configuration.md
@@ -289,9 +289,6 @@ being ignored.
 
 ## Configuring TLS
 
-! warning: Rocket's built-in TLS is **not** considered ready for production use.
-  It is intended for development use _only_.
-
 Rocket includes built-in, native support for TLS >= 1.2 (Transport Layer
 Security). In order for TLS support to be enabled, Rocket must be compiled with
 the `"tls"` feature. To do this, add the `"tls"` feature to the `rocket`


### PR DESCRIPTION
It looks like this warning about using TLS is stale. It was added 2 years ago according to the git blame. As far as I can tell, looking at the open github issues, there's currently nothing majorly wrong being tracked for TLS support. So it seemed reasonable to remove this somewhat scary warning. It's also possible I missed something and there is still TLS work that needs to be done.