### PR TITLE
async: Replace `#[database]` guard API with a `spawn_blocking` wrapper.

### DIFF
--- a/contrib/codegen/src/database.rs
+++ b/contrib/codegen/src/database.rs
@@ -70,8 +70,6 @@ pub fn database_attr(attr: TokenStream, input: TokenStream) -> Result<TokenStrea
 
     // A few useful paths.
     let databases = quote_spanned!(span => ::rocket_contrib::databases);
-    let Poolable = quote_spanned!(span => #databases::Poolable);
-    let r2d2 = quote_spanned!(span => #databases::r2d2);
     let request = quote!(::rocket::request);
 
     let generated_types = quote_spanned! { span =>
@@ -102,7 +100,7 @@ pub fn database_attr(attr: TokenStream, input: TokenStream) -> Result<TokenStrea
             /// closure.
             pub async fn run<F, R>(&self, f: F) -> R
             where
-                F: FnOnce(&mut #r2d2::PooledConnection<<#conn_type as #Poolable>::Manager>) -> R + Send + 'static,
+                F: FnOnce(&mut #conn_type) -> R + Send + 'static,
                 R: Send + 'static,
             {
                 self.0.run(f).await

--- a/contrib/codegen/src/database.rs
+++ b/contrib/codegen/src/database.rs
@@ -78,7 +78,9 @@ pub fn database_attr(attr: TokenStream, input: TokenStream) -> Result<TokenStrea
 
     let generated_types = quote_spanned! { span =>
         /// The request guard type.
-        #vis struct #guard_type(pub #r2d2::PooledConnection<<#conn_type as #Poolable>::Manager>);
+        // TODO: Nest this and pool_type in another module to prevent direct
+        // access to .0 by user code.
+        #vis struct #guard_type(Option<#r2d2::PooledConnection<<#conn_type as #Poolable>::Manager>>);
 
         /// The pool type.
         #vis struct #pool_type(#r2d2::Pool<<#conn_type as #Poolable>::Manager>);
@@ -117,27 +119,47 @@ pub fn database_attr(attr: TokenStream, input: TokenStream) -> Result<TokenStrea
 
             /// Retrieves a connection of type `Self` from the `rocket`
             /// instance. Returns `Some` as long as `Self::fairing()` has been
-            /// attached and there is at least one connection in the pool.
+            /// attached.
             pub fn get_one(cargo: &::rocket::Cargo) -> Option<Self> {
                 cargo.state::<#pool_type>()
                     .and_then(|pool| pool.0.get().ok())
-                    .map(#guard_type)
+                    .map(|c| #guard_type(Some(c)))
+            }
+
+            /// Runs the provided closure on a blocking threadpool. The closure
+            /// will be passed an `&mut r2d2::PooledConnection`, and `.await`ing
+            /// this function will provide whatever value is returned from the
+            /// closure.
+            pub async fn run<F, R>(&mut self, f: F) -> R
+            where
+                F: FnOnce(&mut #r2d2::PooledConnection<<#conn_type as #Poolable>::Manager>) -> R + Send + 'static,
+                R: Send + 'static,
+            {
+                // run() takes &mut self, so the only way this take() should
+                // fail is if the future returned by run() was dropped early OR
+                // if the expect below failed, the resulting panic was caught,
+                // and `run()` was called again.
+                let mut conn = self.0.take()
+                    .expect("Attempted to call run() without awaiting the previous call to run() to completion.");
+                let (ret, conn) = #spawn_blocking(move || {
+                    let ret = f(&mut conn);
+                    (ret, conn)
+                }).await.expect("failed to spawn a blocking task to use a pooled connection");
+                self.0 = Some(conn);
+                ret
             }
         }
 
-        impl ::std::ops::Deref for #guard_type {
-            type Target = #conn_type;
-
-            #[inline(always)]
-            fn deref(&self) -> &Self::Target {
-                &self.0
-            }
-        }
-
-        impl ::std::ops::DerefMut for #guard_type {
-            #[inline(always)]
-            fn deref_mut(&mut self) -> &mut Self::Target {
-                &mut self.0
+        impl Drop for #guard_type {
+            fn drop(&mut self) {
+                // It is okay if `conn` is None here - it was either dropped
+                // already (if spawning the task panicked) or will be dropped
+                // when the spawned task completes.
+                if let Some(conn) = self.0.take() {
+                    #spawn_blocking(move || {
+                        ::std::mem::drop(conn)
+                    });
+                }
             }
         }
 
@@ -147,19 +169,15 @@ pub fn database_attr(attr: TokenStream, input: TokenStream) -> Result<TokenStrea
 
             async fn from_request(request: &'a #request::Request<'r>) -> #request::Outcome<Self, ()> {
                 use ::rocket::{Outcome, http::Status};
-
                 let guard = request.guard::<::rocket::State<'_, #pool_type>>();
                 let pool = ::rocket::try_outcome!(guard.await).0.clone();
-
                 #spawn_blocking(move || {
                     match pool.get() {
-                        Ok(conn) => Outcome::Success(#guard_type(conn)),
+                        Ok(conn) => Outcome::Success(#guard_type(Some(conn))),
                         Err(_) => Outcome::Failure((Status::ServiceUnavailable, ())),
                     }
                 }).await.expect("failed to spawn a blocking task to get a pooled connection")
             }
         }
-
-        // TODO.async: What about spawn_blocking on drop?
     }.into())
 }

