### PR TITLE
Add '#[rocket::launch]' attribute.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ Rocket is a web framework for Rust (nightly) with a focus on ease-of-use,
 expressibility, and speed. Here's an example of a complete Rocket application:
 
 ```rust
-#![feature(proc_macro_hygiene)]
-
 #[macro_use] extern crate rocket;
 
 #[get("/<name>/<age>")]
@@ -19,8 +17,9 @@ fn hello(name: String, age: u8) -> String {
     format!("Hello, {} year old named {}!", age, name)
 }
 
-fn main() {
-    rocket::ignite().mount("/hello", routes![hello]).launch();
+#[launch]
+fn rocket() -> rocket::Rocket {
+    rocket::ignite().mount("/hello", routes![hello])
 }
 ```
 

--- a/contrib/lib/src/databases.rs
+++ b/contrib/lib/src/databases.rs
@@ -62,12 +62,9 @@
 //! #[database("sqlite_logs")]
 //! struct LogsDbConn(diesel::SqliteConnection);
 //!
-//! #[rocket::main]
-//! async fn main() {
-//!     rocket::ignite()
-//!        .attach(LogsDbConn::fairing())
-//!        .launch()
-//!        .await;
+//! #[rocket::launch]
+//! fn rocket() -> rocket::Rocket {
+//!     rocket::ignite().attach(LogsDbConn::fairing())
 //! }
 //! # } fn main() {}
 //! ```
@@ -152,8 +149,8 @@
 //! use std::collections::HashMap;
 //! use rocket::config::{Config, Environment, Value};
 //!
-//! #[rocket::main]
-//! async fn main() {
+//! #[rocket::launch]
+//! fn rocket() -> rocket::Rocket {
 //!     let mut database_config = HashMap::new();
 //!     let mut databases = HashMap::new();
 //!
@@ -167,7 +164,7 @@
 //!         .finalize()
 //!         .unwrap();
 //!
-//!     rocket::custom(config).launch().await;
+//!     rocket::custom(config)
 //! }
 //! # } fn main() {}
 //! ```
@@ -266,8 +263,8 @@
 //! #[database("my_db")]
 //! struct MyDatabase(diesel::SqliteConnection);
 //!
-//! #[rocket::main]
-//! async fn main() {
+//! #[rocket::launch]
+//! fn rocket() -> rocket::Rocket {
 //! #     let mut db_config = HashMap::new();
 //! #     let mut databases = HashMap::new();
 //! #
@@ -280,10 +277,7 @@
 //! #         .finalize()
 //! #         .unwrap();
 //! #
-//!     rocket::custom(config)
-//!         .attach(MyDatabase::fairing())
-//!         .launch()
-//!         .await;
+//!     rocket::custom(config).attach(MyDatabase::fairing())
 //! }
 //! # } fn main() {}
 //! ```

