### PR TITLE
Make 'notify' an optional dependency.

### DIFF
--- a/contrib/lib/Cargo.toml
+++ b/contrib/lib/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 
 [features]
 # Internal use only.
-templates = ["serde", "serde_json", "glob"]
+templates = ["serde", "serde_json", "glob", "notify"]
 databases = ["r2d2", "rocket_contrib_codegen/database_attribute"]
 
 # User-facing features.
@@ -55,7 +55,7 @@ rmp-serde = { version = "0.14.0", optional = true }
 handlebars = { version = "2.0", optional = true }
 glob = { version = "0.3", optional = true }
 tera = { version = "1.0.2", optional = true }
-notify = { version = "4.0.6" }
+notify = { version = "4.0.6", optional = true }
 
 # UUID dependencies.
 uuid = { version = ">=0.7.0, <0.9.0", optional = true }


### PR DESCRIPTION
It is now required only when the 'templates' feature is active.

Closes #1058.

* The original intent at the time (#537) was to have this dependency only when both `debug_assertions` and the `"templates"` feature were active. At the time I was able to determine that both conditions were not possible, so we prioritized `debug_assertions`.
* That never actually worked. It became a warning and later an error from `cargo`, and it was "upgraded" to a regular dependency in #1255.
* Since we can't condition it on `debug_assertions` anyway, we will now condition the dependency on the `"templates"` feature. See also https://github.com/SergioBenitez/Rocket/issues/1058#issuecomment-639896706.