--- a/contrib/codegen/src/database.rs
+++ b/contrib/codegen/src/database.rs
@@ -74,7 +74,7 @@ pub fn database_attr(attr: TokenStream, input: TokenStream) -> Result<TokenStrea
 
     let generated_types = quote_spanned! { span =>
         /// The request guard type.
-        #vis struct #guard_type(#databases::ConnectionPool<#conn_type>);
+        #vis struct #guard_type(#databases::ConnectionPool<Self, #conn_type>);
     };
 
     Ok(quote! {
@@ -84,14 +84,14 @@ pub fn database_attr(attr: TokenStream, input: TokenStream) -> Result<TokenStrea
             /// Returns a fairing that initializes the associated database
             /// connection pool.
             pub fn fairing() -> impl ::rocket::fairing::Fairing {
-                <#databases::ConnectionPool<#conn_type>>::fairing(#fairing_name, #name)
+                <#databases::ConnectionPool<Self, #conn_type>>::fairing(#fairing_name, #name)
             }
 
             /// Retrieves a connection of type `Self` from the `rocket`
             /// instance. Returns `Some` as long as `Self::fairing()` has been
             /// attached.
             pub fn get_one(cargo: &::rocket::Cargo) -> Option<Self> {
-                <#databases::ConnectionPool<#conn_type>>::get_one(cargo).map(Self)
+                <#databases::ConnectionPool<Self, #conn_type>>::get_one(cargo).map(Self)
             }
 
             /// Runs the provided closure on a blocking threadpool. The closure
@@ -112,7 +112,7 @@ pub fn database_attr(attr: TokenStream, input: TokenStream) -> Result<TokenStrea
             type Error = ();
 
             async fn from_request(request: &'a #request::Request<'r>) -> #request::Outcome<Self, ()> {
-                <#databases::ConnectionPool<#conn_type>>::from_request(request).await.map(Self)
+                <#databases::ConnectionPool<Self, #conn_type>>::from_request(request).await.map(Self)
             }
         }
     }.into())

--- a/contrib/codegen/src/database.rs
+++ b/contrib/codegen/src/database.rs
@@ -70,6 +70,7 @@ pub fn database_attr(attr: TokenStream, input: TokenStream) -> Result<TokenStrea
 
     // A few useful paths.
     let databases = quote_spanned!(span => ::rocket_contrib::databases);