--- a/contrib/lib/src/serve.rs
+++ b/contrib/lib/src/serve.rs
@@ -116,17 +116,15 @@ impl std::ops::BitOr for Options {
 /// `/public` path, allowing `index.html` files to be used to respond to
 /// requests for a directory (the default), you might write the following:
 ///
-/// ```rust
+/// ```rust,no_run
 /// # extern crate rocket;
 /// # extern crate rocket_contrib;
-/// # mod no_main {
 /// use rocket_contrib::serve::StaticFiles;
 ///
 /// #[rocket::launch]
 /// fn rocket() -> rocket::Rocket {
 ///     rocket::ignite().mount("/public", StaticFiles::from("/static"))
 /// }
-/// # }
 /// ```
 ///
 /// With this, requests for files at `/public/<path..>` will be handled by
@@ -141,10 +139,9 @@ impl std::ops::BitOr for Options {
 /// For example, to serve files in the `static` subdirectory of your crate at
 /// `/`, you might write:
 ///
-/// ```rust
+/// ```rust,no_run
 /// # extern crate rocket;
 /// # extern crate rocket_contrib;
-/// # mod no_main {
 /// use rocket_contrib::serve::StaticFiles;
 ///
 /// #[rocket::launch]
@@ -152,7 +149,6 @@ impl std::ops::BitOr for Options {
 ///     rocket::ignite()
 ///         .mount("/", StaticFiles::from(concat!(env!("CARGO_MANIFEST_DIR"), "/static")))
 /// }
-/// # }
 /// ```
 #[derive(Clone)]
 pub struct StaticFiles {
@@ -176,34 +172,28 @@ impl StaticFiles {
     /// Serve the static files in the `/www/public` local directory on path
     /// `/static`.
     ///
-    /// ```rust
+    /// ```rust,no_run
     /// # extern crate rocket;
     /// # extern crate rocket_contrib;
-    /// # mod no_main {
     /// use rocket_contrib::serve::StaticFiles;
     ///
     /// #[rocket::launch]
     /// fn rocket() -> rocket::Rocket {
-    ///     rocket::ignite()
-    ///         .mount("/static", StaticFiles::from("/www/public"))
+    ///     rocket::ignite().mount("/static", StaticFiles::from("/www/public"))
     /// }
-    /// # }
     /// ```
     ///
     /// Exactly as before, but set the rank for generated routes to `30`.
     ///
-    /// ```rust
+    /// ```rust,no_run
     /// # extern crate rocket;
     /// # extern crate rocket_contrib;
-    /// # mod no_main {
     /// use rocket_contrib::serve::StaticFiles;
     ///
     /// #[rocket::launch]
     /// fn rocket() -> rocket::Rocket {
-    ///     rocket::ignite()
-    ///         .mount("/static", StaticFiles::from("/www/public").rank(30))
+    ///     rocket::ignite().mount("/static", StaticFiles::from("/www/public").rank(30))
     /// }
-    /// # }
     /// ```
     pub fn from<P: AsRef<Path>>(path: P) -> Self {
         StaticFiles::new(path, Options::default())
@@ -220,10 +210,9 @@ impl StaticFiles {
     /// the same files on `/pub` with a route rank of -1 while also serving
     /// index files and dot files.
     ///
-    /// ```rust
+    /// ```rust,no_run
     /// # extern crate rocket;
     /// # extern crate rocket_contrib;
-    /// # mod no_main {
     /// use rocket_contrib::serve::{StaticFiles, Options};
     ///
     /// #[rocket::launch]
@@ -233,7 +222,6 @@ impl StaticFiles {
     ///         .mount("/static", StaticFiles::from("/www/public"))
     ///         .mount("/pub", StaticFiles::new("/www/public", options).rank(-1))
     /// }
-    /// # }
     /// ```
     pub fn new<P: AsRef<Path>>(path: P, options: Options) -> Self {
         StaticFiles { root: path.as_ref().into(), options, rank: Self::DEFAULT_RANK }

--- a/contrib/lib/src/serve.rs
+++ b/contrib/lib/src/serve.rs
@@ -119,17 +119,14 @@ impl std::ops::BitOr for Options {
 /// ```rust
 /// # extern crate rocket;
 /// # extern crate rocket_contrib;
+/// # mod no_main {
 /// use rocket_contrib::serve::StaticFiles;
 ///
-/// #[rocket::main]
-/// async fn main() {
-/// # if false {
-///     rocket::ignite()
-///         .mount("/public", StaticFiles::from("/static"))
-///         .launch()
-///         .await;
-/// # }
+/// #[rocket::launch]
+/// fn rocket() -> rocket::Rocket {
+///     rocket::ignite().mount("/public", StaticFiles::from("/static"))
 /// }
+/// # }
 /// ```
 ///
 /// With this, requests for files at `/public/<path..>` will be handled by
@@ -147,17 +144,15 @@ impl std::ops::BitOr for Options {
 /// ```rust
 /// # extern crate rocket;
 /// # extern crate rocket_contrib;
+/// # mod no_main {
 /// use rocket_contrib::serve::StaticFiles;
 ///
-/// #[rocket::main]
-/// async fn main() {
-/// # if false {
+/// #[rocket::launch]
+/// fn rocket() -> rocket::Rocket {
 ///     rocket::ignite()
 ///         .mount("/", StaticFiles::from(concat!(env!("CARGO_MANIFEST_DIR"), "/static")))
-///         .launch()
-///         .await;
-/// # }
 /// }
+/// # }
 /// ```
 #[derive(Clone)]
 pub struct StaticFiles {
@@ -184,17 +179,15 @@ impl StaticFiles {
     /// ```rust
     /// # extern crate rocket;
     /// # extern crate rocket_contrib;
+    /// # mod no_main {
     /// use rocket_contrib::serve::StaticFiles;
     ///
-    /// #[rocket::main]
-    /// async fn main() {
-    /// # if false {
+    /// #[rocket::launch]
+    /// fn rocket() -> rocket::Rocket {
     ///     rocket::ignite()
     ///         .mount("/static", StaticFiles::from("/www/public"))
-    ///         .launch()
-    ///         .await;
-    /// # }
     /// }
+    /// # }
     /// ```
     ///
     /// Exactly as before, but set the rank for generated routes to `30`.
@@ -202,17 +195,15 @@ impl StaticFiles {
     /// ```rust
     /// # extern crate rocket;
     /// # extern crate rocket_contrib;
+    /// # mod no_main {
     /// use rocket_contrib::serve::StaticFiles;
     ///
-    /// #[rocket::main]
-    /// async fn main() {
-    /// # if false {
+    /// #[rocket::launch]
+    /// fn rocket() -> rocket::Rocket {
     ///     rocket::ignite()
     ///         .mount("/static", StaticFiles::from("/www/public").rank(30))
-    ///         .launch()
-    ///         .await;
-    /// # }
     /// }
+    /// # }
     /// ```
     pub fn from<P: AsRef<Path>>(path: P) -> Self {
         StaticFiles::new(path, Options::default())
@@ -232,19 +223,17 @@ impl StaticFiles {
     /// ```rust
     /// # extern crate rocket;
     /// # extern crate rocket_contrib;
+    /// # mod no_main {
     /// use rocket_contrib::serve::{StaticFiles, Options};
     ///
-    /// #[rocket::main]
-    /// async fn main() {
-    /// # if false {
+    /// #[rocket::launch]
+    /// fn rocket() -> rocket::Rocket {
     ///     let options = Options::Index | Options::DotFiles;
     ///     rocket::ignite()
     ///         .mount("/static", StaticFiles::from("/www/public"))
     ///         .mount("/pub", StaticFiles::new("/www/public", options).rank(-1))
-    ///         .launch()
-    ///         .await;
-    /// # }
     /// }
+    /// # }
     /// ```
     pub fn new<P: AsRef<Path>>(path: P, options: Options) -> Self {
         StaticFiles { root: path.as_ref().into(), options, rank: Self::DEFAULT_RANK }

--- a/core/codegen/src/attribute/async_entry.rs
+++ b/core/codegen/src/attribute/async_entry.rs
@@ -1,83 +1,134 @@
 use proc_macro::{TokenStream, Span};
-use devise::{syn, Result};
+use devise::{syn, Spanned, Result};
 
 use crate::proc_macro2::TokenStream as TokenStream2;
 use crate::syn_ext::syn_to_diag;
 
-#[derive(Copy, Clone)]
-enum Kind {
-    Main,
-    Test,
+trait EntryAttr {
+    /// Whether the attribute requires the attributed function to be `async`.
+    const REQUIRES_ASYNC: bool;
+
+    /// Return a new or rewritten function, using block as the main execution.
+    fn function(f: &syn::ItemFn, body: &syn::Block) -> Result<TokenStream2>;
 }
 
-impl Kind {
-    // The name of the attribute, used for error messages
-    fn attr_name(&self) -> &'static str {
-        match self {
-            Kind::Main => "main",
-            Kind::Test => "async_test",
-        }
-    }
+struct Main;
 
-    // Attributes to decorate the generated function with
-    fn attrs(&self) -> Option<TokenStream2> {
-        match self {
-            Kind::Main => None,
-            Kind::Test => Some(quote!{ #[test] }),
-        }
-    }
+impl EntryAttr for Main {
+    const REQUIRES_ASYNC: bool = true;
 
-    // The path to the function to call
-    fn fn_path(&self) -> TokenStream2 {
-        match self {
-            Kind::Main => quote! { rocket :: async_main },
-            Kind::Test => quote! { rocket :: async_test },
+    fn function(f: &syn::ItemFn, block: &syn::Block) -> Result<TokenStream2> {
+        let (vis, mut sig) = (&f.vis, f.sig.clone());
+        if sig.ident != "main" {
+            return Err(Span::call_site()
+                .error("attribute can only be applied to `main` function")
+                .span_note(sig.span(), "this function must be `main`"));
         }
+
+        sig.asyncness = None;
+        Ok(quote_spanned!(block.span().into() => #vis #sig {
+            ::rocket::async_main(async move #block)
+        }))
     }
 }
 
-fn parse_input(input: TokenStream, attr_name: &str) -> Result<syn::ItemFn> {
-    let function: syn::ItemFn = syn::parse(input).map_err(syn_to_diag)
-        .map_err(|diag| diag.help(format!("`#[{}]` can only be applied to async functions", attr_name)))?;
+struct Test;
 
-    if function.sig.asyncness.is_none() {
-        return Err(Span::call_site().error(format!("`#[{}]` can only be applied to async functions", attr_name)))
+impl EntryAttr for Test {
+    const REQUIRES_ASYNC: bool = true;
+
+    fn function(f: &syn::ItemFn, block: &syn::Block) -> Result<TokenStream2> {
+        let (vis, mut sig) = (&f.vis, f.sig.clone());
+        sig.asyncness = None;
+        Ok(quote_spanned!(block.span().into() => #[test] #vis #sig {
+            ::rocket::async_test(async move #block)
+        }))
+    }
+}
+
+struct Launch;
+
+impl EntryAttr for Launch {
+    const REQUIRES_ASYNC: bool = false;
+
+    fn function(f: &syn::ItemFn, block: &syn::Block) -> Result<TokenStream2> {
+        if f.sig.ident == "main" {
+            return Err(Span::call_site()
+                .error("attribute cannot be applied to `main` function")
+                .note("this attribute generates a `main` function")
+                .span_note(f.sig.span(), "this function cannot be `main`"));
+        }
+
+        let ty = match &f.sig.output {
+            syn::ReturnType::Type(_, ty) => ty,
+            _ => return Err(Span::call_site()
+                .error("attribute can only be applied to functions that return a value")
+                .span_note(f.sig.span(), "this function must return a value"))
+        };
+
+        let (vis, mut sig) = (&f.vis, f.sig.clone());
+        sig.ident = syn::Ident::new("main", sig.ident.span());
+        sig.output = syn::ReturnType::Default;
+        sig.asyncness = None;
+
+        let rocket = quote_spanned!(ty.span().into() => {
+            let ___rocket: #ty = #block;
+            let ___rocket: ::rocket::Rocket = ___rocket;
+            ___rocket
+        });
+
+        if f.sig.asyncness.is_some() {
+            Ok(quote_spanned!(block.span().into() => #vis #sig {
+                ::rocket::async_main(async move {
+                    let _ = #rocket.launch().await;
+                })
+            } #[allow(dead_code)] #f))
+        } else {
+            Ok(quote_spanned!(block.span().into() => #vis #sig {
+                ::rocket::async_main({
+                    let ___rocket = #rocket;
+                    async move { let _ = ___rocket.launch().await; }
+                })
+            } #[allow(dead_code)] #f))
+        }
+    }
+}
+
+fn parse_input<A: EntryAttr>(input: TokenStream) -> Result<syn::ItemFn> {
+    let function: syn::ItemFn = syn::parse(input)
+        .map_err(syn_to_diag)
+        .map_err(|d| d.help("attribute can only be applied to functions"))?;
+
+    if A::REQUIRES_ASYNC && function.sig.asyncness.is_none() {
+        return Err(Span::call_site()
+            .error("attribute can only be applied to `async` functions")
+            .span_note(function.sig.span(), "this function must be `async`"));
     }
 
     if !function.sig.inputs.is_empty() {
-        return Err(Span::call_site().error(format!("`#[{}]` can only be applied to functions with no parameters", attr_name)));
+        return Err(Span::call_site()
+            .error("attribute can only be applied to functions without arguments")
+            .span_note(function.sig.span(), "this function must take no arguments"));
     }
 
     Ok(function)
 }
 
-fn _async_entry(_args: TokenStream, input: TokenStream, kind: Kind) -> Result<TokenStream> {
-    let function = parse_input(input, kind.attr_name())?;
-
-    let attrs = &function.attrs;
-    let vis = &function.vis;
-    let name = &function.sig.ident;
-    let output = &function.sig.output;
-    let body = &function.block;
-
-    let test_attr = kind.attrs();
-    let fn_path = kind.fn_path();
-
-    Ok(quote! {
-        #test_attr
-        #(#attrs)*
-        #vis fn #name() #output {
-            #fn_path (async move {
-                #body
-            })
-        }
-    }.into())
+fn _async_entry<A: EntryAttr>(_args: TokenStream, input: TokenStream) -> Result<TokenStream> {
+    let function = parse_input::<A>(input)?;
+    let (original_attrs, block) = (&function.attrs, &function.block);
+    let new_fn = A::function(&function, block)?;
+    Ok(quote!(#(#original_attrs)* #new_fn).into())
 }
 
 pub fn async_test_attribute(args: TokenStream, input: TokenStream) -> TokenStream {
-    _async_entry(args, input, Kind::Test).unwrap_or_else(|d| { d.emit(); TokenStream::new() })
+    _async_entry::<Test>(args, input).unwrap_or_else(|d| { d.emit(); TokenStream::new() })
 }
 
 pub fn main_attribute(args: TokenStream, input: TokenStream) -> TokenStream {
-    _async_entry(args, input, Kind::Main).unwrap_or_else(|d| { d.emit(); TokenStream::new() })
+    _async_entry::<Main>(args, input).unwrap_or_else(|d| { d.emit(); quote!(fn main() {}).into() })
+}
+
+pub fn launch_attribute(args: TokenStream, input: TokenStream) -> TokenStream {
+    _async_entry::<Launch>(args, input).unwrap_or_else(|d| { d.emit(); quote!(fn main() {}).into() })
 }

--- a/core/codegen/src/lib.rs
+++ b/core/codegen/src/lib.rs
@@ -405,14 +405,22 @@ pub fn catch(args: TokenStream, input: TokenStream) -> TokenStream {
     emit!(attribute::catch::catch_attribute(args, input))
 }
 
+/// FIXME: Document.
 #[proc_macro_attribute]
 pub fn async_test(args: TokenStream, input: TokenStream) -> TokenStream {
     emit!(attribute::async_entry::async_test_attribute(args, input))
 }
 
+/// FIXME: Document.
 #[proc_macro_attribute]
 pub fn main(args: TokenStream, input: TokenStream) -> TokenStream {
     emit!(attribute::async_entry::main_attribute(args, input))
+}
+
+/// FIXME: Document.
+#[proc_macro_attribute]
+pub fn launch(args: TokenStream, input: TokenStream) -> TokenStream {
+    emit!(attribute::async_entry::launch_attribute(args, input))
 }
 
 /// Derive for the [`FromFormValue`] trait.

--- a/core/codegen/tests/async-entry.rs
+++ b/core/codegen/tests/async-entry.rs
@@ -1,0 +1,76 @@
+#![allow(dead_code, unused_variables)]
+
+mod a {
+    // async launch that uses async.
+    #[rocket::launch]
+    async fn rocket() -> rocket::Rocket {
+        let _ = rocket::ignite().launch().await;
+        rocket::ignite()
+    }
+
+    async fn use_it() {
+        let rocket: rocket::Rocket = rocket().await;
+    }
+}
+
+mod b {
+    // async launch that doesn't use async.
+    #[rocket::launch]
+    async fn main2() -> rocket::Rocket {
+        rocket::ignite()
+    }
+
+    async fn use_it() {
+        let rocket: rocket::Rocket = main2().await;
+    }
+}
+
+mod c {
+    // non-async launch.
+    #[rocket::launch]
+    fn rocket() -> rocket::Rocket {
+        rocket::ignite()
+    }
+
+    fn use_it() {
+        let rocket: rocket::Rocket = rocket();
+    }
+}
+
+mod d {
+    // main with async, using async.
+    #[rocket::main]
+    async fn main() {
+        let _ = rocket::ignite().launch().await;
+    }
+}
+
+mod e {
+    // main with async, not using async.
+    #[rocket::main]
+    async fn main() { }
+}
+
+mod f {
+    // main with async, using async, with termination return.
+    #[rocket::main]
+    async fn main() -> Result<(), String> {
+        let result = rocket::ignite().launch().await;
+        result.map_err(|e| e.to_string())
+    }
+}
+
+mod g {
+    // main with async, not using async, with termination return.
+    #[rocket::main]
+    async fn main() -> Result<(), String> {
+        Ok(())
+    }
+}
+
+// main with async, using async, with termination return.
+#[rocket::main]
+async fn main() -> Result<(), String> {
+    let result = rocket::ignite().launch().await;
+    result.map_err(|e| e.to_string())
+}

--- a/core/codegen/tests/async-entry.rs
+++ b/core/codegen/tests/async-entry.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code, unused_variables)]
 
 mod a {
-    // async launch that uses async.
+    // async launch that is async.
     #[rocket::launch]
     async fn rocket() -> rocket::Rocket {
         let _ = rocket::ignite().launch().await;
@@ -14,7 +14,7 @@ mod a {
 }
 
 mod b {
-    // async launch that doesn't use async.
+    // async launch that isn't async.
     #[rocket::launch]
     async fn main2() -> rocket::Rocket {
         rocket::ignite()
@@ -38,7 +38,7 @@ mod c {
 }
 
 mod d {
-    // main with async, using async.
+    // main with async, is async.
     #[rocket::main]
     async fn main() {
         let _ = rocket::ignite().launch().await;
@@ -46,13 +46,13 @@ mod d {
 }
 
 mod e {
-    // main with async, not using async.
+    // main with async, isn't async.
     #[rocket::main]
     async fn main() { }
 }
 
 mod f {
-    // main with async, using async, with termination return.
+    // main with async, is async, with termination return.
     #[rocket::main]
     async fn main() -> Result<(), String> {
         let result = rocket::ignite().launch().await;
@@ -61,14 +61,14 @@ mod f {
 }
 
 mod g {
-    // main with async, not using async, with termination return.
+    // main with async, isn't async, with termination return.
     #[rocket::main]
     async fn main() -> Result<(), String> {
         Ok(())
     }
 }
 
-// main with async, using async, with termination return.
+// main with async, is async, with termination return.
 #[rocket::main]
 async fn main() -> Result<(), String> {
     let result = rocket::ignite().launch().await;

--- a/core/codegen/tests/ui-fail/async-entry.rs
+++ b/core/codegen/tests/ui-fail/async-entry.rs
@@ -1,0 +1,109 @@
+#![allow(dead_code)]
+
+// rocket::main
+
+mod main_a {
+    #[rocket::main]
+    fn foo() { }
+    //~^^ ERROR `async`
+}
+
+mod main_b {
+    #[rocket::main]
+    async fn foo() { }
+    //~^^ ERROR `main`
+}
+
+mod main_d {
+    #[rocket::main]
+    fn main() {
+        //~^^ ERROR `async`
+        let _ = rocket::ignite().launch().await;
+    }
+}
+
+mod main_f {
+    #[rocket::main]
+    async fn main() {
+        //~^ ERROR mismatched types
+        rocket::ignite()
+    }
+}
+
+// rocket::launch
+
+mod launch_a {
+    #[rocket::launch]
+    async fn rocket() -> String {
+        //~^ ERROR mismatched types
+        let _ = rocket::ignite().launch().await;
+        rocket::ignite()
+        //~^ ERROR mismatched types
+    }
+}
+
+mod launch_b {
+    #[rocket::launch]
+    async fn rocket() -> rocket::Rocket {
+        let _ = rocket::ignite().launch().await;
+        "hi".to_string()
+        //~^ ERROR mismatched types
+    }
+}
+
+mod launch_c {
+    #[rocket::launch]
+    fn main() -> rocket::Rocket {
+        //~^^ ERROR `main`
+        rocket::ignite()
+    }
+}
+
+mod launch_d {
+    #[rocket::launch]
+    async fn rocket() {
+        //~^^ ERROR functions that return
+        let _ = rocket::ignite().launch().await;
+        rocket::ignite()
+    }
+}
+
+mod launch_e {
+    #[rocket::launch]
+    fn rocket() {
+        //~^^ ERROR functions that return
+        rocket::ignite()
+    }
+}
+
+mod launch_f {
+    #[rocket::launch]
+    fn rocket() -> rocket::Rocket {
+        let _ = rocket::ignite().launch().await;
+        //~^ ERROR only allowed inside `async`
+        rocket::ignite()
+    }
+}
+
+mod launch_g {
+    #[rocket::launch]
+    fn main() -> &'static str {
+        //~^^ ERROR `main`
+        let _ = rocket::ignite().launch().await;
+        "hi"
+    }
+}
+
+mod launch_h {
+    #[rocket::launch]
+    async fn main() -> rocket::Rocket {
+        //~^^ ERROR `main`
+        rocket::ignite()
+    }
+}
+
+#[rocket::main]
+async fn main() -> rocket::Rocket {
+    //~^ ERROR invalid return type
+    rocket::ignite()
+}

--- a/core/codegen/tests/ui-fail/async-entry.rs
+++ b/core/codegen/tests/ui-fail/async-entry.rs
@@ -11,7 +11,7 @@ mod main_a {
 mod main_b {
     #[rocket::main]
     async fn foo() { }
-    //~^^ ERROR `main`
+    //~^^ WARNING `main`
 }
 
 mod main_d {

--- a/core/codegen/tests/ui-fail/async-entry.stderr
+++ b/core/codegen/tests/ui-fail/async-entry.stderr
@@ -1,0 +1,162 @@
+error: attribute can only be applied to `async` functions
+ --> $DIR/async-entry.rs:6:5
+  |
+6 |     #[rocket::main]
+  |     ^^^^^^^^^^^^^^^
+  |
+note: this function must be `async`
+ --> $DIR/async-entry.rs:7:5
+  |
+7 |     fn foo() { }
+  |     ^^^^^^^^
+  = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: attribute can only be applied to `main` function
+  --> $DIR/async-entry.rs:12:5
+   |
+12 |     #[rocket::main]
+   |     ^^^^^^^^^^^^^^^
+   |
+note: this function must be `main`
+  --> $DIR/async-entry.rs:13:5
+   |
+13 |     async fn foo() { }
+   |     ^^^^^^^^^^^^^^
+   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: attribute can only be applied to `async` functions
+  --> $DIR/async-entry.rs:18:5
+   |
+18 |     #[rocket::main]
+   |     ^^^^^^^^^^^^^^^
+   |
+note: this function must be `async`
+  --> $DIR/async-entry.rs:19:5
+   |
+19 |     fn main() {
+   |     ^^^^^^^^^
+   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: attribute cannot be applied to `main` function
+  --> $DIR/async-entry.rs:55:5
+   |
+55 |     #[rocket::launch]
+   |     ^^^^^^^^^^^^^^^^^
+   |
+   = note: this attribute generates a `main` function
+note: this function cannot be `main`
+  --> $DIR/async-entry.rs:56:5
+   |
+56 |     fn main() -> rocket::Rocket {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: attribute can only be applied to functions that return a value
+  --> $DIR/async-entry.rs:63:5
+   |
+63 |     #[rocket::launch]
+   |     ^^^^^^^^^^^^^^^^^
+   |
+note: this function must return a value
+  --> $DIR/async-entry.rs:64:5
+   |
+64 |     async fn rocket() {
+   |     ^^^^^^^^^^^^^^^^^
+   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: attribute can only be applied to functions that return a value
+  --> $DIR/async-entry.rs:72:5
+   |
+72 |     #[rocket::launch]
+   |     ^^^^^^^^^^^^^^^^^
+   |
+note: this function must return a value
+  --> $DIR/async-entry.rs:73:5
+   |
+73 |     fn rocket() {
+   |     ^^^^^^^^^^^
+   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: attribute cannot be applied to `main` function
+  --> $DIR/async-entry.rs:89:5
+   |
+89 |     #[rocket::launch]
+   |     ^^^^^^^^^^^^^^^^^
+   |
+   = note: this attribute generates a `main` function
+note: this function cannot be `main`
+  --> $DIR/async-entry.rs:90:5
+   |
+90 |     fn main() -> &'static str {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: attribute cannot be applied to `main` function
+  --> $DIR/async-entry.rs:98:5
+   |
+98 |     #[rocket::launch]
+   |     ^^^^^^^^^^^^^^^^^
+   |
+   = note: this attribute generates a `main` function
+note: this function cannot be `main`
+  --> $DIR/async-entry.rs:99:5
+   |
+99 |     async fn main() -> rocket::Rocket {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0728]: `await` is only allowed inside `async` functions and blocks
+  --> $DIR/async-entry.rs:82:17
+   |
+81 |     fn rocket() -> rocket::Rocket {
+   |        ------ this is not `async`
+82 |         let _ = rocket::ignite().launch().await;
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ only allowed inside `async` functions and blocks
+
+error[E0308]: mismatched types
+  --> $DIR/async-entry.rs:40:9
+   |
+40 |         rocket::ignite()
+   |         ^^^^^^^^^^^^^^^^ expected struct `std::string::String`, found struct `rocket::rocket::Rocket`
+
+error[E0308]: mismatched types
+  --> $DIR/async-entry.rs:49:9
+   |
+49 |         "hi".to_string()
+   |         ^^^^^^^^^^^^^^^^ expected struct `rocket::rocket::Rocket`, found struct `std::string::String`
+
+error[E0308]: mismatched types
+  --> $DIR/async-entry.rs:27:21
+   |
+27 |       async fn main() {
+   |                       ^ expected `()` because of default return type
+   |  _____________________|
+   | |
+28 | |         //~^ ERROR mismatched types
+29 | |         rocket::ignite()
+30 | |     }
+   | |     ^- help: try adding a semicolon: `;`
+   | |_____|
+   |       expected `()`, found struct `rocket::rocket::Rocket`
+
+error[E0308]: mismatched types
+  --> $DIR/async-entry.rs:37:26
+   |
+37 |     async fn rocket() -> String {
+   |                          ^^^^^^
+   |                          |
+   |                          expected struct `rocket::rocket::Rocket`, found struct `std::string::String`
+   |                          expected due to this
+
+error[E0277]: `main` has invalid return type `rocket::rocket::Rocket`
+   --> $DIR/async-entry.rs:106:20
+    |
+106 | async fn main() -> rocket::Rocket {
+    |                    ^^^^^^^^^^^^^^ `main` can only return types that implement `std::process::Termination`
+    |
+    = help: consider using `()`, or a `Result`
+
+error: aborting due to 14 previous errors
+
+Some errors have detailed explanations: E0277, E0308, E0728.
+For more information about an error, try `rustc --explain E0277`.

--- a/core/codegen/tests/ui-fail/async-entry.stderr
+++ b/core/codegen/tests/ui-fail/async-entry.stderr
@@ -11,18 +11,18 @@ note: this function must be `async`
   |     ^^^^^^^^
   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: attribute can only be applied to `main` function
+warning: attribute is typically applied to `main` function
   --> $DIR/async-entry.rs:12:5
    |
 12 |     #[rocket::main]
    |     ^^^^^^^^^^^^^^^
    |
-note: this function must be `main`
+note: this function is not `main`
   --> $DIR/async-entry.rs:13:5
    |
 13 |     async fn foo() { }
    |     ^^^^^^^^^^^^^^
-   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: attribute can only be applied to `async` functions
   --> $DIR/async-entry.rs:18:5
@@ -156,7 +156,7 @@ error[E0277]: `main` has invalid return type `rocket::rocket::Rocket`
     |
     = help: consider using `()`, or a `Result`
 
-error: aborting due to 14 previous errors
+error: aborting due to 13 previous errors; 1 warning emitted
 
 Some errors have detailed explanations: E0277, E0308, E0728.
 For more information about an error, try `rustc --explain E0277`.

--- a/core/lib/src/catcher.rs
+++ b/core/lib/src/catcher.rs
@@ -52,11 +52,11 @@ use yansi::Color::*;
 ///     format!("I couldn't find '{}'. Try something else?", req.uri())
 /// }
 ///
-/// #[rocket::main]
-/// async fn main() {
-/// # if false { // We don't actually want to launch the server in an example.
-///     rocket::ignite().register(catchers![internal_error, not_found]).launch().await;
-/// # }
+/// # /*
+/// #[rocket::launch]
+/// # */
+/// fn rocket() -> rocket::Rocket {
+///     rocket::ignite().register(catchers![internal_error, not_found])
 /// }
 /// ```
 ///

--- a/core/lib/src/catcher.rs
+++ b/core/lib/src/catcher.rs
@@ -35,7 +35,7 @@ use yansi::Color::*;
 /// Catchers should rarely be used directly. Instead, they are typically
 /// declared using the `catch` decorator, as follows:
 ///
-/// ```rust
+/// ```rust,no_run
 /// #![feature(proc_macro_hygiene)]
 ///
 /// #[macro_use] extern crate rocket;
@@ -52,9 +52,7 @@ use yansi::Color::*;
 ///     format!("I couldn't find '{}'. Try something else?", req.uri())
 /// }
 ///
-/// # /*
 /// #[rocket::launch]
-/// # */
 /// fn rocket() -> rocket::Rocket {
 ///     rocket::ignite().register(catchers![internal_error, not_found])
 /// }

--- a/core/lib/src/handler.rs
+++ b/core/lib/src/handler.rs
@@ -65,14 +65,11 @@ pub type HandlerFuture<'r> = BoxFuture<'r, Outcome<'r>>;
 ///     }
 /// }
 ///
-/// #[rocket::main]
-/// async fn main() {
-/// # if false {
-///     rocket::ignite()
-///         .mount("/", CustomHandler(Kind::Simple))
-///         .launch()
-///         .await;
-/// # }
+/// # /*
+/// #[rocket::launch]
+/// # */
+/// fn rocket() -> rocket::Rocket {
+///     rocket::ignite().mount("/", CustomHandler(Kind::Simple))
 /// }
 /// ```
 ///
@@ -114,15 +111,13 @@ pub type HandlerFuture<'r> = BoxFuture<'r, Outcome<'r>>;
 ///     }
 /// }
 ///
-/// #[rocket::main]
-/// async fn main() {
-/// # if false {
+/// # /*
+/// #[rocket::launch]
+/// # */
+/// fn rocket() -> rocket::Rocket {
 ///     rocket::ignite()
 ///         .mount("/", routes![custom_handler])
 ///         .manage(Kind::Simple)
-///         .launch()
-///         .await;
-/// # }
 /// }
 /// ```
 ///

--- a/core/lib/src/handler.rs
+++ b/core/lib/src/handler.rs
@@ -41,7 +41,7 @@ pub type HandlerFuture<'r> = BoxFuture<'r, Outcome<'r>>;
 ///
 /// Such a handler might be written and used as follows:
 ///
-/// ```rust
+/// ```rust,no_run
 /// # #[derive(Copy, Clone)] enum Kind { Simple, Intermediate, Complex, }
 /// use rocket::{Request, Data, Route, http::Method};
 /// use rocket::handler::{self, Handler, Outcome, HandlerFuture};
@@ -65,9 +65,7 @@ pub type HandlerFuture<'r> = BoxFuture<'r, Outcome<'r>>;
 ///     }
 /// }
 ///
-/// # /*
 /// #[rocket::launch]
-/// # */
 /// fn rocket() -> rocket::Rocket {
 ///     rocket::ignite().mount("/", CustomHandler(Kind::Simple))
 /// }
@@ -89,7 +87,7 @@ pub type HandlerFuture<'r> = BoxFuture<'r, Outcome<'r>>;
 /// The previous example could have been implemented using a combination of
 /// managed state and a static route, as follows:
 ///
-/// ```rust
+/// ```rust,no_run
 /// # #![feature(proc_macro_hygiene)]
 /// # #[macro_use] extern crate rocket;
 /// #
@@ -111,9 +109,7 @@ pub type HandlerFuture<'r> = BoxFuture<'r, Outcome<'r>>;
 ///     }
 /// }
 ///
-/// # /*
 /// #[rocket::launch]
-/// # */
 /// fn rocket() -> rocket::Rocket {
 ///     rocket::ignite()
 ///         .mount("/", routes![custom_handler])

--- a/core/lib/src/lib.rs
+++ b/core/lib/src/lib.rs
@@ -67,11 +67,11 @@
 //!     "Hello, world!"
 //! }
 //!
-//! #[rocket::main]
-//! async fn main() {
-//! # if false { // We don't actually want to launch the server in an example.
-//!     rocket::ignite().mount("/", routes![hello]).launch().await;
-//! # }
+//! # /*
+//! #[rocket::launch]
+//! # */
+//! fn rocket() -> rocket::Rocket {
+//!     rocket::ignite().mount("/", routes![hello])
 //! }
 //! ```
 //!

--- a/core/lib/src/lib.rs
+++ b/core/lib/src/lib.rs
@@ -57,7 +57,7 @@
 //! See the [guide](https://rocket.rs/v0.5/guide) for more information on how to
 //! write Rocket applications. Here's a simple example to get you started:
 //!
-//! ```rust
+//! ```rust,no_run
 //! #![feature(proc_macro_hygiene)]
 //!
 //! #[macro_use] extern crate rocket;
@@ -67,9 +67,7 @@
 //!     "Hello, world!"
 //! }
 //!
-//! # /*
 //! #[rocket::launch]
-//! # */
 //! fn rocket() -> rocket::Rocket {
 //!     rocket::ignite().mount("/", routes![hello])
 //! }

--- a/core/lib/src/request/state.rs
+++ b/core/lib/src/request/state.rs
@@ -21,7 +21,7 @@ use crate::http::Status;
 /// like to initialize at start-up and later access it in several handlers. The
 /// following example does just this:
 ///
-/// ```rust
+/// ```rust,no_run
 /// # #![feature(proc_macro_hygiene)]
 /// # #[macro_use] extern crate rocket;
 /// use rocket::State;
@@ -42,9 +42,7 @@ use crate::http::Status;
 ///     state.inner().user_val.as_str()
 /// }
 ///
-/// # /*
 /// #[rocket::launch]
-/// # */
 /// fn rocket() -> rocket::Rocket {
 ///     rocket::ignite()
 ///         .mount("/", routes![index, raw_config_value])

--- a/core/lib/src/request/state.rs
+++ b/core/lib/src/request/state.rs
@@ -42,19 +42,13 @@ use crate::http::Status;
 ///     state.inner().user_val.as_str()
 /// }
 ///
-/// #[rocket::main]
-/// async fn main() {
-///     let config = MyConfig {
-///         user_val: "user input".to_string()
-///     };
-///
-/// # if false { // We don't actually want to launch the server in an example.
+/// # /*
+/// #[rocket::launch]
+/// # */
+/// fn rocket() -> rocket::Rocket {
 ///     rocket::ignite()
 ///         .mount("/", routes![index, raw_config_value])
-///         .manage(config)
-///         .launch()
-///         .await;
-/// # }
+///         .manage(MyConfig { user_val: "user input".to_string() })
 /// }
 /// ```
 ///

--- a/core/lib/src/response/flash.rs
+++ b/core/lib/src/response/flash.rs
@@ -41,8 +41,8 @@ const FLASH_COOKIE_NAME: &str = "_flash";
 ///
 /// # Example
 ///
-/// The following complete Rocket application illustrates the use of a `Flash`
-/// message on both the request and response sides.
+/// The following routes illustrate the use of a `Flash` message on both the
+/// request and response sides.
 ///
 /// ```rust
 /// # #![feature(proc_macro_hygiene)]
@@ -64,13 +64,6 @@ const FLASH_COOKIE_NAME: &str = "_flash";
 /// fn index(flash: Option<FlashMessage>) -> String {
 ///     flash.map(|msg| format!("{}: {}", msg.name(), msg.msg()))
 ///          .unwrap_or_else(|| "Welcome!".to_string())
-/// }
-///
-/// #[rocket::main]
-/// async fn main() {
-/// # if false { // We don't actually want to launch the server in an example.
-///     rocket::ignite().mount("/", routes![login, index]).launch().await;
-/// # }
 /// }
 /// ```
 ///

--- a/core/lib/src/rocket.rs
+++ b/core/lib/src/rocket.rs
@@ -625,7 +625,7 @@ impl Rocket {
     /// generation facilities. Requests to the `/hello/world` URI will be
     /// dispatched to the `hi` route.
     ///
-    /// ```rust
+    /// ```rust,no_run
     /// # #![feature(proc_macro_hygiene)]
     /// # #[macro_use] extern crate rocket;
     /// #
@@ -634,9 +634,7 @@ impl Rocket {
     ///     "Hello!"
     /// }
     ///
-    /// # /*
     /// #[rocket::launch]
-    /// # */
     /// fn rocket() -> rocket::Rocket {
     ///     rocket::ignite().mount("/hello", routes![hi])
     /// }
@@ -681,7 +679,7 @@ impl Rocket {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```rust,no_run
     /// # #![feature(proc_macro_hygiene)]
     /// # #[macro_use] extern crate rocket;
     /// use rocket::Request;
@@ -696,9 +694,7 @@ impl Rocket {
     ///     format!("I couldn't find '{}'. Try something else?", req.uri())
     /// }
     ///
-    /// # /*
     /// #[rocket::launch]
-    /// # */
     /// fn rocket() -> rocket::Rocket {
     ///     rocket::ignite().register(catchers![internal_error, not_found])
     /// }
@@ -725,7 +721,7 @@ impl Rocket {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```rust,no_run
     /// # #![feature(proc_macro_hygiene)]
     /// # #[macro_use] extern crate rocket;
     /// use rocket::State;
@@ -737,9 +733,7 @@ impl Rocket {
     ///     format!("The stateful value is: {}", state.0)
     /// }
     ///
-    /// # /*
     /// #[rocket::launch]
-    /// # */
     /// fn rocket() -> rocket::Rocket {
     ///     rocket::ignite()
     ///         .mount("/", routes![index])
@@ -766,15 +760,13 @@ impl Rocket {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```rust,no_run
     /// # #![feature(proc_macro_hygiene)]
     /// # #[macro_use] extern crate rocket;
     /// use rocket::Rocket;
     /// use rocket::fairing::AdHoc;
     ///
-    /// # /*
     /// #[rocket::launch]
-    /// # */
     /// fn rocket() -> rocket::Rocket {
     ///     rocket::ignite()
     ///         .attach(AdHoc::on_launch("Launch Message", |_| {
@@ -1097,15 +1089,13 @@ impl Manifest {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```rust,no_run
     /// # #![feature(proc_macro_hygiene)]
     /// # #[macro_use] extern crate rocket;
     /// use rocket::Rocket;
     /// use rocket::fairing::AdHoc;
     ///
-    /// # /*
     /// #[rocket::launch]
-    /// # */
     /// fn rocket() -> rocket::Rocket {
     ///     rocket::ignite()
     ///         .attach(AdHoc::on_launch("Config Printer", |manifest| {

--- a/core/lib/src/rocket.rs
+++ b/core/lib/src/rocket.rs
@@ -634,12 +634,11 @@ impl Rocket {
     ///     "Hello!"
     /// }
     ///
-    /// #[rocket::main]
-    /// async fn main() {
-    /// # if false { // We don't actually want to launch the server in an example.
+    /// # /*
+    /// #[rocket::launch]
+    /// # */
+    /// fn rocket() -> rocket::Rocket {
     ///     rocket::ignite().mount("/hello", routes![hi])
-    /// #       .launch().await;
-    /// # }
     /// }
     /// ```
     ///
@@ -697,13 +696,11 @@ impl Rocket {
     ///     format!("I couldn't find '{}'. Try something else?", req.uri())
     /// }
     ///
-    /// #[rocket::main]
-    /// async fn main() {
-    /// # if false { // We don't actually want to launch the server in an example.
-    ///     rocket::ignite()
-    ///         .register(catchers![internal_error, not_found])
-    /// #       .launch().await;
-    /// # }
+    /// # /*
+    /// #[rocket::launch]
+    /// # */
+    /// fn rocket() -> rocket::Rocket {
+    ///     rocket::ignite().register(catchers![internal_error, not_found])
     /// }
     /// ```
     #[inline]
@@ -740,15 +737,13 @@ impl Rocket {
     ///     format!("The stateful value is: {}", state.0)
     /// }
     ///
-    /// #[rocket::main]
-    /// async fn main() {
-    /// # if false { // We don't actually want to launch the server in an example.
+    /// # /*
+    /// #[rocket::launch]
+    /// # */
+    /// fn rocket() -> rocket::Rocket {
     ///     rocket::ignite()
     ///         .mount("/", routes![index])
     ///         .manage(MyValue(10))
-    ///         .launch()
-    ///         .await;
-    /// # }
     /// }
     /// ```
     #[inline]
@@ -777,16 +772,14 @@ impl Rocket {
     /// use rocket::Rocket;
     /// use rocket::fairing::AdHoc;
     ///
-    /// #[rocket::main]
-    /// async fn main() {
-    /// # if false { // We don't actually want to launch the server in an example.
+    /// # /*
+    /// #[rocket::launch]
+    /// # */
+    /// fn rocket() -> rocket::Rocket {
     ///     rocket::ignite()
     ///         .attach(AdHoc::on_launch("Launch Message", |_| {
     ///             println!("Rocket is launching!");
     ///         }))
-    ///         .launch()
-    ///         .await;
-    /// # }
     /// }
     /// ```
     #[inline]
@@ -1110,16 +1103,14 @@ impl Manifest {
     /// use rocket::Rocket;
     /// use rocket::fairing::AdHoc;
     ///
-    /// #[rocket::main]
-    /// async fn main() {
-    /// # if false { // We don't actually want to launch the server in an example.
+    /// # /*
+    /// #[rocket::launch]
+    /// # */
+    /// fn rocket() -> rocket::Rocket {
     ///     rocket::ignite()
     ///         .attach(AdHoc::on_launch("Config Printer", |manifest| {
     ///             println!("Rocket launch config: {:?}", manifest.config());
     ///         }))
-    ///         .launch()
-    ///         .await;
-    /// # }
     /// }
     /// ```
     #[inline(always)]

--- a/core/lib/src/shutdown.rs
+++ b/core/lib/src/shutdown.rs
@@ -12,7 +12,7 @@ use tokio::sync::mpsc;
 ///
 /// # Example
 ///
-/// ```rust
+/// ```rust,no_run
 /// # #![feature(proc_macro_hygiene)]
 /// # #[macro_use] extern crate rocket;
 /// #
@@ -26,15 +26,13 @@ use tokio::sync::mpsc;
 ///
 /// #[rocket::main]
 /// async fn main() {
-///     # if false {
 ///     let result = rocket::ignite()
 ///         .mount("/", routes![shutdown])
 ///         .launch()
 ///         .await;
 ///
-///     // If there server shut down (by visting `/shutdown`), `result` is `Ok`.
+///     // If the server shut down (by visting `/shutdown`), `result` is `Ok`.
 ///     result.expect("server failed unexpectedly");
-///     # }
 /// }
 /// ```
 #[derive(Debug, Clone)]

--- a/core/lib/src/shutdown.rs
+++ b/core/lib/src/shutdown.rs
@@ -27,11 +27,13 @@ use tokio::sync::mpsc;
 /// #[rocket::main]
 /// async fn main() {
 ///     # if false {
-///     rocket::ignite()
+///     let result = rocket::ignite()
 ///         .mount("/", routes![shutdown])
 ///         .launch()
-///         .await
-///         .expect("server failed unexpectedly");
+///         .await;
+///
+///     // If there server shut down (by visting `/shutdown`), `result` is `Ok`.
+///     result.expect("server failed unexpectedly");
 ///     # }
 /// }
 /// ```

--- a/examples/config/src/main.rs
+++ b/examples/config/src/main.rs
@@ -1,5 +1,3 @@
 // This example's illustration is the Rocket.toml file.
-#[rocket::main]
-async fn main() {
-    let _ = rocket::ignite().launch().await;
-}
+#[rocket::launch]
+fn rocket() -> rocket::Rocket { rocket::ignite() }

--- a/examples/content_types/src/main.rs
+++ b/examples/content_types/src/main.rs
@@ -63,10 +63,9 @@ fn not_found(request: &Request<'_>) -> Html<String> {
     Html(html)
 }
 
-#[rocket::main]
-async fn main() {
-    let _ = rocket::ignite()
+#[rocket::launch]
+fn rocket() -> rocket::Rocket {
+    rocket::ignite()
         .mount("/hello", routes![get_hello, post_hello])
         .register(catchers![not_found])
-        .launch().await;
 }

--- a/examples/content_types/src/tests.rs
+++ b/examples/content_types/src/tests.rs
@@ -5,11 +5,7 @@ use rocket::local::Client;
 async fn test<H>(method: Method, uri: &str, header: H, status: Status, body: String)
     where H: Into<Header<'static>>
 {
-    let rocket = rocket::ignite()
-        .mount("/hello", routes![super::get_hello, super::post_hello])
-        .register(catchers![super::not_found]);
-
-    let client = Client::new(rocket).await.unwrap();
+    let client = Client::new(super::rocket()).await.unwrap();
     let mut response = client.req(method, uri).header(header).dispatch().await;
     assert_eq!(response.status(), status);
     assert_eq!(response.body_string().await, Some(body));

--- a/examples/cookies/src/main.rs
+++ b/examples/cookies/src/main.rs
@@ -34,11 +34,7 @@ fn index(cookies: Cookies<'_>) -> Template {
     Template::render("index", &context)
 }
 
+#[rocket::launch]
 fn rocket() -> rocket::Rocket {
     rocket::ignite().mount("/", routes![submit, index]).attach(Template::fairing())
-}
-
-#[rocket::main]
-async fn main() {
-    let _ = rocket().launch().await;
 }

--- a/examples/fairings/src/main.rs
+++ b/examples/fairings/src/main.rs
@@ -63,6 +63,7 @@ fn token(token: State<'_, Token>) -> String {
     format!("{}", token.0)
 }
 
+#[rocket::launch]
 fn rocket() -> rocket::Rocket {
     rocket::ignite()
         .mount("/", routes![hello, token])
@@ -92,9 +93,4 @@ fn rocket() -> rocket::Rocket {
                 }
             })
         }))
-}
-
-#[rocket::main]
-async fn main() {
-    let _ = rocket().launch().await;
 }

--- a/examples/form_kitchen_sink/src/main.rs
+++ b/examples/form_kitchen_sink/src/main.rs
@@ -41,11 +41,7 @@ fn index() -> Option<NamedFile> {
     NamedFile::open("static/index.html").ok()
 }
 
+#[rocket::launch]
 fn rocket() -> rocket::Rocket {
     rocket::ignite().mount("/", routes![index, sink])
-}
-
-#[rocket::main]
-async fn main() {
-    let _ = rocket().launch().await;
 }

--- a/examples/form_validation/src/main.rs
+++ b/examples/form_validation/src/main.rs
@@ -76,12 +76,8 @@ fn user_page(username: &RawStr) -> String {
     format!("This is {}'s page.", username)
 }
 
+#[rocket::launch]
 fn rocket() -> rocket::Rocket {
     rocket::ignite()
         .mount("/", routes![files::index, files::files, user_page, login])
-}
-
-#[rocket::main]
-async fn main() {
-    let _ = rocket().launch().await;
 }

--- a/examples/handlebars_templates/src/main.rs
+++ b/examples/handlebars_templates/src/main.rs
@@ -68,6 +68,7 @@ fn wow_helper(
     Ok(())
 }
 
+#[rocket::launch]
 fn rocket() -> rocket::Rocket {
     rocket::ignite()
         .mount("/", routes![index, hello, about])
@@ -75,9 +76,4 @@ fn rocket() -> rocket::Rocket {
         .attach(Template::custom(|engines| {
             engines.handlebars.register_helper("wow", Box::new(wow_helper));
         }))
-}
-
-#[rocket::main]
-async fn main() {
-    let _ = rocket().launch().await;
 }

--- a/examples/hello_2018/src/main.rs
+++ b/examples/hello_2018/src/main.rs
@@ -1,15 +1,11 @@
-#![feature(proc_macro_hygiene)]
-
 #[cfg(test)] mod tests;
 
-use rocket::{get, routes};
-
-#[get("/")]
+#[rocket::get("/")]
 fn hello() -> &'static str {
     "Hello, Rust 2018!"
 }
 
-#[rocket::main]
-async fn main() {
-    let _ = rocket::ignite().mount("/", routes![hello]).launch().await;
+#[rocket::launch]
+fn rocket() -> rocket::Rocket {
+    rocket::ignite().mount("/", rocket::routes![hello])
 }

--- a/examples/hello_2018/src/tests.rs
+++ b/examples/hello_2018/src/tests.rs
@@ -1,9 +1,8 @@
-use rocket::{self, routes, local::Client};
+use rocket::{self, local::Client};
 
 #[rocket::async_test]
 async fn hello_world() {
-    let rocket = rocket::ignite().mount("/", routes![super::hello]);
-    let client = Client::new(rocket).await.unwrap();
+    let client = Client::new(super::rocket()).await.unwrap();
     let mut response = client.get("/").dispatch().await;
     assert_eq!(response.body_string().await, Some("Hello, Rust 2018!".into()));
 }

--- a/examples/hello_person/src/main.rs
+++ b/examples/hello_person/src/main.rs
@@ -14,7 +14,7 @@ fn hi(name: String) -> String {
     name
 }
 
-#[rocket::main]
-async fn main() {
-    let _ = rocket::ignite().mount("/", routes![hello, hi]).launch().await;
+#[rocket::launch]
+fn rocket() -> rocket::Rocket {
+    rocket::ignite().mount("/", routes![hello, hi])
 }

--- a/examples/hello_person/src/tests.rs
+++ b/examples/hello_person/src/tests.rs
@@ -1,17 +1,13 @@
 use rocket::local::Client;
 use rocket::http::Status;
 
-async fn client() -> Client {
-    Client::new(rocket::ignite().mount("/", routes![super::hello, super::hi])).await.unwrap()
-}
-
 async fn test(uri: String, expected: String) {
-    let client = client().await;
+    let client = Client::new(super::rocket()).await.unwrap();
     assert_eq!(client.get(&uri).dispatch().await.body_string().await, Some(expected));
 }
 
 async fn test_404(uri: &'static str) {
-    let client = client().await;
+    let client = Client::new(super::rocket()).await.unwrap();
     assert_eq!(client.get(uri).dispatch().await.status(), Status::NotFound);
 }
 

--- a/examples/hello_world/src/main.rs
+++ b/examples/hello_world/src/main.rs
@@ -1,5 +1,3 @@
-#![feature(proc_macro_hygiene)]
-
 #[macro_use] extern crate rocket;
 
 #[cfg(test)] mod tests;
@@ -9,7 +7,7 @@ fn hello() -> &'static str {
     "Hello, world!"
 }
 
-#[rocket::main]
-async fn main() {
-    let _ = rocket::ignite().mount("/", routes![hello]).launch().await;
+#[launch]
+fn rocket() -> rocket::Rocket {
+    rocket::ignite().mount("/", routes![hello])
 }

--- a/examples/hello_world/src/tests.rs
+++ b/examples/hello_world/src/tests.rs
@@ -2,8 +2,7 @@ use rocket::local::Client;
 
 #[rocket::async_test]
 async fn hello_world() {
-    let rocket = rocket::ignite().mount("/", routes![super::hello]);
-    let client = Client::new(rocket).await.unwrap();
+    let client = Client::new(super::rocket()).await.unwrap();
     let mut response = client.get("/").dispatch().await;
     assert_eq!(response.body_string().await, Some("Hello, world!".into()));
 }

--- a/examples/json/src/main.rs
+++ b/examples/json/src/main.rs
@@ -69,14 +69,10 @@ fn not_found() -> JsonValue {
     })
 }
 
+#[rocket::launch]
 fn rocket() -> rocket::Rocket {
     rocket::ignite()
         .mount("/message", routes![new, update, get])
         .register(catchers![not_found])
         .manage(Mutex::new(HashMap::<ID, String>::new()))
-}
-
-#[rocket::main]
-async fn main() {
-    let _ = rocket().launch().await;
 }

--- a/examples/managed_queue/src/main.rs
+++ b/examples/managed_queue/src/main.rs
@@ -19,13 +19,9 @@ fn pop(queue: State<'_, LogChannel>) -> Option<String> {
     queue.0.pop().ok()
 }
 
+#[rocket::launch]
 fn rocket() -> rocket::Rocket {
     rocket::ignite()
         .mount("/", routes![push, pop])
         .manage(LogChannel(SegQueue::new()))
-}
-
-#[rocket::main]
-async fn main() {
-    let _ = rocket().launch().await;
 }

--- a/examples/manual_routes/src/main.rs
+++ b/examples/manual_routes/src/main.rs
@@ -98,6 +98,7 @@ impl Handler for CustomHandler {
     }
 }
 
+#[rocket::launch]
 fn rocket() -> rocket::Rocket {
     let always_forward = Route::ranked(1, Get, "/", forward);
     let hello = Route::ranked(2, Get, "/", hi);
@@ -116,9 +117,4 @@ fn rocket() -> rocket::Rocket {
         .mount("/hi", vec![name])
         .mount("/custom", CustomHandler::new("some data here"))
         .register(vec![not_found_catcher])
-}
-
-#[rocket::main]
-async fn main() {
-    let _ = rocket().launch().await;
 }

--- a/examples/msgpack/src/main.rs
+++ b/examples/msgpack/src/main.rs
@@ -23,11 +23,7 @@ fn create(data: MsgPack<Message<'_>>) -> String {
     data.contents.to_string()
 }
 
+#[rocket::launch]
 fn rocket() -> rocket::Rocket {
     rocket::ignite().mount("/message", routes![get, create])
-}
-
-#[rocket::main]
-async fn main() {
-    let _ = rocket().launch().await;
 }

--- a/examples/optional_redirect/src/main.rs
+++ b/examples/optional_redirect/src/main.rs
@@ -26,7 +26,7 @@ fn login() -> &'static str {
     "Hi! That user doesn't exist. Maybe you need to log in?"
 }
 
-#[rocket::main]
-async fn main() {
-    let _ = rocket::ignite().mount("/", routes![root, user, login]).launch().await;
+#[rocket::launch]
+fn rocket() -> rocket::Rocket {
+    rocket::ignite().mount("/", routes![root, user, login])
 }

--- a/examples/optional_redirect/src/tests.rs
+++ b/examples/optional_redirect/src/tests.rs
@@ -1,22 +1,15 @@
 use rocket::local::Client;
 use rocket::http::Status;
 
-async fn client() -> Client {
-    let rocket = rocket::ignite()
-        .mount("/", routes![super::root, super::user, super::login]);
-    Client::new(rocket).await.unwrap()
-
-}
-
 async fn test_200(uri: &str, expected_body: &str) {
-    let client = client().await;
+    let client = Client::new(super::rocket()).await.unwrap();
     let mut response = client.get(uri).dispatch().await;
     assert_eq!(response.status(), Status::Ok);
     assert_eq!(response.body_string().await, Some(expected_body.to_string()));
 }
 
 async fn test_303(uri: &str, expected_location: &str) {
-    let client = client().await;
+    let client = Client::new(super::rocket()).await.unwrap();
     let response = client.get(uri).dispatch().await;
     let location_headers: Vec<_> = response.headers().get("Location").collect();
     assert_eq!(response.status(), Status::SeeOther);

--- a/examples/pastebin/src/main.rs
+++ b/examples/pastebin/src/main.rs
@@ -51,11 +51,7 @@ fn index() -> &'static str {
     "
 }
 
+#[rocket::launch]
 fn rocket() -> rocket::Rocket {
     rocket::ignite().mount("/", routes![index, upload, retrieve])
-}
-
-#[rocket::main]
-async fn main() {
-    let _ = rocket().launch().await;
 }

--- a/examples/query_params/src/main.rs
+++ b/examples/query_params/src/main.rs
@@ -30,11 +30,7 @@ fn hello_20(person: LenientForm<Person>) -> String {
     format!("20 years old? Hi, {}!", person.name)
 }
 
+#[rocket::launch]
 fn rocket() -> rocket::Rocket {
     rocket::ignite().mount("/", routes![hello, hello_20])
-}
-
-#[rocket::main]
-async fn main() {
-    let _ = rocket().launch().await;
 }

--- a/examples/ranking/src/main.rs
+++ b/examples/ranking/src/main.rs
@@ -16,7 +16,7 @@ fn hi(name: String, age: &RawStr) -> String {
     format!("Hi {}! Your age ({}) is kind of funky.", name, age)
 }
 
-#[rocket::main]
-async fn main() {
-    let _ = rocket::ignite().mount("/", routes![hi, hello]).launch().await;
+#[rocket::launch]
+fn rocket() -> rocket::Rocket {
+    rocket::ignite().mount("/", routes![hi, hello])
 }

--- a/examples/ranking/src/tests.rs
+++ b/examples/ranking/src/tests.rs
@@ -1,8 +1,7 @@
 use rocket::local::Client;
 
 async fn test(uri: String, expected: String) {
-    let rocket = rocket::ignite().mount("/", routes![super::hello, super::hi]);
-    let client = Client::new(rocket).await.unwrap();
+    let client = Client::new(super::rocket()).await.unwrap();
     let mut response = client.get(&uri).dispatch().await;
     assert_eq!(response.body_string().await, Some(expected));
 }

--- a/examples/raw_sqlite/src/main.rs
+++ b/examples/raw_sqlite/src/main.rs
@@ -2,15 +2,12 @@
 
 #[macro_use] extern crate rocket;
 
-use rusqlite::types::ToSql;
-
 #[cfg(test)] mod tests;
 
 use std::sync::Mutex;
 
 use rocket::{Rocket, State, response::Debug};
-
-use rusqlite::{Connection, Error};
+use rusqlite::{Connection, Error, types::ToSql};
 
 type DbConn = Mutex<Connection>;
 
@@ -35,6 +32,7 @@ fn hello(db_conn: State<'_, DbConn>) -> Result<String, Debug<Error>>  {
         .map_err(Debug)
 }
 
+#[rocket::launch]
 fn rocket() -> Rocket {
     // Open a new in-memory SQLite database.
     let conn = Connection::open_in_memory().expect("in memory db");
@@ -46,9 +44,4 @@ fn rocket() -> Rocket {
     rocket::ignite()
         .manage(Mutex::new(conn))
         .mount("/", routes![hello])
-}
-
-#[rocket::main]
-async fn main() {
-    let _ = rocket().launch().await;
 }

--- a/examples/raw_upload/src/main.rs
+++ b/examples/raw_upload/src/main.rs
@@ -17,11 +17,7 @@ fn index() -> &'static str {
     "Upload your text files by POSTing them to /upload."
 }
 
+#[rocket::launch]
 fn rocket() -> rocket::Rocket {
     rocket::ignite().mount("/", routes![index, upload])
-}
-
-#[rocket::main]
-async fn main() {
-    let _ = rocket().launch().await;
 }

--- a/examples/redirect/src/main.rs
+++ b/examples/redirect/src/main.rs
@@ -16,7 +16,7 @@ fn login() -> &'static str {
     "Hi! Please log in before continuing."
 }
 
-#[rocket::main]
-async fn main() {
-    let _ = rocket::ignite().mount("/", routes![root, login]).launch().await;
+#[rocket::launch]
+fn rocket() -> rocket::Rocket {
+    rocket::ignite().mount("/", routes![root, login])
 }

--- a/examples/request_guard/src/main.rs
+++ b/examples/request_guard/src/main.rs
@@ -22,13 +22,9 @@ fn header_count(header_count: HeaderCount) -> String {
     format!("Your request contained {} headers!", header_count.0)
 }
 
+#[rocket::launch]
 fn rocket() -> rocket::Rocket {
     rocket::ignite().mount("/", routes![header_count])
-}
-
-#[rocket::main]
-async fn main() {
-    let _ = rocket().launch().await;
 }
 
 #[cfg(test)]

--- a/examples/request_local_state/src/main.rs
+++ b/examples/request_local_state/src/main.rs
@@ -78,13 +78,9 @@ async fn r_async(_g1: Guard3, _g2: Guard4) {
     // This exists only to run the request guards.
 }
 
+#[rocket::launch]
 fn rocket() -> rocket::Rocket {
     rocket::ignite()
         .manage(Atomics::default())
         .mount("/", routes![r_sync, r_async])
-}
-
-#[rocket::main]
-async fn main() {
-    let _ = rocket().launch().await;
 }

--- a/examples/session/src/main.rs
+++ b/examples/session/src/main.rs
@@ -80,13 +80,9 @@ fn index() -> Redirect {
     Redirect::to(uri!(login_page))
 }
 
+#[rocket::launch]
 fn rocket() -> rocket::Rocket {
     rocket::ignite()
         .attach(Template::fairing())
         .mount("/", routes![index, user_index, login, logout, login_user, login_page])
-}
-
-#[rocket::main]
-async fn main() {
-    let _ = rocket().launch().await;
 }

--- a/examples/state/src/main.rs
+++ b/examples/state/src/main.rs
@@ -24,13 +24,9 @@ fn count(hit_count: State<'_, HitCount>) -> String {
     hit_count.0.load(Ordering::Relaxed).to_string()
 }
 
+#[rocket::launch]
 fn rocket() -> rocket::Rocket {
     rocket::ignite()
         .mount("/", routes![index, count])
         .manage(HitCount(AtomicUsize::new(0)))
-}
-
-#[rocket::main]
-async fn main() {
-    let _ = rocket().launch().await;
 }

--- a/examples/static_files/src/main.rs
+++ b/examples/static_files/src/main.rs
@@ -5,11 +5,7 @@ extern crate rocket_contrib;
 
 use rocket_contrib::serve::StaticFiles;
 
+#[rocket::launch]
 fn rocket() -> rocket::Rocket {
     rocket::ignite().mount("/", StaticFiles::from("static"))
-}
-
-#[rocket::main]
-async fn main() {
-    let _ = rocket().launch().await;
 }

--- a/examples/stream/src/main.rs
+++ b/examples/stream/src/main.rs
@@ -22,11 +22,7 @@ async fn file() -> Option<Stream<File>> {
     File::open(FILENAME).await.map(Stream::from).ok()
 }
 
+#[rocket::launch]
 fn rocket() -> rocket::Rocket {
     rocket::ignite().mount("/", routes![root, file])
-}
-
-#[rocket::main]
-async fn main() {
-    let _ = rocket().launch().await;
 }

--- a/examples/tera_templates/src/main.rs
+++ b/examples/tera_templates/src/main.rs
@@ -35,14 +35,10 @@ fn not_found(req: &Request<'_>) -> Template {
     Template::render("error/404", &map)
 }
 
+#[rocket::launch]
 fn rocket() -> rocket::Rocket {
     rocket::ignite()
         .mount("/", routes![index, get])
         .attach(Template::fairing())
         .register(catchers![not_found])
-}
-
-#[rocket::main]
-async fn main() {
-    let _ = rocket().launch().await;
 }

--- a/examples/testing/src/main.rs
+++ b/examples/testing/src/main.rs
@@ -7,13 +7,9 @@ fn hello() -> &'static str {
     "Hello, world!"
 }
 
+#[rocket::launch]
 fn rocket() -> rocket::Rocket {
     rocket::ignite().mount("/", routes![hello])
-}
-
-#[rocket::main]
-async fn main() {
-    let _ = rocket().launch().await;
 }
 
 #[cfg(test)]

--- a/examples/tls/src/main.rs
+++ b/examples/tls/src/main.rs
@@ -9,7 +9,7 @@ fn hello() -> &'static str {
     "Hello, world!"
 }
 
-#[rocket::main]
-async fn main() {
-    let _ = rocket::ignite().mount("/", routes![hello]).launch().await;
+#[rocket::launch]
+fn rocket() -> rocket::Rocket {
+    rocket::ignite().mount("/", routes![hello])
 }

--- a/examples/tls/src/tests.rs
+++ b/examples/tls/src/tests.rs
@@ -2,8 +2,7 @@ use rocket::local::Client;
 
 #[rocket::async_test]
 async fn hello_world() {
-    let rocket = rocket::ignite().mount("/", routes![super::hello]);
-    let client = Client::new(rocket).await.unwrap();
+    let client = Client::new(super::rocket()).await.unwrap();
     let mut response = client.get("/").dispatch().await;
     assert_eq!(response.body_string().await, Some("Hello, world!".into()));
 }

--- a/examples/todo/src/main.rs
+++ b/examples/todo/src/main.rs
@@ -89,6 +89,7 @@ async fn run_db_migrations(mut rocket: Rocket) -> Result<Rocket, Rocket> {
     }
 }
 
+#[rocket::launch]
 fn rocket() -> Rocket {
     rocket::ignite()
         .attach(DbConn::fairing())
@@ -97,9 +98,4 @@ fn rocket() -> Rocket {
         .mount("/", routes![index])
         .mount("/todo", routes![new, toggle, delete])
         .attach(Template::fairing())
-}
-
-#[rocket::main]
-async fn main() {
-    let _ = rocket().launch().await;
 }

--- a/examples/uuid/src/main.rs
+++ b/examples/uuid/src/main.rs
@@ -33,11 +33,7 @@ fn people(id: Uuid) -> Result<String, String> {
         .ok_or_else(|| format!("Person not found for UUID: {}", id))?)
 }
 
+#[rocket::launch]
 fn rocket() -> rocket::Rocket {
     rocket::ignite().mount("/", routes![people])
-}
-
-#[rocket::main]
-async fn main() {
-    let _ = rocket().launch().await;
 }

--- a/site/guide/10-pastebin.md
+++ b/site/guide/10-pastebin.md
@@ -54,9 +54,9 @@ And finally, create a skeleton Rocket application to work off of in
 
 #[macro_use] extern crate rocket;
 
-#[rocket::main]
-async fn main() {
-    rocket::ignite().launch().await;
+#[rocket::launch]
+fn rocket() -> rocket::Rocket {
+    rocket::ignite()
 }
 ```
 
@@ -106,9 +106,9 @@ Remember that routes first need to be mounted before Rocket dispatches requests
 to them. To mount the `index` route, modify the main function so that it reads:
 
 ```rust
-#[rocket::main]
-async fn main() {
-    rocket::ignite().mount("/", routes![index]).launch().await;
+#[rocket::launch]
+fn rocket() -> rocket::Rocket {
+    rocket::ignite().mount("/", routes![index])
 }
 ```
 
@@ -254,9 +254,9 @@ async fn upload(paste: Data) -> Result<String, Debug<io::Error>> {
 Ensure that the route is mounted at the root path:
 
 ```rust
-#[rocket::main]
-async fn main() {
-    rocket::ignite().mount("/", routes![index, upload]).launch().await;
+#[rocket::launch]
+fn rocket() -> rocket::Rocket {
+    rocket::ignite().mount("/", routes![index, upload])
 }
 ```
 
@@ -308,9 +308,9 @@ fn retrieve(id: &RawStr) -> Option<File> {
 Make sure that the route is mounted at the root path:
 
 ```rust
-#[rocket::main]
-async fn main() {
-    rocket::ignite().mount("/", routes![index, upload, retrieve]).launch().await;
+#[rocket::launch]
+fn rocket() -> rocket::Rocket {
+    rocket::ignite().mount("/", routes![index, upload, retrieve])
 }
 ```
 

--- a/site/guide/2-getting-started.md
+++ b/site/guide/2-getting-started.md
@@ -66,9 +66,9 @@ fn index() -> &'static str {
     "Hello, world!"
 }
 
-#[rocket::main]
-async fn main() {
-    rocket::ignite().mount("/", routes![index]).launch().await;
+#[rocket::launch]
+fn rocket() -> rocket::Rocket {
+    rocket::ignite().mount("/", routes![index])
 }
 ```
 

--- a/site/guide/3-overview.md
+++ b/site/guide/3-overview.md
@@ -150,9 +150,9 @@ fn world() -> &'static str {
     "Hello, world!"
 }
 
-#[rocket::main]
-async fn main() {
-    rocket::ignite().mount("/hello", routes![world]).launch().await;
+#[rocket::launch]
+fn rocket() -> rocket::Rocket {
+    rocket::ignite().mount("/hello", routes![world])
 }
 ```
 
@@ -215,9 +215,9 @@ You can find async-ready libraries on [crates.io](https://crates.io) with the
 
 ! note
 
-  Rocket 0.5 uses the tokio (0.2) runtime. The runtime is started for you
-  if you use `#[rocket::main]`, but you can still `launch()` a rocket
-  instance on a custom-built `Runtime`.
+  Rocket 0.5 uses the tokio (0.2) runtime. The runtime is started for you if you
+  use `#[rocket::launch]` or `#[rocket::main]`, but you can still `launch()` a
+  rocket instance on a custom-built `Runtime`.
 
 ### Cooperative Multitasking
 

--- a/site/guide/4-requests.md
+++ b/site/guide/4-requests.md
@@ -191,17 +191,14 @@ fn user_int(id: isize) -> T { ... }
 #[get("/user/<id>", rank = 3)]
 fn user_str(id: &RawStr) -> T { ... }
 
-#[rocket::main]
-async fn main() {
-    rocket::ignite()
-        .mount("/", routes![user, user_int, user_str])
-        .launch()
-        .await;
+#[rocket::launch]
+fn rocket() -> rocket::Rocket {
+    rocket::ignite().mount("/", routes![user, user_int, user_str])
 }
 ```
 
 Notice the `rank` parameters in `user_int` and `user_str`. If we run this
-application with the routes mounted at the root path, as is done in `main`
+application with the routes mounted at the root path, as is done in `rocket`
 above, requests to `/user/<id>` (such as `/user/123`, `/user/Bob`, and so on)
 will be routed as follows:
 

--- a/site/guide/4-requests.md
+++ b/site/guide/4-requests.md
@@ -198,7 +198,7 @@ fn rocket() -> rocket::Rocket {
 ```
 
 Notice the `rank` parameters in `user_int` and `user_str`. If we run this
-application with the routes mounted at the root path, as is done in `rocket`
+application with the routes mounted at the root path, as is done in `rocket()`
 above, requests to `/user/<id>` (such as `/user/123`, `/user/Bob`, and so on)
 will be routed as follows:
 

--- a/site/guide/6-state.md
+++ b/site/guide/6-state.md
@@ -254,12 +254,9 @@ use rocket_contrib::databases::diesel;
 #[database("sqlite_logs")]
 struct LogsDbConn(diesel::SqliteConnection);
 
-#[rocket::main]
-async fn main() {
-    rocket::ignite()
-       .attach(LogsDbConn::fairing())
-       .launch()
-       .await;
+#[rocket::launch]
+fn rocket() -> rocket::Rocket {
+    rocket::ignite().attach(LogsDbConn::fairing())
 }
 ```
 

--- a/site/guide/8-testing.md
+++ b/site/guide/8-testing.md
@@ -90,13 +90,9 @@ fn hello() -> &'static str {
     "Hello, world!"
 }
 
-fn rocket() -> Rocket {
+#[rocket::launch]
+fn rocket() -> rocket::Rocket {
     rocket::ignite().mount("/", routes![hello])
-}
-
-#[rocket::main]
-async fn main() {
-    rocket().launch().await;
 }
 ```
 

--- a/site/guide/9-configuration.md
+++ b/site/guide/9-configuration.md
@@ -196,8 +196,8 @@ fn assets(asset: PathBuf, assets_dir: State<AssetsDir>) -> Option<NamedFile> {
     NamedFile::open(Path::new(&assets_dir.0).join(asset)).ok()
 }
 
-#[rocket::main]
-async fn main() {
+#[rocket::launch]
+fn rocket() -> rocket::Rocket {
     rocket::ignite()
         .mount("/", routes![assets])
         .attach(AdHoc::on_attach("Assets Config", |mut rocket| {
@@ -208,8 +208,6 @@ async fn main() {
 
             Ok(rocket.manage(AssetsDir(assets_dir)))
         }))
-        .launch()
-        .await;
 }
 ```
 

--- a/site/index.toml
+++ b/site/index.toml
@@ -47,8 +47,6 @@ margin = 9
 [[sections]]
 title = "Hello, Rocket!"
 code = '''
-  #![feature(proc_macro_hygiene)]
-
   #[macro_use] extern crate rocket;
 
   #[get("/hello/<name>/<age>")]
@@ -56,8 +54,9 @@ code = '''
       format!("Hello, {} year old named {}!", age, name)
   }
 
-  fn main() {
-      rocket::ignite().mount("/", routes![hello]).launch();
+  #[launch]
+  fn rocket() -> rocket::Rocket {
+      rocket::ignite().mount("/", routes![hello])
   }
 '''
 text = '''

--- a/site/overview.toml
+++ b/site/overview.toml
@@ -150,7 +150,7 @@ fn rocket() -> Rocket {
 The `mount` call takes a base path and a set of routes via the `routes!` macro.
 The base path (`/base` above) is prepended to the path of every route in the
 list. This namespaces the routes, allowing for composition. The `#[launch]`
-attrbutes creates a `main` function that starts the server. In development,
+attribute creates a `main` function that starts the server. In development,
 Rocket prints useful information to the console to let you know everything is
 okay.
 

--- a/site/overview.toml
+++ b/site/overview.toml
@@ -136,22 +136,23 @@ fn not_found() -> T { ... }
 name = "Launching"
 content = '''
 Launching a Rocket application is the funnest part! For Rocket to begin
-dispatching requests to routes, the routes need to be _mounted_. After mounting,
-the application needs to be _launched_. These two steps, usually done in `main`,
-look like:
+dispatching requests to routes, routes need to be _mounted_. After mounting, the
+application needs to be _launched_. These two steps, usually done in a `rocket`
+function, look like:
 
 ```rust
-rocket::ignite()
-   .mount("/base", routes![index, another])
-   .launch();
+#[launch]
+fn rocket() -> Rocket {
+    rocket::ignite().mount("/base", routes![index, another])
+}
 ```
 
 The `mount` call takes a base path and a set of routes via the `routes!` macro.
 The base path (`/base` above) is prepended to the path of every route in the
-list. This effectively namespaces the routes, allowing for easier composition.
-
-The `launch` call starts the server. In development, Rocket prints useful
-information to the console to let you know everything is okay.
+list. This namespaces the routes, allowing for composition. The `#[launch]`
+attrbutes creates a `main` function that starts the server. In development,
+Rocket prints useful information to the console to let you know everything is
+okay.
 
 ```sh
 🚀  Rocket has launched from http://localhost:8000


### PR DESCRIPTION
Adds the `#[rocket::launch]` attribute which, as discussed in #1242, can be used on a function that returns a `Rocket` instance to construct a `main` function that starts the corresponding server. Functions attributed with `#[launch]` must: 1) return an instance of `Rocket` and 2) not be `main`. They may optionally be `async`.

This commit keeps `#[rocket::main]` but deemphasizes its use, preferring `#[rocket::launch]`. It also makes `#[rocket::main]` more strict by allowing it only on `main`.