### PR TITLE
Simplify ASCII checks for char and byte primitives

### DIFF
--- a/core/http/src/parse/uri/parser.rs
+++ b/core/http/src/parse/uri/parser.rs
@@ -64,7 +64,7 @@ fn port_from<'a>(input: &mut RawInput<'a>, bytes: &IndexedBytes<'a>) -> Result<'
     let source = Some(input.cow_source());
     let string = bytes.from_cow_source(&source);
     for (&b, i) in string.iter().rev().zip(&[1, 10, 100, 1000, 10000]) {
-        if b < b'0' || b > b'9' {
+        if !b.is_ascii_digit() {
             return Err(pear_error!("port byte is out of range"));
         }
 
@@ -80,7 +80,7 @@ fn port_from<'a>(input: &mut RawInput<'a>, bytes: &IndexedBytes<'a>) -> Result<'
 
 #[parser]
 fn port<'a>(input: &mut RawInput<'a>) -> Result<'a, u16> {
-    let port_str = take_n_while(5, |c| c >= b'0' && c <= b'9')?;
+    let port_str = take_n_while(5, |c| c.is_ascii_digit())?;
     port_from(&port_str)?
 }
 

--- a/core/http/src/route.rs
+++ b/core/http/src/route.rs
@@ -63,18 +63,15 @@ pub type SResult<'a, P> = Result<RouteSegment<'a, P>, (&'a str, Error<'a>)>;
 
 #[inline]
 fn is_ident_start(c: char) -> bool {
-    ('a' <= c && c <= 'z')
-        || ('A' <= c && c <= 'Z')
+    c.is_ascii_alphabetic()
         || c == '_'
         || (c > '\x7f' && UnicodeXID::is_xid_start(c))
 }
 
 #[inline]
 fn is_ident_continue(c: char) -> bool {
-    ('a' <= c && c <= 'z')
-        || ('A' <= c && c <= 'Z')
+    c.is_ascii_alphanumeric()
         || c == '_'
-        || ('0' <= c && c <= '9')
         || (c > '\x7f' && UnicodeXID::is_xid_continue(c))
 }
 

--- a/core/lib/src/config/toml_ext.rs
+++ b/core/lib/src/config/toml_ext.rs
@@ -23,10 +23,7 @@ fn is_not_separator(byte: char) -> bool {
 // FIXME: Be more permissive here?
 #[inline(always)]
 fn is_ident_char(byte: char) -> bool {
-    match byte {
-        '0'..='9' | 'A'..='Z' | 'a'..='z' | '_' | '-' => true,
-        _ => false
-    }
+    byte.is_ascii_alphanumeric() || byte == '_' || byte == '-'
 }
 
 #[parser]

--- a/core/lib/src/request/param.rs
+++ b/core/lib/src/request/param.rs
@@ -154,7 +154,7 @@ use crate::http::{RawStr, uri::{Segments, SegmentError}};
 ///             _ => return Err(param)
 ///         };
 ///
-///         if !key.chars().all(|c| (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')) {
+///         if !key.chars().all(|c| c.is_ascii_alphabetic()) {
 ///             return Err(param);
 ///         }
 ///

--- a/examples/pastebin/src/paste_id.rs
+++ b/examples/pastebin/src/paste_id.rs
@@ -35,11 +35,7 @@ impl<'a> fmt::Display for PasteID<'a> {
 
 /// Returns `true` if `id` is a valid paste ID and `false` otherwise.
 fn valid_id(id: &str) -> bool {
-    id.chars().all(|c| {
-        (c >= 'a' && c <= 'z')
-            || (c >= 'A' && c <= 'Z')
-            || (c >= '0' && c <= '9')
-    })
+    id.chars().all(|c| c.is_ascii_alphanumeric())
 }
 
 /// Returns an instance of `PasteID` if the path segment is a valid ID.


### PR DESCRIPTION
This PR simplifies some ASCII checks for byte and char types, it doesn't change behaviour.