### PR TITLE
SSE for Rocket 0.4.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
   "examples/testing",
   "examples/request_local_state",
   "examples/request_guard",
+  "examples/sse",
   "examples/stream",
   "examples/json",
   "examples/msgpack",

--- a/core/lib/Cargo.toml
+++ b/core/lib/Cargo.toml
@@ -20,6 +20,7 @@ all-features = true
 [features]
 default = ["private-cookies"]
 tls = ["rocket_http/tls"]
+sse = []
 private-cookies = ["rocket_http/private-cookies"]
 
 [dependencies]

--- a/core/lib/src/ext.rs
+++ b/core/lib/src/ext.rs
@@ -1,18 +1,23 @@
 use std::io;
 
-pub trait ReadExt: io::Read {
-    fn read_max(&mut self, mut buf: &mut [u8]) -> io::Result<usize> {
-        let start_len = buf.len();
-        while !buf.is_empty() {
-            match self.read(buf) {
-                Ok(0) => break,
-                Ok(n) => { let tmp = buf; buf = &mut tmp[n..]; }
-                Err(ref e) if e.kind() == io::ErrorKind::Interrupted => {}
-                Err(e) => return Err(e),
-            }
+fn read_max_internal<T: io::Read>(reader: &mut T, mut buf: &mut [u8])
+                                  -> io::Result<usize> {
+    let start_len = buf.len();
+    while !buf.is_empty() {
+        match reader.read(buf) {
+            Ok(0) => break,
+            Ok(n) => { let tmp = buf; buf = &mut tmp[n..]; }
+            Err(ref e) if e.kind() == io::ErrorKind::Interrupted => {}
+            Err(e) => return Err(e),
         }
+    };
 
-        Ok(start_len - buf.len())
+    Ok(start_len - buf.len())
+}
+
+pub trait ReadExt: io::Read + Sized {
+    fn read_max(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        Ok(read_max_internal(self, buf)?)
     }
 }
 

--- a/core/lib/src/ext.rs
+++ b/core/lib/src/ext.rs
@@ -1,23 +1,35 @@
 use std::io;
 
-fn read_max_internal<T: io::Read>(reader: &mut T, mut buf: &mut [u8])
-                                  -> io::Result<usize> {
+fn read_max_internal<T: io::Read>(reader: &mut T, mut buf: &mut [u8],
+                                  wouldblock_flush_signalling: bool)
+                                  -> io::Result<(usize, bool)> {
     let start_len = buf.len();
-    while !buf.is_empty() {
+    let need_flush = loop {
+        if buf.is_empty() { break false }
         match reader.read(buf) {
-            Ok(0) => break,
+            Ok(0) => { break true }
             Ok(n) => { let tmp = buf; buf = &mut tmp[n..]; }
             Err(ref e) if e.kind() == io::ErrorKind::Interrupted => {}
+            Err(ref e) if (e.kind() == io::ErrorKind::WouldBlock &&
+                           wouldblock_flush_signalling) => { break true }
             Err(e) => return Err(e),
         }
     };
 
-    Ok(start_len - buf.len())
+    Ok((start_len - buf.len(), need_flush))
 }
 
 pub trait ReadExt: io::Read + Sized {
     fn read_max(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        Ok(read_max_internal(self, buf)?)
+        Ok(read_max_internal(self, buf, false)?.0)
+    }
+
+    /// Tries to fill buf with data.  Short reads can occur
+    /// for EOF or flush requests.  A flush request occurs
+    /// if the underlying reader returns ErrorKind::Wouldblock
+    fn read_max_wfs(&mut self, buf: &mut [u8])
+                    -> io::Result<(usize, bool)> {
+        read_max_internal(self, buf, true)
     }
 }
 

--- a/core/lib/src/ext.rs
+++ b/core/lib/src/ext.rs
@@ -24,12 +24,12 @@ pub trait ReadExt: io::Read + Sized {
         Ok(read_max_internal(self, buf, false)?.0)
     }
 
-    /// Tries to fill buf with data.  Short reads can occur
-    /// for EOF or flush requests.  A flush request occurs
-    /// if the underlying reader returns ErrorKind::Wouldblock
+    /// Tries to fill buf with data.  Short reads can occur for EOF or
+    /// flush requests.  With SSE enabled, a flush request occurs if
+    /// the underlying reader returns ErrorKind::Wouldblock
     fn read_max_wfs(&mut self, buf: &mut [u8])
                     -> io::Result<(usize, bool)> {
-        read_max_internal(self, buf, true)
+        read_max_internal(self, buf, cfg!(feature="sse"))
     }
 }
 

--- a/core/lib/src/response/response.rs
+++ b/core/lib/src/response/response.rs
@@ -1018,6 +1018,11 @@ impl<'r> Response<'r> {
     /// [DEFAULT_CHUNK_SIZE](::response::DEFAULT_CHUNK_SIZE). Use
     /// [set_chunked_body](#method.set_chunked_body) for custom chunk sizes.
     ///
+    /// Normally, data will be buffered and sent only in complete
+    /// chunks.  If you need timely transmission of available data,
+    /// rather than buffering, use the `WouldBlock` technique
+    /// described in [Stream](::response::Stream).
+    ///
     /// # Example
     ///
     /// ```rust

--- a/core/lib/src/response/response.rs
+++ b/core/lib/src/response/response.rs
@@ -1020,8 +1020,9 @@ impl<'r> Response<'r> {
     ///
     /// Normally, data will be buffered and sent only in complete
     /// chunks.  If you need timely transmission of available data,
-    /// rather than buffering, use the `WouldBlock` technique
-    /// described in [Stream](::response::Stream).
+    /// rather than buffering, enable the `sse` feature and use the
+    /// `WouldBlock` technique described in
+    /// [Stream](::response::Stream).
     ///
     /// # Example
     ///

--- a/core/lib/src/response/stream.rs
+++ b/core/lib/src/response/stream.rs
@@ -33,13 +33,16 @@ impl<T: Read> Stream<T> {
     /// # Buffering and blocking
     ///
     /// Normally, data will be buffered and sent only in complete
-    /// `chunk_size` chunks.  If the `reader` needs data sent so far
-    /// to be transmitted in a timely fashion (e.g. it is responding
-    /// to a Server-Side Events (JavaScript `EventSource`) request, it
-    /// should return an [io::Error](std::io::Error) of kind
-    /// `WouldBlock` (which should not normally occur), after
-    /// returning a collection of data.  This will cause a flush of
-    /// data seen so far, rather than being treated as an error.
+    /// `chunk_size` chunks.
+    ///
+    /// With the feature `sse` enabled, the `Read`er may signal that
+    /// data sent so far should be transmitted in a timely fashion
+    /// (e.g. it is responding to a Server-Side Events (JavaScript
+    /// `EventSource`) request.  To do this it should return an
+    /// [io::Error](std::io::Error) of kind `WouldBlock` (which should
+    /// not normally occur), after returning a collection of data.
+    /// This will cause a flush of data seen so far, rather than being
+    /// treated as an error.
     ///
     /// Note that long-running responses may easily exhaust Rocket's
     /// thread pool, so consider increasing the number of threads.
@@ -47,6 +50,9 @@ impl<T: Read> Stream<T> {
     /// limitation which is described in the
     /// [EventSource documentation](https://developer.mozilla.org/en-US/docs/Web/API/EventSource)
     /// on the Mozilla Developer Network.
+    ///
+    /// Without the `sse` feature, a `WouldBlock` error is treated
+    /// as an actual error.
     pub fn chunked(reader: T, chunk_size: u64) -> Stream<T> {
         Stream(reader, chunk_size)
     }

--- a/core/lib/src/response/stream.rs
+++ b/core/lib/src/response/stream.rs
@@ -29,6 +29,24 @@ impl<T: Read> Stream<T> {
     /// # #[allow(unused_variables)]
     /// let response = Stream::chunked(io::stdin(), 10);
     /// ```
+    ///
+    /// # Buffering and blocking
+    ///
+    /// Normally, data will be buffered and sent only in complete
+    /// `chunk_size` chunks.  If the `reader` needs data sent so far
+    /// to be transmitted in a timely fashion (e.g. it is responding
+    /// to a Server-Side Events (JavaScript `EventSource`) request, it
+    /// should return an [io::Error](std::io::Error) of kind
+    /// `WouldBlock` (which should not normally occur), after
+    /// returning a collection of data.  This will cause a flush of
+    /// data seen so far, rather than being treated as an error.
+    ///
+    /// Note that long-running responses may easily exhaust Rocket's
+    /// thread pool, so consider increasing the number of threads.
+    /// If doing SSE, also note the 'maximum open connections' browser
+    /// limitation which is described in the
+    /// [EventSource documentation](https://developer.mozilla.org/en-US/docs/Web/API/EventSource)
+    /// on the Mozilla Developer Network.
     pub fn chunked(reader: T, chunk_size: u64) -> Stream<T> {
         Stream(reader, chunk_size)
     }

--- a/core/lib/src/rocket.rs
+++ b/core/lib/src/rocket.rs
@@ -159,9 +159,12 @@ impl Rocket {
                 let mut buffer = vec![0; chunk_size as usize];
                 let mut stream = hyp_res.start()?;
                 loop {
-                    match body.read_max(&mut buffer)? {
-                        0 => break,
-                        n => stream.write_all(&buffer[..n])?,
+                    match body.read_max_wfs(&mut buffer)? {
+                        (0, _) => break,
+                        (n, f) => {
+                            stream.write_all(&buffer[..n])?;
+                            if f { stream.flush()? }
+                        },
                     }
                 }
 

--- a/examples/sse/Cargo.toml
+++ b/examples/sse/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "sse"
+version = "0.0.0"
+workspace = "../../"
+publish = false
+
+[dependencies]
+rocket = { path = "../../core/lib", features = ["sse"] }

--- a/examples/sse/src/main.rs
+++ b/examples/sse/src/main.rs
@@ -1,0 +1,72 @@
+#![feature(proc_macro_hygiene, decl_macro)]
+#[macro_use]
+extern crate rocket;
+
+use rocket::http::ContentType;
+use rocket::response::Content;
+use rocket::response::Responder;
+use std::io::Read;
+use std::thread::sleep;
+use std::time::Duration;
+
+#[get("/")]
+fn index<'r>() -> impl Responder<'r> {
+    Content(
+        ContentType::HTML,
+        r##"
+<body>
+<h1>Hi!</h1>
+
+<div id="spong">nothing yet</div>
+
+</body>
+<script src="script.js"></script>
+"##,
+    )
+}
+
+#[get("/script.js")]
+fn script<'r>() -> impl Responder<'r> {
+    Content(
+        ContentType::JavaScript,
+        r##"
+status_node = document.getElementById('spong');
+status_node.innerHTML = 'js-done'
+
+es = new EventSource("updates");
+es.onmessage = function(event) {
+  status_node.innerHTML = event.data;
+}
+"##,
+    )
+}
+
+type TestCounter = std::io::BufReader<TestCounterInner>;
+#[derive(Debug)]
+struct TestCounterInner {
+    next: usize,
+}
+impl Read for TestCounterInner {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        sleep(Duration::from_millis(500));
+        let data = format!("data: {}\n\n", self.next);
+        self.next += 1;
+        buf[0..data.len()].copy_from_slice(data.as_bytes());
+        Ok(buf.len())
+    }
+}
+
+#[get("/updates")]
+fn updates<'x>() -> impl Responder<'x> {
+    let tc = TestCounterInner { next: 0 };
+    let tc = std::io::BufReader::new(tc);
+    let ch = rocket::response::Stream::chunked(tc, 1);
+    let ct = ContentType::parse_flexible("text/event-stream; charset=utf-8").unwrap();
+    Content(ct, ch)
+}
+
+fn main() {
+    rocket::ignite()
+        .mount("/", routes![index, script, updates,])
+        .launch();
+}

--- a/examples/sse/src/main.rs
+++ b/examples/sse/src/main.rs
@@ -5,6 +5,7 @@ extern crate rocket;
 use rocket::http::ContentType;
 use rocket::response::Content;
 use rocket::response::Responder;
+use std::io::BufReader;
 use std::io::Read;
 use std::thread::sleep;
 use std::time::Duration;
@@ -41,7 +42,7 @@ es.onmessage = function(event) {
     )
 }
 
-type TestCounter = std::io::BufReader<TestCounterInner>;
+type TestCounter = BufReader<TestCounterInner>;
 #[derive(Debug)]
 struct TestCounterInner {
     next: usize,
@@ -59,8 +60,8 @@ impl Read for TestCounterInner {
 #[get("/updates")]
 fn updates<'x>() -> impl Responder<'x> {
     let tc = TestCounterInner { next: 0 };
-    let tc = std::io::BufReader::new(tc);
-    let ch = rocket::response::Stream::chunked(tc, 4096);
+    let tc = BufReader::new(tc);
+    let ch = rocket::response::Stream::from(tc);
     let ct = ContentType::parse_flexible("text/event-stream; charset=utf-8").unwrap();
     Content(ct, ch)
 }

--- a/examples/sse/src/main.rs
+++ b/examples/sse/src/main.rs
@@ -60,7 +60,7 @@ impl Read for TestCounterInner {
 fn updates<'x>() -> impl Responder<'x> {
     let tc = TestCounterInner { next: 0 };
     let tc = std::io::BufReader::new(tc);
-    let ch = rocket::response::Stream::chunked(tc, 1);
+    let ch = rocket::response::Stream::chunked(tc, 4096);
     let ct = ContentType::parse_flexible("text/event-stream; charset=utf-8").unwrap();
     Content(ct, ch)
 }


### PR DESCRIPTION
Hi.  I'm writing a Rocket application which uses JS SSE.  I had some difficulties getting my events to get through in a timely fashion.  After some investigation, I came up with this MR.

With this MR, I am able to use SSE with Rocket as expected.  I implement a Read which blocks and dribbles out data as needed.  (I think I will need to increase my thread pool size and I will probably have to do the multiple-domains-SSE trick to avoid the SSE connection limit bug.)

Please see the commit message of the 2nd commit for lots of discussion about my API design strategy.  The API is certainly not as pretty as it might be in some alternative universe, but I think it's about as good as we're going to get for this one.  At least it doesn't get in the way of 'normal' use of Rocket.

To save you digging it out of the github UI here it is:

```
Stream: Provide a way to flush chunks, to support SSE

Problem:

To support Server-Side Events (SSE, aka JS EventSource) it is
necessary for the server to keep open an HTTP request and dribble out
data (the event stream) as it is generated.

Currently, Rocket handles this poorly.  It likes to fill in complete
chunks.  Also there is no way to force a flush of the underlying
stream: in particular, there is a BufWriter underneath hyper.  hyper
would honour a flush request, but there is no way to send one.

Options:

Ideally the code which is producing the data would be able to
explicitly designate when a flush should occur.  Certainly it would
not be acceptable to flush all the time for all readers.

1. Invent a new kind of Body (UnbufferedChunked) which translates the
data from each Read::read() call into a single call to the stream
write, and which always flushes.  This would be a seriously invasive
change.  And it would mean that SSE systems with fast event streams
might work poorly.

2. Invent a new kind of Body which doesn't use Read at all, and
instead has a more sophisticated API.  This would be super-invasive
and heavyweight.

3. Find a way to encode the necessary information in the Read trait
protocol.

Chosen solution:

It turns out that option 3 is quite easy.  The read() call can return
an io::Error.  There are at least some errors that clearly ought not
to occur here.  An obvious one is ErrorKind::WouldBlock.

Rocket expects the reader to block.  WouldBlock is only applicable to
nonblocking objects.  And indeed the reader will generally want to
return it (once) when it is about to block.

We have the Stream treat io::Error with ErrorKind::WouldBlock, from
its reader, as a request to flush.  There are two effects: we stop
trying to accumulate a full chunk, and we issue a flush call to the
underlying writer (which, eventually, makes it all the way down into
hyper and BufWriter).

Implementation:

We provide a method ReadExt::read_max_wfs which is like read_max but
which handles the WouldBlock case specially.  It tells its caller
whether a flush was wanted.

This is implemented by adding a new code to read_max_internal.  with a
boolean to control it.  This seemed better than inventing a trait or
something.  (The other read_max call site is reading http headers in
data.rs, and I think it wants to tread WouldBlock as an error.)

Risks and downsides:

Obviously this ad-hoc extension to the Read protocol is not
particularly pretty.  At least, people who aren't doing SSE (or
similar) won't need it and can ignore it.

If for some reason the data source is actually nonblocking, this new
arrangement would spin, rather than calling the situation a fatal
error.  This possibility seems fairly remote, in production settings
at least.  To migitate this it might be possible for the loop in
Rocket::issue_response to bomb out if it notices it is sending lots of
consecutive empty chunks.

It is possible that async Rocket will want to take a different
approach entirely.  But it will definitely need to solve this problem
somehow, and naively it seems like the obvious transformation to eg
the Tokio read trait would have the same API limitation and admit the
same solution.  (Having a flush occur every time the body stream
future returns Pending would not be good for performance, I think.)
```

Background and references:

I found these issues already:
 * #1066 _(async) Add a Write-like interface for responses_: I guess this may obviate the need for the approach I have taken in 0.4.  I'll leave you to think about that :-).
 * #33 _Support for Server Sent Events_.  I think this MR would fix #33 for 0.4.  I haven't looked at 0.5 at all but it seems likely that a similar approach would be possible.
 * #90 _Native WebSocket support_.  Well that's a good idea, but not closely related.  I thougt I should mention it because WebSockets are an alternative way to solve some of the problems that SSE addresses.
 
PS: Thanks for Rocket.  This is my 2nd Rocket application so consider yourselves appreciated :-).