+    let r2d2 = quote_spanned!(span => #databases::r2d2);
     let request = quote!(::rocket::request);
 
     let generated_types = quote_spanned! { span =>
@@ -98,7 +99,7 @@ pub fn database_attr(attr: TokenStream, input: TokenStream) -> Result<TokenStrea
             /// will be passed an `&mut r2d2::PooledConnection`, and `.await`ing
             /// this function will provide whatever value is returned from the
             /// closure.
-            pub async fn run<F, R>(&self, f: F) -> R
+            pub async fn run<F, R>(&self, f: F) -> Result<R, #r2d2::Error>
             where
                 F: FnOnce(&mut #conn_type) -> R + Send + 'static,
                 R: Send + 'static,

--- a/contrib/codegen/tests/ui-fail/database-types.rs
+++ b/contrib/codegen/tests/ui-fail/database-types.rs
@@ -4,10 +4,12 @@ extern crate rocket;
 struct Unknown;
 
 #[database("foo")]
+//~^ ERROR Unknown: rocket_contrib::databases::Poolable
 struct A(Unknown);
 //~^ ERROR Unknown: rocket_contrib::databases::Poolable
 
 #[database("foo")]
+//~^ ERROR Vec<i32>: rocket_contrib::databases::Poolable
 struct B(Vec<i32>);
 //~^ ERROR Vec<i32>: rocket_contrib::databases::Poolable
 

--- a/contrib/codegen/tests/ui-fail/database-types.rs
+++ b/contrib/codegen/tests/ui-fail/database-types.rs
@@ -4,12 +4,10 @@ extern crate rocket;
 struct Unknown;
 
 #[database("foo")]
-//~^ ERROR Unknown: rocket_contrib::databases::Poolable
 struct A(Unknown);
 //~^ ERROR Unknown: rocket_contrib::databases::Poolable
 
 #[database("foo")]
-//~^ ERROR Vec<i32>: rocket_contrib::databases::Poolable
 struct B(Vec<i32>);
 //~^ ERROR Vec<i32>: rocket_contrib::databases::Poolable
 

--- a/contrib/lib/src/databases.rs
+++ b/contrib/lib/src/databases.rs
@@ -328,8 +328,8 @@
 //! }
 //!
 //! #[get("/")]
-//! fn my_handler(conn: MyDatabase) -> Data {
-//!     load_from_db(&*conn)
+//! async fn my_handler(mut conn: MyDatabase) -> Data {
+//!     conn.run(|c| load_from_db(c)).await
 //! }
 //! # }
 //! ```

--- a/contrib/lib/src/databases.rs
+++ b/contrib/lib/src/databases.rs
@@ -891,14 +891,14 @@ impl<C: Poolable> ConnectionPool<C> {
 
     pub async fn run<F, R>(&self, f: F) -> R
     where
-        F: FnOnce(&mut r2d2::PooledConnection<C::Manager>) -> R + Send + 'static,
+        F: FnOnce(&mut C) -> R + Send + 'static,
         R: Send + 'static,
     {
         let _permit = self.semaphore.acquire().await;
         let pool = self.pool.clone();
         let ret = tokio::task::spawn_blocking(move || {
             let mut conn = pool.get().expect("TODO");
-            let ret = f(&mut conn);
+            let ret = f(&mut *conn);
             ret
         }).await.expect("failed to spawn a blocking task to use a pooled connection");
         ret

--- a/contrib/lib/tests/databases.rs
+++ b/contrib/lib/tests/databases.rs
@@ -34,7 +34,7 @@ mod rusqlite_integration_test {
             .unwrap();
 
         let mut rocket = rocket::custom(config).attach(SqliteDb::fairing());
-        let mut conn = SqliteDb::get_one(rocket.inspect().await).expect("unable to get connection");
+        let conn = SqliteDb::get_one(rocket.inspect().await).expect("unable to get connection");
 
         // Rusqlite's `transaction()` method takes `&mut self`; this tests that
         // the &mut method can be called inside the closure passed to `run()`.

--- a/contrib/lib/tests/databases.rs
+++ b/contrib/lib/tests/databases.rs
@@ -47,6 +47,6 @@ mod rusqlite_integration_test {
             let tx = conn.transaction().unwrap();
             let _: i32 = tx.query_row("SELECT 1", &[] as &[&dyn ToSql], |row| row.get(0)).expect("get row");
             tx.commit().expect("committed transaction");
-        }).await;
+        }).await.unwrap();
     }
 }

--- a/examples/todo/src/main.rs
+++ b/examples/todo/src/main.rs
@@ -12,9 +12,10 @@ mod task;
 
 use rocket::Rocket;
 use rocket::fairing::AdHoc;
-use rocket::request::{Form, FlashMessage};
-use rocket::response::{Flash, Redirect};
-use rocket_contrib::{templates::Template, serve::StaticFiles};
+use rocket::http::Status;
+use rocket::request::{Form, FlashMessage, Request};
+use rocket::response::{self, Flash, Redirect, Responder};
+use rocket_contrib::{databases::r2d2, templates::Template, serve::StaticFiles};
 use diesel::SqliteConnection;
 
 use crate::task::{Task, Todo};
@@ -40,8 +41,31 @@ impl Context {
     }
 }
 
