### PR TITLE
Replace `#[database]` guard API with a `spawn_blocking` wrapper.

### DIFF
--- a/contrib/codegen/src/database.rs
+++ b/contrib/codegen/src/database.rs
@@ -93,10 +93,10 @@ pub fn database_attr(attr: TokenStream, input: TokenStream) -> Result<TokenStrea
                 <#databases::ConnectionPool<Self, #conn_type>>::get_one(cargo).await.map(Self)
             }
 
-            /// Runs the provided closure on a blocking threadpool. The closure
-            /// will be passed an `&mut r2d2::PooledConnection`, and `.await`ing
-            /// this function will provide whatever value is returned from the
-            /// closure.
+            /// Runs the provided closure on a thread from a threadpool. The
+            /// closure will be passed an `&mut r2d2::PooledConnection`.
+            /// `.await`ing the return value of this function yields the value
+            /// returned by the closure.
             pub async fn run<F, R>(&mut self, f: F) -> R
             where
                 F: FnOnce(&mut #conn_type) -> R + Send + 'static,

--- a/contrib/codegen/src/database.rs
+++ b/contrib/codegen/src/database.rs
@@ -97,12 +97,17 @@ pub fn database_attr(attr: TokenStream, input: TokenStream) -> Result<TokenStrea
             /// closure will be passed an `&mut r2d2::PooledConnection`.
             /// `.await`ing the return value of this function yields the value
             /// returned by the closure.
-            pub async fn run<F, R>(&mut self, f: F) -> R
+            pub async fn run<F, R>(self, f: F) -> R
             where
                 F: FnOnce(&mut #conn_type) -> R + Send + 'static,
                 R: Send + 'static,
             {
                 self.0.run(f).await
+            }
+
+            /// Asynchronously acquires another connection from the connection pool.
+            pub async fn clone(&mut self) -> ::std::result::Result<Self, ()> {
+                self.0.clone().await.map(Self)
             }
         }
 

--- a/contrib/codegen/src/database.rs
+++ b/contrib/codegen/src/database.rs
@@ -64,23 +64,16 @@ pub fn database_attr(attr: TokenStream, input: TokenStream) -> Result<TokenStrea
     let name = &invocation.db_name;
     let guard_type = &invocation.type_name;
     let vis = &invocation.visibility;
-    let pool_type = Ident::new(&format!("{}Pool", guard_type), guard_type.span());
     let fairing_name = format!("'{}' Database Pool", name);
     let span = conn_type.span().into();
 
     // A few useful paths.
     let databases = quote_spanned!(span => ::rocket_contrib::databases);
-    let Poolable = quote_spanned!(span => #databases::Poolable);
-    let r2d2 = quote_spanned!(span => #databases::r2d2);
-    let spawn_blocking = quote_spanned!(span => #databases::spawn_blocking);
     let request = quote!(::rocket::request);
 
     let generated_types = quote_spanned! { span =>
         /// The request guard type.
-        #vis struct #guard_type(pub #r2d2::PooledConnection<<#conn_type as #Poolable>::Manager>);
-
-        /// The pool type.
-        #vis struct #pool_type(#r2d2::Pool<<#conn_type as #Poolable>::Manager>);
+        #vis struct #guard_type(#databases::Connection<Self, #conn_type>);
     };
 
     Ok(quote! {
@@ -90,53 +83,26 @@ pub fn database_attr(attr: TokenStream, input: TokenStream) -> Result<TokenStrea
             /// Returns a fairing that initializes the associated database
             /// connection pool.
             pub fn fairing() -> impl ::rocket::fairing::Fairing {
-                use #databases::Poolable;
-
-                ::rocket::fairing::AdHoc::on_attach(#fairing_name, |mut rocket| async {
-                    let pool = #databases::database_config(#name, rocket.config().await)
-                        .map(<#conn_type>::pool);
-
-                    match pool {
-                        Ok(Ok(p)) => Ok(rocket.manage(#pool_type(p))),
-                        Err(config_error) => {
-                            ::rocket::logger::error(
-                                &format!("Database configuration failure: '{}'", #name));
-                            ::rocket::logger::error_(&format!("{}", config_error));
-                            Err(rocket)
-                        },
-                        Ok(Err(pool_error)) => {
-                            ::rocket::logger::error(
-                                &format!("Failed to initialize pool for '{}'", #name));
-                            ::rocket::logger::error_(&format!("{:?}", pool_error));
-                            Err(rocket)
-                        },
-                    }
-                })
+                <#databases::ConnectionPool<Self, #conn_type>>::fairing(#fairing_name, #name)
             }
 
             /// Retrieves a connection of type `Self` from the `rocket`
             /// instance. Returns `Some` as long as `Self::fairing()` has been
-            /// attached and there is at least one connection in the pool.
-            pub fn get_one(cargo: &::rocket::Cargo) -> Option<Self> {
-                cargo.state::<#pool_type>()
-                    .and_then(|pool| pool.0.get().ok())
-                    .map(#guard_type)
+            /// attached.
+            pub async fn get_one(cargo: &::rocket::Cargo) -> Option<Self> {
+                <#databases::ConnectionPool<Self, #conn_type>>::get_one(cargo).await.map(Self)
             }
-        }
 
-        impl ::std::ops::Deref for #guard_type {
-            type Target = #conn_type;
-
-            #[inline(always)]
-            fn deref(&self) -> &Self::Target {
-                &self.0
-            }
-        }
-
-        impl ::std::ops::DerefMut for #guard_type {
-            #[inline(always)]
-            fn deref_mut(&mut self) -> &mut Self::Target {
-                &mut self.0
+            /// Runs the provided closure on a blocking threadpool. The closure
+            /// will be passed an `&mut r2d2::PooledConnection`, and `.await`ing
+            /// this function will provide whatever value is returned from the
+            /// closure.
+            pub async fn run<F, R>(&mut self, f: F) -> R
+            where
+                F: FnOnce(&mut #conn_type) -> R + Send + 'static,
+                R: Send + 'static,
+            {
+                self.0.run(f).await
             }
         }
 
@@ -145,20 +111,8 @@ pub fn database_attr(attr: TokenStream, input: TokenStream) -> Result<TokenStrea
             type Error = ();
 
             async fn from_request(request: &'a #request::Request<'r>) -> #request::Outcome<Self, ()> {
-                use ::rocket::http::Status;
-
-                let guard = request.guard::<::rocket::State<'_, #pool_type>>();
-                let pool = ::rocket::try_outcome!(guard.await).0.clone();
-
-                #spawn_blocking(move || {
-                    match pool.get() {
-                        Ok(conn) => #request::Outcome::Success(#guard_type(conn)),
-                        Err(_) => #request::Outcome::Failure((Status::ServiceUnavailable, ())),
-                    }
-                }).await.expect("failed to spawn a blocking task to get a pooled connection")
+                <#databases::Connection<Self, #conn_type>>::from_request(request).await.map(Self)
             }
         }
-
-        // TODO.async: What about spawn_blocking on drop?
     }.into())
 }

--- a/contrib/codegen/src/database.rs
+++ b/contrib/codegen/src/database.rs
@@ -97,7 +97,7 @@ pub fn database_attr(attr: TokenStream, input: TokenStream) -> Result<TokenStrea
             /// closure will be passed an `&mut r2d2::PooledConnection`.
             /// `.await`ing the return value of this function yields the value
             /// returned by the closure.
-            pub async fn run<F, R>(self, f: F) -> R
+            pub async fn run<F, R>(&self, f: F) -> R
             where
                 F: FnOnce(&mut #conn_type) -> R + Send + 'static,
                 R: Send + 'static,
@@ -105,10 +105,10 @@ pub fn database_attr(attr: TokenStream, input: TokenStream) -> Result<TokenStrea
                 self.0.run(f).await
             }
 
-            /// Asynchronously acquires another connection from the connection pool.
-            pub async fn clone(&mut self) -> ::std::result::Result<Self, ()> {
-                self.0.clone().await.map(Self)
-            }
+            // /// Asynchronously acquires another connection from the connection pool.
+            // pub async fn clone(&mut self) -> ::std::result::Result<Self, ()> {
+            //     self.0.clone().await.map(Self)
+            // }
         }
 
         #[::rocket::async_trait]

--- a/contrib/codegen/tests/ui-fail-nightly/database-types.stderr
+++ b/contrib/codegen/tests/ui-fail-nightly/database-types.stderr
@@ -4,9 +4,9 @@ error[E0277]: the trait bound `Unknown: rocket_contrib::databases::Poolable` is 
 7   | struct A(Unknown);
     |          ^^^^^^^ the trait `rocket_contrib::databases::Poolable` is not implemented for `Unknown`
     |
-   ::: $WORKSPACE/contrib/lib/src/databases.rs:798:29
+   ::: $WORKSPACE/contrib/lib/src/databases.rs:832:29
     |
-798 | pub struct Connection<K, C: Poolable> {
+832 | pub struct Connection<K, C: Poolable> {
     |                             -------- required by this bound in `rocket_contrib::databases::Connection`
 
 error[E0277]: the trait bound `std::vec::Vec<i32>: rocket_contrib::databases::Poolable` is not satisfied
@@ -15,7 +15,7 @@ error[E0277]: the trait bound `std::vec::Vec<i32>: rocket_contrib::databases::Po
 10  | struct B(Vec<i32>);
     |          ^^^^^^^^ the trait `rocket_contrib::databases::Poolable` is not implemented for `std::vec::Vec<i32>`
     |
-   ::: $WORKSPACE/contrib/lib/src/databases.rs:798:29
+   ::: $WORKSPACE/contrib/lib/src/databases.rs:832:29
     |
-798 | pub struct Connection<K, C: Poolable> {
+832 | pub struct Connection<K, C: Poolable> {
     |                             -------- required by this bound in `rocket_contrib::databases::Connection`

--- a/contrib/codegen/tests/ui-fail-nightly/database-types.stderr
+++ b/contrib/codegen/tests/ui-fail-nightly/database-types.stderr
@@ -1,11 +1,21 @@
 error[E0277]: the trait bound `Unknown: rocket_contrib::databases::Poolable` is not satisfied
- --> $DIR/database-types.rs:7:10
-  |
-7 | struct A(Unknown);
-  |          ^^^^^^^ the trait `rocket_contrib::databases::Poolable` is not implemented for `Unknown`
+   --> $DIR/database-types.rs:7:10
+    |
+7   | struct A(Unknown);
+    |          ^^^^^^^ the trait `rocket_contrib::databases::Poolable` is not implemented for `Unknown`
+    |
+   ::: $WORKSPACE/contrib/lib/src/databases.rs:798:29
+    |
+798 | pub struct Connection<K, C: Poolable> {
+    |                             -------- required by this bound in `rocket_contrib::databases::Connection`
 
 error[E0277]: the trait bound `std::vec::Vec<i32>: rocket_contrib::databases::Poolable` is not satisfied
-  --> $DIR/database-types.rs:10:10
-   |
-10 | struct B(Vec<i32>);
-   |          ^^^^^^^^ the trait `rocket_contrib::databases::Poolable` is not implemented for `std::vec::Vec<i32>`
+   --> $DIR/database-types.rs:10:10
+    |
+10  | struct B(Vec<i32>);
+    |          ^^^^^^^^ the trait `rocket_contrib::databases::Poolable` is not implemented for `std::vec::Vec<i32>`
+    |
+   ::: $WORKSPACE/contrib/lib/src/databases.rs:798:29
+    |
+798 | pub struct Connection<K, C: Poolable> {
+    |                             -------- required by this bound in `rocket_contrib::databases::Connection`

--- a/contrib/codegen/tests/ui-fail-nightly/database-types.stderr
+++ b/contrib/codegen/tests/ui-fail-nightly/database-types.stderr
@@ -4,9 +4,9 @@ error[E0277]: the trait bound `Unknown: rocket_contrib::databases::Poolable` is 
 7   | struct A(Unknown);
     |          ^^^^^^^ the trait `rocket_contrib::databases::Poolable` is not implemented for `Unknown`
     |
-   ::: $WORKSPACE/contrib/lib/src/databases.rs:832:29
+   ::: $WORKSPACE/contrib/lib/src/databases.rs
     |
-832 | pub struct Connection<K, C: Poolable> {
+    | pub struct Connection<K, C: Poolable> {
     |                             -------- required by this bound in `rocket_contrib::databases::Connection`
 
 error[E0277]: the trait bound `std::vec::Vec<i32>: rocket_contrib::databases::Poolable` is not satisfied
@@ -15,7 +15,7 @@ error[E0277]: the trait bound `std::vec::Vec<i32>: rocket_contrib::databases::Po
 10  | struct B(Vec<i32>);
     |          ^^^^^^^^ the trait `rocket_contrib::databases::Poolable` is not implemented for `std::vec::Vec<i32>`
     |
-   ::: $WORKSPACE/contrib/lib/src/databases.rs:832:29
+   ::: $WORKSPACE/contrib/lib/src/databases.rs
     |
-832 | pub struct Connection<K, C: Poolable> {
+    | pub struct Connection<K, C: Poolable> {
     |                             -------- required by this bound in `rocket_contrib::databases::Connection`

--- a/contrib/codegen/tests/ui-fail-stable/database-types.stderr
+++ b/contrib/codegen/tests/ui-fail-stable/database-types.stderr
@@ -1,11 +1,21 @@
 error[E0277]: the trait bound `Unknown: rocket_contrib::databases::Poolable` is not satisfied
- --> $DIR/database-types.rs:7:10
-  |
-7 | struct A(Unknown);
-  |          ^^^^^^^ the trait `rocket_contrib::databases::Poolable` is not implemented for `Unknown`
+   --> $DIR/database-types.rs:7:10
+    |
+7   | struct A(Unknown);
+    |          ^^^^^^^ the trait `rocket_contrib::databases::Poolable` is not implemented for `Unknown`
+    |
+   ::: $WORKSPACE/contrib/lib/src/databases.rs:798:29
+    |
+798 | pub struct Connection<K, C: Poolable> {
+    |                             -------- required by this bound in `rocket_contrib::databases::Connection`
 
 error[E0277]: the trait bound `std::vec::Vec<i32>: rocket_contrib::databases::Poolable` is not satisfied
-  --> $DIR/database-types.rs:10:10
-   |
-10 | struct B(Vec<i32>);
-   |          ^^^ the trait `rocket_contrib::databases::Poolable` is not implemented for `std::vec::Vec<i32>`
+   --> $DIR/database-types.rs:10:10
+    |
+10  | struct B(Vec<i32>);
+    |          ^^^ the trait `rocket_contrib::databases::Poolable` is not implemented for `std::vec::Vec<i32>`
+    |
+   ::: $WORKSPACE/contrib/lib/src/databases.rs:798:29
+    |
+798 | pub struct Connection<K, C: Poolable> {
+    |                             -------- required by this bound in `rocket_contrib::databases::Connection`

--- a/contrib/codegen/tests/ui-fail-stable/database-types.stderr
+++ b/contrib/codegen/tests/ui-fail-stable/database-types.stderr
@@ -4,9 +4,9 @@ error[E0277]: the trait bound `Unknown: rocket_contrib::databases::Poolable` is 
 7   | struct A(Unknown);
     |          ^^^^^^^ the trait `rocket_contrib::databases::Poolable` is not implemented for `Unknown`
     |
-   ::: $WORKSPACE/contrib/lib/src/databases.rs:798:29
+   ::: $WORKSPACE/contrib/lib/src/databases.rs:832:29
     |
-798 | pub struct Connection<K, C: Poolable> {
+832 | pub struct Connection<K, C: Poolable> {
     |                             -------- required by this bound in `rocket_contrib::databases::Connection`
 
 error[E0277]: the trait bound `std::vec::Vec<i32>: rocket_contrib::databases::Poolable` is not satisfied
@@ -15,7 +15,7 @@ error[E0277]: the trait bound `std::vec::Vec<i32>: rocket_contrib::databases::Po
 10  | struct B(Vec<i32>);
     |          ^^^ the trait `rocket_contrib::databases::Poolable` is not implemented for `std::vec::Vec<i32>`
     |
-   ::: $WORKSPACE/contrib/lib/src/databases.rs:798:29
+   ::: $WORKSPACE/contrib/lib/src/databases.rs:832:29
     |
-798 | pub struct Connection<K, C: Poolable> {
+832 | pub struct Connection<K, C: Poolable> {
     |                             -------- required by this bound in `rocket_contrib::databases::Connection`

--- a/contrib/codegen/tests/ui-fail-stable/database-types.stderr
+++ b/contrib/codegen/tests/ui-fail-stable/database-types.stderr
@@ -4,9 +4,9 @@ error[E0277]: the trait bound `Unknown: rocket_contrib::databases::Poolable` is 
 7   | struct A(Unknown);
     |          ^^^^^^^ the trait `rocket_contrib::databases::Poolable` is not implemented for `Unknown`
     |
-   ::: $WORKSPACE/contrib/lib/src/databases.rs:832:29
+   ::: $WORKSPACE/contrib/lib/src/databases.rs
     |
-832 | pub struct Connection<K, C: Poolable> {
+    | pub struct Connection<K, C: Poolable> {
     |                             -------- required by this bound in `rocket_contrib::databases::Connection`
 
 error[E0277]: the trait bound `std::vec::Vec<i32>: rocket_contrib::databases::Poolable` is not satisfied
@@ -15,7 +15,7 @@ error[E0277]: the trait bound `std::vec::Vec<i32>: rocket_contrib::databases::Po
 10  | struct B(Vec<i32>);
     |          ^^^ the trait `rocket_contrib::databases::Poolable` is not implemented for `std::vec::Vec<i32>`
     |
-   ::: $WORKSPACE/contrib/lib/src/databases.rs:832:29
+   ::: $WORKSPACE/contrib/lib/src/databases.rs
     |
-832 | pub struct Connection<K, C: Poolable> {
+    | pub struct Connection<K, C: Poolable> {
     |                             -------- required by this bound in `rocket_contrib::databases::Connection`

--- a/contrib/lib/src/databases.rs
+++ b/contrib/lib/src/databases.rs
@@ -222,9 +222,9 @@
 //! ```
 //!
 //! The macro generates a [`FromRequest`] implementation for the decorated type,
-//! allowing the type to be used as a request guard. This implementation always
-//! succeeds; database availability is not actually checked until `run()` is
-//! called.
+//! allowing the type to be used as a request guard. This implementation
+//! retrieves a connection from the database pool or fails with a
+//! `Status::ServiceUnavailable` if connecting to the database times out.
 //!
 //! The macro will also generate two inherent methods on the decorated type:
 //!
@@ -233,7 +233,7 @@
 //!      Returns a fairing that initializes the associated database connection
 //!      pool.
 //!
-//!   * `fn async get_one(&Cargo) -> Option<Self>`
+//!   * `async fn get_one(&Cargo) -> Option<Self>`
 //!
 //!     Retrieves a connection wrapper from the configured pool. Returns `Some`
 //!     as long as `Self::fairing()` has been attached.

--- a/contrib/lib/tests/databases.rs
+++ b/contrib/lib/tests/databases.rs
@@ -21,40 +21,31 @@ mod rusqlite_integration_test {
     #[database("test_db")]
     struct SqliteDb(pub rusqlite::Connection);
 
+    // Test to ensure that multiple databases of the same type can be used
+    #[database("test_db_2")]
+    struct SqliteDb2(pub rusqlite::Connection);
+
     #[rocket::async_test]
-    async fn deref_mut_impl_present() {
+    async fn test_db() {
         let mut test_db: Map<String, Value> = Map::new();
         let mut test_db_opts: Map<String, Value> = Map::new();
         test_db_opts.insert("url".into(), Value::String(":memory:".into()));
-        test_db.insert("test_db".into(), Value::Table(test_db_opts));
+        test_db.insert("test_db".into(), Value::Table(test_db_opts.clone()));
+        test_db.insert("test_db_2".into(), Value::Table(test_db_opts));
         let config = Config::build(Environment::Development)
             .extra("databases", Value::Table(test_db))
             .finalize()
             .unwrap();
 
-        let mut rocket = rocket::custom(config).attach(SqliteDb::fairing());
-        let mut conn = SqliteDb::get_one(rocket.inspect().await).expect("unable to get connection");
+        let mut rocket = rocket::custom(config).attach(SqliteDb::fairing()).attach(SqliteDb2::fairing());
+        let mut conn = SqliteDb::get_one(rocket.inspect().await).await.expect("unable to get connection");
 
-        // Rusqlite's `transaction()` method takes `&mut self`; this tests the
-        // presence of a `DerefMut` trait on the generated connection type.
-        let tx = conn.transaction().unwrap();
-        let _: i32 = tx.query_row("SELECT 1", &[] as &[&dyn ToSql], |row| row.get(0)).expect("get row");
-        tx.commit().expect("committed transaction");
-    }
-
-    #[rocket::async_test]
-    async fn deref_impl_present() {
-        let mut test_db: Map<String, Value> = Map::new();
-        let mut test_db_opts: Map<String, Value> = Map::new();
-        test_db_opts.insert("url".into(), Value::String(":memory:".into()));
-        test_db.insert("test_db".into(), Value::Table(test_db_opts));
-        let config = Config::build(Environment::Development)
-            .extra("databases", Value::Table(test_db))
-            .finalize()
-            .unwrap();
-
-        let mut rocket = rocket::custom(config).attach(SqliteDb::fairing());
-        let conn = SqliteDb::get_one(rocket.inspect().await).expect("unable to get connection");
-        let _: i32 = conn.query_row("SELECT 1", &[] as &[&dyn ToSql], |row| row.get(0)).expect("get row");
+        // Rusqlite's `transaction()` method takes `&mut self`; this tests that
+        // the &mut method can be called inside the closure passed to `run()`.
+        conn.run(|conn| {
+            let tx = conn.transaction().unwrap();
+            let _: i32 = tx.query_row("SELECT 1", &[] as &[&dyn ToSql], |row| row.get(0)).expect("get row");
+            tx.commit().expect("committed transaction");
+        }).await;
     }
 }

--- a/contrib/lib/tests/databases.rs
+++ b/contrib/lib/tests/databases.rs
@@ -38,7 +38,7 @@ mod rusqlite_integration_test {
             .unwrap();
 
         let mut rocket = rocket::custom(config).attach(SqliteDb::fairing()).attach(SqliteDb2::fairing());
-        let mut conn = SqliteDb::get_one(rocket.inspect().await).await.expect("unable to get connection");
+        let conn = SqliteDb::get_one(rocket.inspect().await).await.expect("unable to get connection");
 
         // Rusqlite's `transaction()` method takes `&mut self`; this tests that
         // the &mut method can be called inside the closure passed to `run()`.

--- a/examples/todo/src/main.rs
+++ b/examples/todo/src/main.rs
@@ -53,7 +53,7 @@ impl Context {
 }
 
 #[post("/", data = "<todo_form>")]
-async fn new(todo_form: Form<Todo>, mut conn: DbConn) -> Flash<Redirect> {
+async fn new(todo_form: Form<Todo>, conn: DbConn) -> Flash<Redirect> {
     conn.run(|c| {
         let todo = todo_form.into_inner();
         if todo.description.is_empty() {
@@ -68,7 +68,7 @@ async fn new(todo_form: Form<Todo>, mut conn: DbConn) -> Flash<Redirect> {
 }
 
 #[put("/<id>")]
-async fn toggle(id: i32, mut conn: DbConn) -> Result<Redirect, Template> {
+async fn toggle(id: i32, conn: DbConn) -> Result<Redirect, Template> {
     conn.run(move |c| {
         Task::toggle_with_id(id, c)
             .map(|_| Redirect::to("/"))
@@ -80,7 +80,7 @@ async fn toggle(id: i32, mut conn: DbConn) -> Result<Redirect, Template> {
 }
 
 #[delete("/<id>")]
-async fn delete(id: i32, mut conn: DbConn) -> Result<Flash<Redirect>, Template> {
+async fn delete(id: i32, conn: DbConn) -> Result<Flash<Redirect>, Template> {
     conn.run(move |c| {
         Task::delete_with_id(id, c)
             .map(|_| Flash::success(Redirect::to("/"), "Todo was deleted."))
@@ -92,7 +92,7 @@ async fn delete(id: i32, mut conn: DbConn) -> Result<Flash<Redirect>, Template> 
 }
 
 #[get("/")]
-async fn index(msg: Option<FlashMessage<'_, '_>>, mut conn: DbConn) -> Template {
+async fn index(msg: Option<FlashMessage<'_, '_>>, conn: DbConn) -> Template {
     let msg = msg.map(|m| (m.name().to_string(), m.msg().to_string()));
     conn.run(|c| {
         Template::render("index", match msg {
@@ -103,7 +103,7 @@ async fn index(msg: Option<FlashMessage<'_, '_>>, mut conn: DbConn) -> Template 
 }
 
 async fn run_db_migrations(mut rocket: Rocket) -> Result<Rocket, Rocket> {
-    let mut conn = DbConn::get_one(rocket.inspect().await).await.expect("database connection");
+    let conn = DbConn::get_one(rocket.inspect().await).await.expect("database connection");
     conn.run(|c| {
         match embedded_migrations::run(c) {
             Ok(()) => Ok(rocket),

--- a/examples/todo/src/task.rs
+++ b/examples/todo/src/task.rs
@@ -29,14 +29,14 @@ pub struct Todo {
 }
 
 impl Task {
-    pub async fn all(conn: DbConn) -> QueryResult<Vec<Task>> {
+    pub async fn all(conn: &DbConn) -> QueryResult<Vec<Task>> {
         conn.run(|c| {
             all_tasks.order(tasks::id.desc()).load::<Task>(c)
         }).await
     }
 
     /// Returns the number of affected rows: 1.
-    pub async fn insert(todo: Todo, conn: DbConn) -> QueryResult<usize> {
+    pub async fn insert(todo: Todo, conn: &DbConn) -> QueryResult<usize> {
         conn.run(|c| {
             let t = Task { id: None, description: todo.description, completed: false };
             diesel::insert_into(tasks::table).values(&t).execute(c)
@@ -44,7 +44,7 @@ impl Task {
     }
 
     /// Returns the number of affected rows: 1.
-    pub async fn toggle_with_id(id: i32, conn: DbConn) -> QueryResult<usize> {
+    pub async fn toggle_with_id(id: i32, conn: &DbConn) -> QueryResult<usize> {
         conn.run(move |c| {
             let task = all_tasks.find(id).get_result::<Task>(c)?;
             let new_status = !task.completed;
@@ -54,13 +54,13 @@ impl Task {
     }
 
     /// Returns the number of affected rows: 1.
-    pub async fn delete_with_id(id: i32, conn: DbConn) -> QueryResult<usize> {
+    pub async fn delete_with_id(id: i32, conn: &DbConn) -> QueryResult<usize> {
         conn.run(move |c| diesel::delete(all_tasks.find(id)).execute(c)).await
     }
 
     /// Returns the number of affected rows.
     #[cfg(test)]
-    pub async fn delete_all(conn: DbConn) -> QueryResult<usize> {
+    pub async fn delete_all(conn: &DbConn) -> QueryResult<usize> {
         conn.run(|c| diesel::delete(all_tasks).execute(c)).await
     }
 }

--- a/examples/todo/src/tests.rs
+++ b/examples/todo/src/tests.rs
@@ -19,9 +19,8 @@ macro_rules! run_test {
             let rocket = super::rocket();
             let $client = Client::new(rocket).await.expect("Rocket client");
             let db = super::DbConn::get_one($client.cargo()).await;
-            let mut $conn = db.expect("failed to get database connection for testing");
-            let delete_conn = $conn.clone().await.expect("failed to get a second database connection for testing");
-            Task::delete_all(delete_conn).await.expect("failed to delete all tasks for testing");
+            let $conn = db.expect("failed to get database connection for testing");
+            Task::delete_all(&$conn).await.expect("failed to delete all tasks for testing");
 
             $block
         })
@@ -32,7 +31,7 @@ macro_rules! run_test {
 fn test_insertion_deletion() {
     run_test!(|client, conn| {
         // Get the tasks before making changes.
-        let init_tasks = Task::all(conn.clone().await.unwrap()).await.unwrap();
+        let init_tasks = Task::all(&conn).await.unwrap();
 
         // Issue a request to insert a new task.
         client.post("/todo")
@@ -42,7 +41,7 @@ fn test_insertion_deletion() {
             .await;
 
         // Ensure we have one more task in the database.
-        let new_tasks = Task::all(conn.clone().await.unwrap()).await.unwrap();
+        let new_tasks = Task::all(&conn).await.unwrap();
         assert_eq!(new_tasks.len(), init_tasks.len() + 1);
 
         // Ensure the task is what we expect.
@@ -54,7 +53,7 @@ fn test_insertion_deletion() {
         client.delete(format!("/todo/{}", id)).dispatch().await;
 
         // Ensure it's gone.
-        let final_tasks = Task::all(conn).await.unwrap();
+        let final_tasks = Task::all(&conn).await.unwrap();
         assert_eq!(final_tasks.len(), init_tasks.len());
         if final_tasks.len() > 0 {
             assert_ne!(final_tasks[0].description, "My first task");
@@ -72,16 +71,16 @@ fn test_toggle() {
             .dispatch()
             .await;
 
-        let task = Task::all(conn.clone().await.unwrap()).await.unwrap()[0].clone();
+        let task = Task::all(&conn).await.unwrap()[0].clone();
         assert_eq!(task.completed, false);
 
         // Issue a request to toggle the task; ensure it is completed.
         client.put(format!("/todo/{}", task.id.unwrap())).dispatch().await;
-        assert_eq!(Task::all(conn.clone().await.unwrap()).await.unwrap()[0].completed, true);
+        assert_eq!(Task::all(&conn).await.unwrap()[0].completed, true);
 
         // Issue a request to toggle the task; ensure it's not completed again.
         client.put(format!("/todo/{}", task.id.unwrap())).dispatch().await;
-        assert_eq!(Task::all(conn).await.unwrap()[0].completed, false);
+        assert_eq!(Task::all(&conn).await.unwrap()[0].completed, false);
     })
 }
 
@@ -91,7 +90,7 @@ fn test_many_insertions() {
 
     run_test!(|client, conn| {
         // Get the number of tasks initially.
-        let init_num = Task::all(conn.clone().await.unwrap()).await.unwrap().len();
+        let init_num = Task::all(&conn).await.unwrap().len();
         let mut descs = Vec::new();
 
         for i in 0..ITER {
@@ -107,7 +106,7 @@ fn test_many_insertions() {
             descs.insert(0, desc);
 
             // Ensure the task was inserted properly and all other tasks remain.
-            let tasks = Task::all(conn.clone().await.unwrap()).await.unwrap();
+            let tasks = Task::all(&conn).await.unwrap();
             assert_eq!(tasks.len(), init_num + i + 1);
 
             for j in 0..i {

--- a/examples/todo/src/tests.rs
+++ b/examples/todo/src/tests.rs
@@ -3,7 +3,7 @@ use super::task::Task;
 use parking_lot::Mutex;
 use rand::{Rng, thread_rng, distributions::Alphanumeric};
 
-use rocket::local::blocking::Client;
+use rocket::local::asynchronous::Client;
 use rocket::http::{Status, ContentType};
 
 // We use a lock to synchronize between tests so DB operations don't collide.
@@ -15,13 +15,15 @@ macro_rules! run_test {
     (|$client:ident, $conn:ident| $block:expr) => ({
         let _lock = DB_LOCK.lock();
 
-        let rocket = super::rocket();
-        let $client = Client::new(rocket).expect("Rocket client");
-        let db = super::DbConn::get_one($client.cargo());
-        let $conn = db.expect("failed to get database connection for testing");
-        Task::delete_all(&$conn).expect("failed to delete all tasks for testing");
+        rocket::async_test(async move {
+            let rocket = super::rocket();
+            let $client = Client::new(rocket).await.expect("Rocket client");
+            let db = super::DbConn::get_one($client.cargo()).await;
+            let mut $conn = db.expect("failed to get database connection for testing");
+            $conn.run(|c| Task::delete_all(c)).await.expect("failed to delete all tasks for testing");
 
-        $block
+            $block
+        })
     })
 }
 
@@ -29,16 +31,17 @@ macro_rules! run_test {
 fn test_insertion_deletion() {
     run_test!(|client, conn| {
         // Get the tasks before making changes.
-        let init_tasks = Task::all(&conn).unwrap();
+        let init_tasks = conn.run(|c| Task::all(c)).await.unwrap();
 
         // Issue a request to insert a new task.
         client.post("/todo")
             .header(ContentType::Form)
             .body("description=My+first+task")
-            .dispatch();
+            .dispatch()
+            .await;
 
         // Ensure we have one more task in the database.
-        let new_tasks = Task::all(&conn).unwrap();
+        let new_tasks = conn.run(|c| Task::all(c)).await.unwrap();
         assert_eq!(new_tasks.len(), init_tasks.len() + 1);
 
         // Ensure the task is what we expect.
@@ -47,10 +50,10 @@ fn test_insertion_deletion() {
 
         // Issue a request to delete the task.
         let id = new_tasks[0].id.unwrap();
-        client.delete(format!("/todo/{}", id)).dispatch();
+        client.delete(format!("/todo/{}", id)).dispatch().await;
 
         // Ensure it's gone.
-        let final_tasks = Task::all(&conn).unwrap();
+        let final_tasks = conn.run(|c| Task::all(c)).await.unwrap();
         assert_eq!(final_tasks.len(), init_tasks.len());
         if final_tasks.len() > 0 {
             assert_ne!(final_tasks[0].description, "My first task");
@@ -65,18 +68,19 @@ fn test_toggle() {
         client.post("/todo")
             .header(ContentType::Form)
             .body("description=test_for_completion")
-            .dispatch();
+            .dispatch()
+            .await;
 
-        let task = Task::all(&conn).unwrap()[0].clone();
+        let task = conn.run(|c| Task::all(c)).await.unwrap()[0].clone();
         assert_eq!(task.completed, false);
 
         // Issue a request to toggle the task; ensure it is completed.
-        client.put(format!("/todo/{}", task.id.unwrap())).dispatch();
-        assert_eq!(Task::all(&conn).unwrap()[0].completed, true);
+        client.put(format!("/todo/{}", task.id.unwrap())).dispatch().await;
+        assert_eq!(conn.run(|c| Task::all(c)).await.unwrap()[0].completed, true);
 
         // Issue a request to toggle the task; ensure it's not completed again.
-        client.put(format!("/todo/{}", task.id.unwrap())).dispatch();
-        assert_eq!(Task::all(&conn).unwrap()[0].completed, false);
+        client.put(format!("/todo/{}", task.id.unwrap())).dispatch().await;
+        assert_eq!(conn.run(|c| Task::all(c)).await.unwrap()[0].completed, false);
     })
 }
 
@@ -86,7 +90,7 @@ fn test_many_insertions() {
 
     run_test!(|client, conn| {
         // Get the number of tasks initially.
-        let init_num = Task::all(&conn).unwrap().len();
+        let init_num = conn.run(|c| Task::all(c)).await.unwrap().len();
         let mut descs = Vec::new();
 
         for i in 0..ITER {
@@ -95,13 +99,14 @@ fn test_many_insertions() {
             client.post("/todo")
                 .header(ContentType::Form)
                 .body(format!("description={}", desc))
-                .dispatch();
+                .dispatch()
+                .await;
 
             // Record the description we choose for this iteration.
             descs.insert(0, desc);
 
             // Ensure the task was inserted properly and all other tasks remain.
-            let tasks = Task::all(&conn).unwrap();
+            let tasks = conn.run(|c| Task::all(c)).await.unwrap();
             assert_eq!(tasks.len(), init_num + i + 1);
 
             for j in 0..i {
@@ -117,7 +122,8 @@ fn test_bad_form_submissions() {
         // Submit an empty form. We should get a 422 but no flash error.
         let res = client.post("/todo")
             .header(ContentType::Form)
-            .dispatch();
+            .dispatch()
+            .await;
 
         let mut cookies = res.headers().get("Set-Cookie");
         assert_eq!(res.status(), Status::UnprocessableEntity);
@@ -128,7 +134,8 @@ fn test_bad_form_submissions() {
         let res = client.post("/todo")
             .header(ContentType::Form)
             .body("description=")
-            .dispatch();
+            .dispatch()
+            .await;
 
         let mut cookies = res.headers().get("Set-Cookie");
         assert!(cookies.any(|value| value.contains("error")));
@@ -137,7 +144,8 @@ fn test_bad_form_submissions() {
         let res = client.post("/todo")
             .header(ContentType::Form)
             .body("evil=smile")
-            .dispatch();
+            .dispatch()
+            .await;
 
         let mut cookies = res.headers().get("Set-Cookie");
         assert_eq!(res.status(), Status::UnprocessableEntity);

--- a/examples/todo/src/tests.rs
+++ b/examples/todo/src/tests.rs
@@ -21,7 +21,7 @@ macro_rules! run_test {
             let db = super::DbConn::get_one($client.cargo()).await;
             let mut $conn = db.expect("failed to get database connection for testing");
             let delete_conn = $conn.clone().await.expect("failed to get a second database connection for testing");
-            delete_conn.run(|c| Task::delete_all(c)).await.expect("failed to delete all tasks for testing");
+            Task::delete_all(delete_conn).await.expect("failed to delete all tasks for testing");
 
             $block
         })
@@ -32,7 +32,7 @@ macro_rules! run_test {
 fn test_insertion_deletion() {
     run_test!(|client, conn| {
         // Get the tasks before making changes.
-        let init_tasks = conn.clone().await.unwrap().run(|c| Task::all(c)).await.unwrap();
+        let init_tasks = Task::all(conn.clone().await.unwrap()).await.unwrap();
 
         // Issue a request to insert a new task.
         client.post("/todo")
@@ -42,7 +42,7 @@ fn test_insertion_deletion() {
             .await;
 
         // Ensure we have one more task in the database.
-        let new_tasks = conn.clone().await.unwrap().run(|c| Task::all(c)).await.unwrap();
+        let new_tasks = Task::all(conn.clone().await.unwrap()).await.unwrap();
         assert_eq!(new_tasks.len(), init_tasks.len() + 1);
 
         // Ensure the task is what we expect.
@@ -54,7 +54,7 @@ fn test_insertion_deletion() {
         client.delete(format!("/todo/{}", id)).dispatch().await;
 
         // Ensure it's gone.
-        let final_tasks = conn.run(|c| Task::all(c)).await.unwrap();
+        let final_tasks = Task::all(conn).await.unwrap();
         assert_eq!(final_tasks.len(), init_tasks.len());
         if final_tasks.len() > 0 {
             assert_ne!(final_tasks[0].description, "My first task");
@@ -72,16 +72,16 @@ fn test_toggle() {
             .dispatch()
             .await;
 
-        let task = conn.clone().await.unwrap().run(|c| Task::all(c)).await.unwrap()[0].clone();
+        let task = Task::all(conn.clone().await.unwrap()).await.unwrap()[0].clone();
         assert_eq!(task.completed, false);
 
         // Issue a request to toggle the task; ensure it is completed.
         client.put(format!("/todo/{}", task.id.unwrap())).dispatch().await;
-        assert_eq!(conn.clone().await.unwrap().run(|c| Task::all(c)).await.unwrap()[0].completed, true);
+        assert_eq!(Task::all(conn.clone().await.unwrap()).await.unwrap()[0].completed, true);
 
         // Issue a request to toggle the task; ensure it's not completed again.
         client.put(format!("/todo/{}", task.id.unwrap())).dispatch().await;
-        assert_eq!(conn.run(|c| Task::all(c)).await.unwrap()[0].completed, false);
+        assert_eq!(Task::all(conn).await.unwrap()[0].completed, false);
     })
 }
 
@@ -91,7 +91,7 @@ fn test_many_insertions() {
 
     run_test!(|client, conn| {
         // Get the number of tasks initially.
-        let init_num = conn.clone().await.unwrap().run(|c| Task::all(c)).await.unwrap().len();
+        let init_num = Task::all(conn.clone().await.unwrap()).await.unwrap().len();
         let mut descs = Vec::new();
 
         for i in 0..ITER {
@@ -107,7 +107,7 @@ fn test_many_insertions() {
             descs.insert(0, desc);
 
             // Ensure the task was inserted properly and all other tasks remain.
-            let tasks = conn.clone().await.unwrap().run(|c| Task::all(c)).await.unwrap();
+            let tasks = Task::all(conn.clone().await.unwrap()).await.unwrap();
             assert_eq!(tasks.len(), init_num + i + 1);
 
             for j in 0..i {

--- a/site/guide/6-state.md
+++ b/site/guide/6-state.md
@@ -330,10 +330,10 @@ async fn get_logs(conn: LogsDbConn, id: usize) -> Logs {
 
 ! note
 
-  The database engines supported by `#[database]` are *synchronous*, and
-  normally block the thread of execution. The `run()` function automatically
-  uses `tokio::spawn_blocking` so that database access does not interfere with
-  other in-flight requests. See [Cooperative
+  The database engines supported by `#[database]` are *synchronous*. Normally,
+  using such a database would block the thread of execution. To prevent this,
+  the `run()` function automatically uses a thread pool so that database access
+  does not interfere with other in-flight requests. See [Cooperative
   Multitasking](../overview/#cooperative-multitasking) for more information on
   why this is necessary.
 

--- a/site/guide/6-state.md
+++ b/site/guide/6-state.md
@@ -205,7 +205,6 @@ request-local state to implement request timing.
 [`FromRequest` request-local state]: @api/rocket/request/trait.FromRequest.html#request-local-state
 [`Fairing`]: @api/rocket/fairing/trait.Fairing.html#request-local-state
 
-<!-- TODO.async: rewrite? -->
 ## Databases
 
 Rocket includes built-in, ORM-agnostic support for databases. In particular,
@@ -222,7 +221,7 @@ three simple steps:
 
   1. Configure the databases in `Rocket.toml`.
   2. Associate a request guard type and fairing with each database.
-  3. Use the request guard to retrieve a connection in a handler.
+  3. Use the request guard to retrieve and use a connection in a handler.
 
 Presently, Rocket provides built-in support for the following databases:
 
@@ -301,7 +300,7 @@ fn rocket() -> rocket::Rocket {
 ```
 
 That's it! Whenever a connection to the database is needed, use your type as a
-request guard:
+request guard. The database can be accessed by calling the `run` method:
 
 ```rust
 # #[macro_use] extern crate rocket;
@@ -315,9 +314,9 @@ request guard:
 # type Logs = ();
 
 #[get("/logs/<id>")]
-fn get_logs(conn: LogsDbConn, id: usize) -> Logs {
+async fn get_logs(conn: LogsDbConn, id: usize) -> Logs {
     # /*
-    logs::filter(id.eq(log_id)).load(&*conn)
+    conn.run(|c| logs::filter(id.eq(log_id)).load(c)).await
     # */
 }
 ```
@@ -328,6 +327,15 @@ fn get_logs(conn: LogsDbConn, id: usize) -> Logs {
   specific and not built into Rocket. It also uses [Diesel]'s query-building
   syntax. Rocket does not provide an ORM. It is up to you to decide how to model
   your application's data.
+
+! note
+
+  The database engines supported by `#[database]` are *synchronous*, and
+  normally block the thread of execution. The `run()` function automatically
+  uses `tokio::spawn_blocking` so that database access does not interfere with
+  other in-flight requests. See [Cooperative
+  Multitasking](../overview/#cooperative-multitasking) for more information on
+  why this is necessary.
 
 If your application uses features of a database engine that are not available
 by default, for example support for `chrono` or `uuid`, you may enable those


### PR DESCRIPTION
Replaces #1343. Most of this description is a verbatim copy from that PR, but "High-Level Implementation Notes" is new.

The connection guard type generated by `#[database]` no longer implements `Deref` and `DerefMut`. Instead, it provides an `async fn run()` that gives access to the underlying connection on a closure run through `spawn_blocking()`.

## Background

All existing engines supported by `#[database]` are synchronous. Several of them, such as `diesel` and `sqlite`, do not have a well-supported `async` version or close alternative available. Therefore, I would consider it a non-starter to entirely drop support for them. However, using synchronous database libraries from `async` code has some issues:

## Motivation

Performing blocking operations while running on an asynchronous runtime is a footgun:
* Best case: the server does not experience enough load to exhibit any problems.
* Bad case: requests that are busy in a blocking operation will "artificially" prevent other requests from running or continuing, including any that are partway through I/O with the client, even if those other requests don't need to perform any blocking operation themselves.
* Worst case: deadlocks can occur. With database pools in particular, you could end up in a situation where all threads are waiting for a connection to be returned to the pool - but those connections are all held by tasks that cannot run, because the worker threads are all tied up waiting.

## High-Level Implementation Notes
* Most code has been moved into library code instead of being generated. This isn't *supposed* to make a difference to consuming code, but it is revealed in an error message. It does break any code that relied on certain implementation details, such as `conn.0` being equivalent to `*conn` or the existence of `<db_type>Pool` inside managed state. Although these were not part of the documented interface, they might have been used on accident (e.g. an IDE or compiler suggestion).
* `FromRequest`, `run()`, and `Drop` perform operations inside `spawn_blocking()`. `FromRequest` and `run` await the operations, and `Drop` ignores the eventual result.
  * A previous version of this PR made a single `spawn_blocking` call in `run()`. This has a theoretical and not-measured performance advantage, but at *significant* cost to ergonomics: it moves the "connection unavailable" error condition into routes, instead of `FromRequest`.
* An async `Semaphore` limits the number of active guard objects to `pool_size`. This is necessary to prevent a lockup: the blocking task queue has capacity `N`, and if at least `N` blocking tasks from `FromRequest` are busy, the tasks spawned by `Drop`  never get to run. `r2d2` does have a few timeouts; without those this situtation would be a deadlock.

## Problems and Alternatives

* It's inconvenient to do any asynchronous work inside the closure, so depending on the usage patterns `run()` might need to be called multiple times in between non-database work.
* `spawn_blocking`, and several other approaches such as a work queue, require the passed-in closure/data to be `'static`. This can become a headache in combination with any data that holds a borrow, such as `State<'_, T>` or an `&str`. I expect this to be the biggest problem with this approach in user code.
  * This drawback is *also* the most problematic one to "work around". In order to be sound, a wrapper that did *not* require a `'static` closure would need to either (synchronously!) wait on the spawned task's completion or abort the process in the event that the parent task was canceled before the blocking task completed.
* Instead of wrapping only database operations, we could wrap entire routes in `spawn_blocking`. I have avoided this approach, as I expect it to be *even more* problematic given the `'static` restrictions.

## Todo

* [ ] Thoroughly review and fix all applicable documentation, including the guide -- especially code that is for demonstration purposes and is not actually checked or run.