### PR TITLE
add support for Last-Modified and If-Modified-Since headers

### DIFF
--- a/core/lib/src/response/status.rs
+++ b/core/lib/src/response/status.rs
@@ -413,6 +413,18 @@ impl<'r, 'o: 'r, R: Responder<'r, 'o>> Responder<'r, 'o> for Conflict<R> {
     }
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct NotModified;
+
+/// Sets the status code of the response to 304 Not Modified.
+impl<'r, 'o: 'r> Responder<'r, 'o> for NotModified {
+    fn respond_to(self, _req: &'r Request<'_>) -> response::Result<'o> {
+        Response::build()
+            .status(Status::NotModified)
+            .ok()
+    }
+}
+
 /// Creates a response with the given status code and underlying responder.
 ///
 /// # Example


### PR DESCRIPTION
#989, #95 

Adds support for Last-Modified and If-Modified-Since headers.

- If a `NamedFile` is requested with the If-Modified-Since header set and the file was last modified before the date in the header, the server instead responds with 304 Not Modified
- If that header is not present, the file is sent over with the Last-Modified header (on supported platforms/OS)

I'm pretty new to rocket so let me know if I'm doing anything wrong and if the style is ok! (no rustfmt... shame :stuck_out_tongue: )