+enum DbResult<R> {
+    Success(R),
+    Unavailable,
+}
+
+impl<'r, 'o: 'r, R: Responder<'r, 'o>> Responder<'r, 'o> for DbResult<R> {
+    fn respond_to(self, req: &'r Request<'_>) -> response::Result<'o> {
+        match self {
+            Self::Success(o) => o.respond_to(req),
+            Self::Unavailable => Status::ServiceUnavailable.respond_to(req),
+        }
+    }
+}
+
+impl<T> From<Result<T, r2d2::Error>> for DbResult<T> {
+    fn from(res: Result<T, r2d2::Error>) -> Self {
+        match res {
+            Ok(val) => DbResult::Success(val),
+            Err(_) => DbResult::Unavailable,
+        }
+    }
+}
+
 #[post("/", data = "<todo_form>")]
-async fn new(todo_form: Form<Todo>, conn: DbConn) -> Flash<Redirect> {
+async fn new(todo_form: Form<Todo>, conn: DbConn) -> DbResult<Flash<Redirect>> {
     conn.run(|conn| {
         let todo = todo_form.into_inner();
         if todo.description.is_empty() {
@@ -51,51 +75,55 @@ async fn new(todo_form: Form<Todo>, conn: DbConn) -> Flash<Redirect> {
         } else {
             Flash::error(Redirect::to("/"), "Whoops! The server failed.")
         }
-    }).await
+    }).await.into()
 }
 
 #[put("/<id>")]
-async fn toggle(id: i32, conn: DbConn) -> Result<Redirect, Template> {
+async fn toggle(id: i32, conn: DbConn) -> DbResult<Result<Redirect, Template>> {
     conn.run(move |conn| {
         if Task::toggle_with_id(id, &conn) {
             Ok(Redirect::to("/"))
         } else {
             Err(Template::render("index", &Context::err(&conn, "Couldn't toggle task.".to_string())))
         }
-    }).await
+    }).await.into()
 }
 
 #[delete("/<id>")]
-async fn delete(id: i32, conn: DbConn) -> Result<Flash<Redirect>, Template> {
+async fn delete(id: i32, conn: DbConn) -> DbResult<Result<Flash<Redirect>, Template>> {
     conn.run(move |conn| {
         if Task::delete_with_id(id, &conn) {
             Ok(Flash::success(Redirect::to("/"), "Todo was deleted."))
         } else {
             Err(Template::render("index", &Context::err(&conn, "Couldn't delete task.".to_string())))
         }
-    }).await
+    }).await.into()
 }
 
 #[get("/")]
