### PR TITLE
Relax lifetime bound for `&Request` in `respond_to` (async branch)

### DIFF
--- a/core/lib/src/response/content.rs
+++ b/core/lib/src/response/content.rs
@@ -49,7 +49,7 @@ pub struct Content<R>(pub ContentType, pub R);
 #[crate::async_trait]
 impl<'r, R: Responder<'r> + Send + 'r> Responder<'r> for Content<R> {
     #[inline(always)]
-    async fn respond_to(self, req: &'r Request<'_>) -> response::Result<'r> {
+    async fn respond_to(self, req: &Request<'_>) -> response::Result<'r> where 'r: 'async_trait {
         Response::build()
             .merge(self.1.respond_to(req).await?)
             .header(self.0)
@@ -75,8 +75,8 @@ macro_rules! ctrs {
             /// Sets the Content-Type of the response then delegates the
             /// remainder of the response to the wrapped responder.
             impl<'r, R: Responder<'r> + Send + 'r> Responder<'r> for $name<R> {
-                fn respond_to<'a, 'x>(self, req: &'r Request<'a>) -> BoxFuture<'x, response::Result<'r>>
-                    where 'a: 'x, 'r: 'x, Self: 'x
+                fn respond_to<'a, 'b, 'x>(self, req: &'a Request<'b>) -> BoxFuture<'x, response::Result<'r>>
+                    where 'a: 'x, 'b: 'x, 'r: 'x, Self: 'x
                 {
                     Content(ContentType::$ct, self.0).respond_to(req)
                 }

--- a/core/lib/src/response/debug.rs
+++ b/core/lib/src/response/debug.rs
@@ -65,7 +65,7 @@ impl<E> From<E> for Debug<E> {
 
 #[crate::async_trait]
 impl<'r, E: std::fmt::Debug + Send + 'r> Responder<'r> for Debug<E> {
-    async fn respond_to(self, _: &'r Request<'_>) -> response::Result<'r> {
+    async fn respond_to(self, _: &Request<'_>) -> response::Result<'r> where 'r: 'async_trait {
         warn_!("Debug: {:?}", Paint::default(self.0));
         warn_!("Debug always responds with {}.", Status::InternalServerError);
         Response::build().status(Status::InternalServerError).ok()

--- a/core/lib/src/response/flash.rs
+++ b/core/lib/src/response/flash.rs
@@ -195,7 +195,7 @@ impl<'r, R: Responder<'r>> Flash<R> {
 /// the response is the `Outcome` of the wrapped `Responder`.
 #[crate::async_trait]
 impl<'r, R: Responder<'r> + Send + 'r> Responder<'r> for Flash<R> {
-    async fn respond_to(self, req: &'r Request<'_>) -> response::Result<'r> {
+    async fn respond_to(self, req: &Request<'_>) -> response::Result<'r> where 'r: 'async_trait {
         trace_!("Flash: setting message: {}:{}", self.name, self.message);
         req.cookies().add(self.cookie());
         self.inner.respond_to(req).await

--- a/core/lib/src/response/named_file.rs
+++ b/core/lib/src/response/named_file.rs
@@ -80,7 +80,7 @@ impl NamedFile {
 /// implied by its extension, use a [`File`] directly.
 #[crate::async_trait]
 impl<'r> Responder<'r> for NamedFile {
-    async fn respond_to(self, req: &'r Request<'_>) -> response::Result<'r> {
+    async fn respond_to(self, req: &Request<'_>) -> response::Result<'r> {
         let mut response = self.1.respond_to(req).await?;
         if let Some(ext) = self.0.extension() {
             if let Some(ct) = ContentType::from_extension(&ext.to_string_lossy()) {

--- a/core/lib/src/response/redirect.rs
+++ b/core/lib/src/response/redirect.rs
@@ -149,7 +149,7 @@ impl Redirect {
 /// `Status::InternalServerError` is returned.
 #[crate::async_trait]
 impl<'r> Responder<'r> for Redirect {
-    async fn respond_to(self, _: &'r Request<'_>) -> response::Result<'r> {
+    async fn respond_to(self, _: &Request<'_>) -> response::Result<'r> {
         if let Some(uri) = self.1 {
             Response::build()
                 .status(self.0)

--- a/core/lib/src/response/response.rs
+++ b/core/lib/src/response/response.rs
@@ -1206,7 +1206,7 @@ use crate::request::Request;
 #[crate::async_trait]
 impl<'r> Responder<'r> for Response<'r> {
     /// This is the identity implementation. It simply returns `Ok(self)`.
-    async fn respond_to(self, _: &'r Request<'_>) -> response::Result<'r> {
+    async fn respond_to(self, _: &Request<'_>) -> response::Result<'r> {
         Ok(self)
     }
 }

--- a/core/lib/src/response/status.rs
+++ b/core/lib/src/response/status.rs
@@ -162,7 +162,7 @@ impl<'r, R> Created<R> {
 /// header is set to a hash value of the responder.
 #[crate::async_trait]
 impl<'r, R: Responder<'r> + Send + 'r> Responder<'r> for Created<R> {
-    async fn respond_to(self, req: &'r Request<'_>) -> response::Result<'r> {
+    async fn respond_to(self, req: &Request<'_>) -> response::Result<'r> where 'r: 'async_trait {
         let mut response = Response::build();
         if let Some(responder) = self.1 {
             response.merge(responder.respond_to(req).await?);
@@ -209,7 +209,7 @@ pub struct Accepted<R>(pub Option<R>);
 /// `Some`, it is used to finalize the response.
 #[crate::async_trait]
 impl<'r, R: Responder<'r> + Send + 'r> Responder<'r> for Accepted<R> {
-    async fn respond_to(self, req: &'r Request<'_>) -> response::Result<'r> {
+    async fn respond_to(self, req: &Request<'_>) -> response::Result<'r> where 'r: 'async_trait {
         let mut build = Response::build();
         if let Some(responder) = self.0 {
             build.merge(responder.respond_to(req).await?);
@@ -250,7 +250,7 @@ pub struct BadRequest<R>(pub Option<R>);
 /// `Some`, it is used to finalize the response.
 #[crate::async_trait]
 impl<'r, R: Responder<'r> + Send + 'r> Responder<'r> for BadRequest<R> {
-    async fn respond_to(self, req: &'r Request<'_>) -> response::Result<'r> {
+    async fn respond_to(self, req: &Request<'_>) -> response::Result<'r> where 'r: 'async_trait {
         let mut build = Response::build();
         if let Some(responder) = self.0 {
             build.merge(responder.respond_to(req).await?);
@@ -278,7 +278,7 @@ pub struct NotFound<R>(pub R);
 /// Sets the status code of the response to 404 Not Found.
 #[crate::async_trait]
 impl<'r, R: Responder<'r> + Send + 'r> Responder<'r> for NotFound<R> {
-    async fn respond_to(self, req: &'r Request<'_>) -> response::Result<'r> {
+    async fn respond_to(self, req: &Request<'_>) -> response::Result<'r> where 'r: 'async_trait {
         Response::build_from(self.0.respond_to(req).await?)
             .status(Status::NotFound)
             .ok()
@@ -303,7 +303,7 @@ pub struct Custom<R>(pub Status, pub R);
 /// response to the wrapped responder.
 #[crate::async_trait]
 impl<'r, R: Responder<'r> + Send + 'r> Responder<'r> for Custom<R> {
-    async fn respond_to(self, req: &'r Request<'_>) -> response::Result<'r> {
+    async fn respond_to(self, req: &Request<'_>) -> response::Result<'r> where 'r: 'async_trait {
         Response::build_from(self.1.respond_to(req).await?)
             .status(self.0)
             .ok()

--- a/core/lib/src/response/stream.rs
+++ b/core/lib/src/response/stream.rs
@@ -68,7 +68,7 @@ impl<T: AsyncRead> From<T> for Stream<T> {
 /// to the console with an indication of what went wrong.
 #[crate::async_trait]
 impl<'r, T: AsyncRead + Send + 'r> Responder<'r> for Stream<T> {
-    async fn respond_to(self, _: &'r Request<'_>) -> response::Result<'r> {
+    async fn respond_to(self, _: &Request<'_>) -> response::Result<'r> where 'r: 'async_trait {
         Response::build().chunked_body(self.0, self.1).ok()
     }
 }

--- a/core/lib/tests/responder_lifetime-2.rs
+++ b/core/lib/tests/responder_lifetime-2.rs
@@ -1,0 +1,29 @@
+#![feature(proc_macro_hygiene)]
+#![allow(dead_code)] // This test is only here so that we can ensure it compiles.
+
+use rocket::handler::{Handler, HandlerFuture, Outcome};
+use rocket::http::Method;
+use rocket::response::Responder;
+use rocket::{Data, Request, Route};
+
+/// A "reusable responder" that can be mounted anywhere via 'into_route'.
+#[derive(Clone)]
+pub struct ReusableResponder<R>(R);
+
+impl<R: Responder<'static> + Clone + Send + Sync + 'static> ReusableResponder<R> {
+    pub fn into_route(self, path: impl AsRef<str>) -> Route {
+        Route::new(Method::Get, path, self)
+    }
+}
+
+impl<R: Responder<'static> + Clone + Send + Sync + 'static> Handler for ReusableResponder<R> {
+    fn handle<'r>(&self, req: &'r Request, _: Data) -> HandlerFuture<'r> {
+        let responder = self.0.clone();
+        Box::pin(async move {
+            match responder.respond_to(req).await {
+                Ok(response) => Outcome::Success(response),
+                Err(status) => Outcome::Failure(status)
+            }
+        })
+    }
+}


### PR DESCRIPTION
This was reported in IRC: <https://freenode.logbot.info/rocket/20200525#c3970295> - see also GREsau/okapi#29.

Currently, `respond_to` is too restrictive: it requires an `&'r Request`, where `'r` is from the trait - so if you have an `R: Responder<'static>` (i.e. an owned `Responder`), you can only `respond_to` an `&'static Request`. This PR changes that.

Before merging, I would also want to find more concrete documentation of using `'async_trait` in this position. So far, the closest I have found is https://github.com/dtolnay/async-trait/issues/8#issuecomment-514812245.