-async fn index(msg: Option<FlashMessage<'_, '_>>, conn: DbConn) -> Template {
+async fn index(msg: Option<FlashMessage<'_, '_>>, conn: DbConn) -> DbResult<Template> {
     let msg = msg.map(|m| (m.name().to_string(), m.msg().to_string()));
 
     conn.run(|conn| {
         Template::render("index", Context::raw(&conn, msg))
-    }).await
+    }).await.into()
 }
 
 async fn run_db_migrations(mut rocket: Rocket) -> Result<Rocket, Rocket> {
     let conn = DbConn::get_one(rocket.inspect().await).expect("database connection");
-    conn.run(move |c| {
-        match embedded_migrations::run(&*c) {
-            Ok(()) => Ok(rocket),
-            Err(e) => {
-                error!("Failed to run database migrations: {:?}", e);
-                Err(rocket)
-            }
+    let result = conn.run(|c| embedded_migrations::run(c)).await;
+
+    match result {
+        Ok(Ok(())) => Ok(rocket),
+        Ok(Err(e)) => {
+            error!("Failed to run database migrations: {:?}", e);
+            Err(rocket)
         }
-    }).await
+        Err(e) => {
+            error!("Failed to connect to database: {}", e);
+            Err(rocket)
+        }
+    }
 }
 
 #[rocket::launch]

--- a/examples/todo/src/main.rs
+++ b/examples/todo/src/main.rs
@@ -41,7 +41,7 @@ impl Context {
 }
 
 #[post("/", data = "<todo_form>")]
-async fn new(todo_form: Form<Todo>, mut conn: DbConn) -> Flash<Redirect> {
+async fn new(todo_form: Form<Todo>, conn: DbConn) -> Flash<Redirect> {
     conn.run(|conn| {
         let todo = todo_form.into_inner();
         if todo.description.is_empty() {
@@ -55,7 +55,7 @@ async fn new(todo_form: Form<Todo>, mut conn: DbConn) -> Flash<Redirect> {
 }
 
 #[put("/<id>")]
-async fn toggle(id: i32, mut conn: DbConn) -> Result<Redirect, Template> {
+async fn toggle(id: i32, conn: DbConn) -> Result<Redirect, Template> {
     conn.run(move |conn| {
         if Task::toggle_with_id(id, &conn) {
             Ok(Redirect::to("/"))
@@ -66,7 +66,7 @@ async fn toggle(id: i32, mut conn: DbConn) -> Result<Redirect, Template> {
 }
 
 #[delete("/<id>")]
-async fn delete(id: i32, mut conn: DbConn) -> Result<Flash<Redirect>, Template> {
+async fn delete(id: i32, conn: DbConn) -> Result<Flash<Redirect>, Template> {
     conn.run(move |conn| {
         if Task::delete_with_id(id, &conn) {
             Ok(Flash::success(Redirect::to("/"), "Todo was deleted."))
@@ -77,7 +77,7 @@ async fn delete(id: i32, mut conn: DbConn) -> Result<Flash<Redirect>, Template> 
 }
 
 #[get("/")]
-async fn index(msg: Option<FlashMessage<'_, '_>>, mut conn: DbConn) -> Template {
+async fn index(msg: Option<FlashMessage<'_, '_>>, conn: DbConn) -> Template {
     let msg = msg.map(|m| (m.name().to_string(), m.msg().to_string()));
 
     conn.run(|conn| {
@@ -86,7 +86,7 @@ async fn index(msg: Option<FlashMessage<'_, '_>>, mut conn: DbConn) -> Template 
 }
 
 async fn run_db_migrations(mut rocket: Rocket) -> Result<Rocket, Rocket> {
-    let mut conn = DbConn::get_one(rocket.inspect().await).expect("database connection");
+    let conn = DbConn::get_one(rocket.inspect().await).expect("database connection");
     conn.run(move |c| {
         match embedded_migrations::run(&*c) {
             Ok(()) => Ok(rocket),

--- a/examples/todo/src/tests.rs
+++ b/examples/todo/src/tests.rs
@@ -20,7 +20,7 @@ macro_rules! run_test {
             let db = super::DbConn::get_one(rocket.inspect().await);
             let $client = Client::new(rocket).await.expect("Rocket client");
             let $conn = db.expect("failed to get database connection for testing");
-            assert!($conn.run(|c| Task::delete_all(c)).await, "failed to delete all tasks for testing");
+            assert!($conn.run(|c| Task::delete_all(c)).await.unwrap(), "failed to delete all tasks for testing");
 
             $block
         })
@@ -31,7 +31,7 @@ macro_rules! run_test {
 fn test_insertion_deletion() {
     run_test!(|client, conn| {
         // Get the tasks before making changes.
-        let init_tasks = conn.run(|c| Task::all(c)).await;
+        let init_tasks = conn.run(|c| Task::all(c)).await.unwrap();
 
         // Issue a request to insert a new task.
         client.post("/todo")
@@ -40,7 +40,7 @@ fn test_insertion_deletion() {
             .dispatch().await;
 
         // Ensure we have one more task in the database.
-        let new_tasks = conn.run(|c| Task::all(c)).await;
+        let new_tasks = conn.run(|c| Task::all(c)).await.unwrap();
         assert_eq!(new_tasks.len(), init_tasks.len() + 1);
 
         // Ensure the task is what we expect.
@@ -52,7 +52,7 @@ fn test_insertion_deletion() {
         client.delete(format!("/todo/{}", id)).dispatch().await;
 
         // Ensure it's gone.
-        let final_tasks = conn.run(|c| Task::all(c)).await;
+        let final_tasks = conn.run(|c| Task::all(c)).await.unwrap();
         assert_eq!(final_tasks.len(), init_tasks.len());
         if final_tasks.len() > 0 {
             assert_ne!(final_tasks[0].description, "My first task");
@@ -69,16 +69,16 @@ fn test_toggle() {
             .body("description=test_for_completion")
             .dispatch().await;
 
-        let task = conn.run(|c| Task::all(c)).await[0].clone();
+        let task = conn.run(|c| Task::all(c)).await.unwrap()[0].clone();
         assert_eq!(task.completed, false);
 
         // Issue a request to toggle the task; ensure it is completed.
         client.put(format!("/todo/{}", task.id.unwrap())).dispatch().await;
-        assert_eq!(conn.run(|c| Task::all(c)).await[0].completed, true);
+        assert_eq!(conn.run(|c| Task::all(c)).await.unwrap()[0].completed, true);
 
         // Issue a request to toggle the task; ensure it's not completed again.
         client.put(format!("/todo/{}", task.id.unwrap())).dispatch().await;
-        assert_eq!(conn.run(|c| Task::all(c)).await[0].completed, false);
+        assert_eq!(conn.run(|c| Task::all(c)).await.unwrap()[0].completed, false);
     })
 }
 
@@ -88,7 +88,7 @@ fn test_many_insertions() {
 
     run_test!(|client, conn| {
         // Get the number of tasks initially.
-        let init_num = conn.run(|c| Task::all(c)).await.len();
+        let init_num = conn.run(|c| Task::all(c)).await.unwrap().len();
         let mut descs = Vec::new();
 
         for i in 0..ITER {
@@ -103,7 +103,7 @@ fn test_many_insertions() {
             descs.insert(0, desc);
 
             // Ensure the task was inserted properly and all other tasks remain.
-            let tasks = conn.run(|c| Task::all(c)).await;
+            let tasks = conn.run(|c| Task::all(c)).await.unwrap();
             assert_eq!(tasks.len(), init_num + i + 1);
 
             for j in 0..i {

--- a/examples/todo/src/tests.rs
+++ b/examples/todo/src/tests.rs
@@ -19,7 +19,7 @@ macro_rules! run_test {
             let mut rocket = super::rocket();
             let db = super::DbConn::get_one(rocket.inspect().await);
             let $client = Client::new(rocket).await.expect("Rocket client");
-            let mut $conn = db.expect("failed to get database connection for testing");
+            let $conn = db.expect("failed to get database connection for testing");
             assert!($conn.run(|c| Task::delete_all(c)).await, "failed to delete all tasks for testing");
 
             $block

--- a/site/guide/6-state.md
+++ b/site/guide/6-state.md
@@ -173,7 +173,7 @@ three simple steps:
 
   1. Configure the databases in `Rocket.toml`.
   2. Associate a request guard type and fairing with each database.
-  3. Use the request guard to retrieve a connection in a handler.
+  3. Use the request guard to retrieve and use a connection in a handler.
 
 Presently, Rocket provides built-in support for the following databases:
 
@@ -260,7 +260,7 @@ fn rocket() -> rocket::Rocket {
 ```
 
 That's it! Whenever a connection to the database is needed, use your type as a
-request guard. The database can be used by calling `run`:
+request guard. The database can be accessed by calling the `run` method:
 
 ```rust
 #[get("/logs/<id>")]
@@ -273,11 +273,12 @@ async fn get_logs(conn: LogsDbConn, id: usize) -> Result<Logs> {
 
 ! note
 
-  The database engines supported by `#[database]` are *synchronous*. The `run()`
-  function offloads this synchronous work via `tokio::spawn_blocking`, so that
-  database access does not interfere with other in-flight requests. See
-  [Cooperative Multitasking](../overview/#cooperative-multitasking) for more
-  information on why this is necessary.
+  The database engines supported by `#[database]` are *synchronous*, and
+  normally block the thread of execution. The `run()` function automatically
+  uses `tokio::spawn_blocking` so that database access does not interfere with
+  other in-flight requests. See [Cooperative
+  Multitasking](../overview/#cooperative-multitasking) for more information on
+  why this is necessary.
 
 If your application uses features of a database engine that are not available
 by default, for example support for `chrono` or `uuid`, you may enable those


### PR DESCRIPTION
The connection guard type generated by `#[database]` no longer implements `Deref` and `DerefMut`. Instead, it provides an `async fn run()` that gives access to the underlying connection on a closure run through `spawn_blocking()`.

## Background

All existing engines supported by `#[database]` are synchronous. Several of them, such as `diesel` and `sqlite`, do not have a well-supported `async` version or close alternative available. Therefore, I would consider it a non-starter to entirely drop support for them. However, using synchronous database libraries from `async` code has some issues:

## Motivation

Performing blocking operations while running on an asynchronous runtime is a footgun:
* Best case: the server does not experience enough load to exhibit any problems.
* Bad case: requests that are busy in a blocking operation will "artificially" prevent other requests from running or continuing, including any that are partway through I/O with the client, even if those other requests don't need to perform any blocking operation themselves.
* Worst case: deadlocks can occur. With database pools in particular, you could end up in a situation where all threads are waiting for a connection to be returned to the pool - but those connections are all held by tasks that cannot run, because the worker threads are all tied up waiting.

## Problems and Alternatives

* ~~`spawn_blocking` [panics when the blocking thread limit (currently 512) is reached](https://github.com/tokio-rs/tokio/issues/2309). In other words, there is no "queue" for spawned operations.~~ Apologies; I misread/misunderstood parts of the implementation of `spawn_blocking` *and* of the linked issue. There *is* a queue for spawned tasks, which is actually worse in a sense:
* `spawn_blocking` without any backpressure creates a ridiculously long queue of threads, which most of the time are just waiting for an open connection to be returned to the pool. These threads prevent the "return to the pool" operation from happening, which would cause a deadlock if it were not for r2d2's built-in timeouts.
  * A lightweight option that shows a lot of promise in my testing: put the connection acquisition operation inside behind an async `Semaphore` or `Mutex`. Limiting on acquisition should be sufficient, since the pool already limits the number of open connections - thereby limiting the number of active `spawn_blocking()` calls by construction.
  * Instead of `spawn_blocking`, we could use a work queue specifically for databases. This poses all kinds of new questions, like whether workers should be per-guard type or global and how many worker threads.
* It's inconvenient to do any asynchronous work inside the closure, so depending on the usage patterns `run()` might need to be called multiple times in between non-database work.
* `spawn_blocking`, and several other approaches such as a work queue, require the passed-in closure/data to be `'static`. This can become a headache in combination with any data that holds a borrow, such as `State<'_, T>` or an `&str`. I expect this to be the biggest problem with this approach in user code.
  * This drawback is *also* the most problematic one to "work around". In order to be sound, a wrapper that did *not* require a `'static` closure would need to either (synchronously!) wait on the spawned task's completion or abort the process in the event that the task was canceled before the blocking task completed.
* Instead of wrapping only database operations, we could wrap entire routes in `spawn_blocking`. I have avoided this approach, as I expect it to be *even more* problematic given the `'static` restrictions.

## Todo

* [x] Decide on the underlying approach and/or workarounds for any aforementioned problems with `spawn_blocking` - for now, treating this as "solved" by using a `Semaphore`. Further improvements are of course possible!
* [ ] Thoroughly review and fix all applicable documentation, including the guide.
* [x] Prevent the user from accessing the inner fields of the generated guard type and pool type by nesting them inside another module.
  * [x] ~~This turns out to be... tricky. We would be going from `struct A(B);` to `mod __inner { struct A(B); }` with (as far as I can tell) to reliable way to access `B` from `__inner`. One "awkward-but-works" option would be to generate `mod __inner { struct A<T>(T); } type A = __inner::A<B>;`.~~
* [ ] I now realize this will have a *lot* of conflicts with #1230 on `master`. Perhaps we can forward-port that commit to `async`.
* [x] error handling in the case that the database is unavailable.