### PR TITLE
Upgrade (almost) all dependencies

### DIFF
--- a/contrib/lib/Cargo.toml
+++ b/contrib/lib/Cargo.toml
@@ -36,7 +36,6 @@ postgres_pool = ["databases", "postgres", "r2d2_postgres"]
 mysql_pool = ["databases", "mysql", "r2d2_mysql"]
 sqlite_pool = ["databases", "rusqlite", "r2d2_sqlite"]
 redis_pool = ["databases", "redis", "r2d2_redis"]
-mongodb_pool = ["databases", "mongodb", "r2d2-mongodb"]
 memcache_pool = ["databases", "memcache", "r2d2-memcache"]
 
 [dependencies]
@@ -71,8 +70,6 @@ rusqlite = { version = "0.23", optional = true }
 r2d2_sqlite = { version = "0.16", optional = true }
 redis = { version = "0.15", optional = true }
 r2d2_redis = { version = "0.13", optional = true }
-mongodb = { version = "0.3.12", optional = true }
-r2d2-mongodb = { version = "0.2.0", optional = true }
 memcache = { version = "0.14", optional = true }
 r2d2-memcache = { version = "0.5", optional = true }
 

--- a/contrib/lib/Cargo.toml
+++ b/contrib/lib/Cargo.toml
@@ -68,8 +68,8 @@ r2d2 = { version = "0.8", optional = true }
 r2d2_postgres = { version = "0.16", optional = true }
 mysql = { version = "18.0", optional = true }
 r2d2_mysql = { version = "18.0", optional = true }
-rusqlite = { version = "0.16.0", optional = true }
-r2d2_sqlite = { version = "0.8", optional = true }
+rusqlite = { version = "0.23", optional = true }
+r2d2_sqlite = { version = "0.16", optional = true }
 rusted_cypher = { version = "1", optional = true }
 r2d2_cypher = { version = "0.4", optional = true }
 redis = { version = "0.13", optional = true }

--- a/contrib/lib/Cargo.toml
+++ b/contrib/lib/Cargo.toml
@@ -72,8 +72,8 @@ rusqlite = { version = "0.23", optional = true }
 r2d2_sqlite = { version = "0.16", optional = true }
 rusted_cypher = { version = "1", optional = true }
 r2d2_cypher = { version = "0.4", optional = true }
-redis = { version = "0.13", optional = true }
-r2d2_redis = { version = "0.12", optional = true }
+redis = { version = "0.15", optional = true }
+r2d2_redis = { version = "0.13", optional = true }
 mongodb = { version = "0.3.12", optional = true }
 r2d2-mongodb = { version = "0.2.0", optional = true }
 memcache = { version = "0.14", optional = true }

--- a/contrib/lib/Cargo.toml
+++ b/contrib/lib/Cargo.toml
@@ -35,7 +35,6 @@ diesel_mysql_pool = ["databases", "diesel/mysql", "diesel/r2d2"]
 postgres_pool = ["databases", "postgres", "r2d2_postgres"]
 mysql_pool = ["databases", "mysql", "r2d2_mysql"]
 sqlite_pool = ["databases", "rusqlite", "r2d2_sqlite"]
-cypher_pool = ["databases", "rusted_cypher", "r2d2_cypher"]
 redis_pool = ["databases", "redis", "r2d2_redis"]
 mongodb_pool = ["databases", "mongodb", "r2d2-mongodb"]
 memcache_pool = ["databases", "memcache", "r2d2-memcache"]
@@ -70,8 +69,6 @@ mysql = { version = "18.0", optional = true }
 r2d2_mysql = { version = "18.0", optional = true }
 rusqlite = { version = "0.23", optional = true }
 r2d2_sqlite = { version = "0.16", optional = true }
-rusted_cypher = { version = "1", optional = true }
-r2d2_cypher = { version = "0.4", optional = true }
 redis = { version = "0.15", optional = true }
 r2d2_redis = { version = "0.13", optional = true }
 mongodb = { version = "0.3.12", optional = true }

--- a/contrib/lib/Cargo.toml
+++ b/contrib/lib/Cargo.toml
@@ -66,8 +66,8 @@ diesel = { version = "1.0", default-features = false, optional = true }
 postgres = { version = "0.17", optional = true }
 r2d2 = { version = "0.8", optional = true }
 r2d2_postgres = { version = "0.16", optional = true }
-mysql = { version = "17.0", optional = true }
-r2d2_mysql = { version = "17.0", optional = true }
+mysql = { version = "18.0", optional = true }
+r2d2_mysql = { version = "18.0", optional = true }
 rusqlite = { version = "0.16.0", optional = true }
 r2d2_sqlite = { version = "0.8", optional = true }
 rusted_cypher = { version = "1", optional = true }

--- a/contrib/lib/src/databases.rs
+++ b/contrib/lib/src/databases.rs
@@ -340,7 +340,7 @@
 //! | Kind     | Driver                | Version   | `Poolable` Type                | Feature                |
 //! |----------|-----------------------|-----------|--------------------------------|------------------------|
 //! | MySQL    | [Diesel]              | `1`       | [`diesel::MysqlConnection`]    | `diesel_mysql_pool`    |
-//! | MySQL    | [`rust-mysql-simple`] | `17`      | [`mysql::Conn`]                | `mysql_pool`           |
+//! | MySQL    | [`rust-mysql-simple`] | `18`      | [`mysql::Conn`]                | `mysql_pool`           |
 //! | Postgres | [Diesel]              | `1`       | [`diesel::PgConnection`]       | `diesel_postgres_pool` |
 //! | Postgres | [Rust-Postgres]       | `0.17`    | [`postgres::Client`]           | `postgres_pool`        |
 //! | Sqlite   | [Diesel]              | `1`       | [`diesel::SqliteConnection`]   | `diesel_sqlite_pool`   |
@@ -357,7 +357,7 @@
 //! [`diesel::SqliteConnection`]: http://docs.diesel.rs/diesel/prelude/struct.SqliteConnection.html
 //! [`postgres::Client`]: https://docs.rs/postgres/0.17/postgres/struct.Client.html
 //! [`diesel::PgConnection`]: http://docs.diesel.rs/diesel/pg/struct.PgConnection.html
-//! [`mysql::Conn`]: https://docs.rs/mysql/17/mysql/struct.Conn.html
+//! [`mysql::Conn`]: https://docs.rs/mysql/18/mysql/struct.Conn.html
 //! [`diesel::MysqlConnection`]: http://docs.diesel.rs/diesel/mysql/struct.MysqlConnection.html
 //! [`redis-rs`]: https://github.com/mitsuhiko/redis-rs
 //! [`rusted_cypher`]: https://github.com/livioribeiro/rusted-cypher

--- a/contrib/lib/src/databases.rs
+++ b/contrib/lib/src/databases.rs
@@ -346,7 +346,6 @@
 //! | Sqlite   | [Diesel]              | `1`       | [`diesel::SqliteConnection`]   | `diesel_sqlite_pool`   |
 //! | Sqlite   | [`Rusqlite`]          | `0.23`    | [`rusqlite::Connection`]       | `sqlite_pool`          |
 //! | Redis    | [`redis-rs`]          | `0.15`    | [`redis::Connection`]          | `redis_pool`           |
-//! | MongoDB  | [`mongodb`]           | `0.3.12`  | [`mongodb::db::Database`]      | `mongodb_pool`         |
 //! | Memcache | [`memcache`]          | `0.14`    | [`memcache::Client`]           | `memcache_pool`        |
 //!
 //! [Diesel]: https://diesel.rs
@@ -362,8 +361,6 @@
 //! [Rust-Postgres]: https://github.com/sfackler/rust-postgres
 //! [`rust-mysql-simple`]: https://github.com/blackbeam/rust-mysql-simple
 //! [`diesel::PgConnection`]: http://docs.diesel.rs/diesel/pg/struct.PgConnection.html
-//! [`mongodb`]: https://github.com/mongodb-labs/mongo-rust-driver-prototype
-//! [`mongodb::db::Database`]: https://docs.rs/mongodb/0.3.12/mongodb/db/type.Database.html
 //! [`memcache`]: https://github.com/aisk/rust-memcache
 //! [`memcache::Client`]: https://docs.rs/memcache/0.14/memcache/struct.Client.html
 //!
@@ -415,9 +412,6 @@ use self::r2d2::ManageConnection;
 
 #[cfg(feature = "redis_pool")] pub extern crate redis;
 #[cfg(feature = "redis_pool")] pub extern crate r2d2_redis;
-
-#[cfg(feature = "mongodb_pool")] pub extern crate mongodb;
-#[cfg(feature = "mongodb_pool")] pub extern crate r2d2_mongodb;
 
 #[cfg(feature = "memcache_pool")] pub extern crate memcache;
 #[cfg(feature = "memcache_pool")] pub extern crate r2d2_memcache;
@@ -792,17 +786,6 @@ impl Poolable for redis::Connection {
         let manager = r2d2_redis::RedisConnectionManager::new(config.url).map_err(DbError::Custom)?;
         r2d2::Pool::builder().max_size(config.pool_size).build(manager)
             .map_err(DbError::PoolError)
-    }
-}
-
-#[cfg(feature = "mongodb_pool")]
-impl Poolable for mongodb::db::Database {
-    type Manager = r2d2_mongodb::MongodbConnectionManager;
-    type Error = DbError<mongodb::Error>;
-
-    fn pool(config: DatabaseConfig<'_>) -> Result<r2d2::Pool<Self::Manager>, Self::Error> {
-        let manager = r2d2_mongodb::MongodbConnectionManager::new_with_uri(config.url).map_err(DbError::Custom)?;
-        r2d2::Pool::builder().max_size(config.pool_size).build(manager).map_err(DbError::PoolError)
     }
 }
 

--- a/contrib/lib/src/databases.rs
+++ b/contrib/lib/src/databases.rs
@@ -346,12 +346,12 @@
 //! | Sqlite   | [Diesel]              | `1`       | [`diesel::SqliteConnection`]   | `diesel_sqlite_pool`   |
 //! | Sqlite   | [`Rusqlite`]          | `0.23`    | [`rusqlite::Connection`]       | `sqlite_pool`          |
 //! | Neo4j    | [`rusted_cypher`]     | `1`       | [`rusted_cypher::GraphClient`] | `cypher_pool`          |
-//! | Redis    | [`redis-rs`]          | `0.13`    | [`redis::Connection`]          | `redis_pool`           |
+//! | Redis    | [`redis-rs`]          | `0.15`    | [`redis::Connection`]          | `redis_pool`           |
 //! | MongoDB  | [`mongodb`]           | `0.3.12`  | [`mongodb::db::Database`]      | `mongodb_pool`         |
 //! | Memcache | [`memcache`]          | `0.14`    | [`memcache::Client`]           | `memcache_pool`        |
 //!
 //! [Diesel]: https://diesel.rs
-//! [`redis::Connection`]: https://docs.rs/redis/0.13.0/redis/struct.Connection.html
+//! [`redis::Connection`]: https://docs.rs/redis/0.15.0/redis/struct.Connection.html
 //! [`rusted_cypher::GraphClient`]: https://docs.rs/rusted_cypher/1.1.0/rusted_cypher/graph/struct.GraphClient.html
 //! [`rusqlite::Connection`]: https://docs.rs/rusqlite/0.23.0/rusqlite/struct.Connection.html
 //! [`diesel::SqliteConnection`]: http://docs.diesel.rs/diesel/prelude/struct.SqliteConnection.html

--- a/contrib/lib/src/databases.rs
+++ b/contrib/lib/src/databases.rs
@@ -344,7 +344,7 @@
 //! | Postgres | [Diesel]              | `1`       | [`diesel::PgConnection`]       | `diesel_postgres_pool` |
 //! | Postgres | [Rust-Postgres]       | `0.17`    | [`postgres::Client`]           | `postgres_pool`        |
 //! | Sqlite   | [Diesel]              | `1`       | [`diesel::SqliteConnection`]   | `diesel_sqlite_pool`   |
-//! | Sqlite   | [`Rusqlite`]          | `0.16`    | [`rusqlite::Connection`]       | `sqlite_pool`          |
+//! | Sqlite   | [`Rusqlite`]          | `0.23`    | [`rusqlite::Connection`]       | `sqlite_pool`          |
 //! | Neo4j    | [`rusted_cypher`]     | `1`       | [`rusted_cypher::GraphClient`] | `cypher_pool`          |
 //! | Redis    | [`redis-rs`]          | `0.13`    | [`redis::Connection`]          | `redis_pool`           |
 //! | MongoDB  | [`mongodb`]           | `0.3.12`  | [`mongodb::db::Database`]      | `mongodb_pool`         |
@@ -353,7 +353,7 @@
 //! [Diesel]: https://diesel.rs
 //! [`redis::Connection`]: https://docs.rs/redis/0.13.0/redis/struct.Connection.html
 //! [`rusted_cypher::GraphClient`]: https://docs.rs/rusted_cypher/1.1.0/rusted_cypher/graph/struct.GraphClient.html
-//! [`rusqlite::Connection`]: https://docs.rs/rusqlite/0.16.0/rusqlite/struct.Connection.html
+//! [`rusqlite::Connection`]: https://docs.rs/rusqlite/0.23.0/rusqlite/struct.Connection.html
 //! [`diesel::SqliteConnection`]: http://docs.diesel.rs/diesel/prelude/struct.SqliteConnection.html
 //! [`postgres::Client`]: https://docs.rs/postgres/0.17/postgres/struct.Client.html
 //! [`diesel::PgConnection`]: http://docs.diesel.rs/diesel/pg/struct.PgConnection.html

--- a/contrib/lib/src/databases.rs
+++ b/contrib/lib/src/databases.rs
@@ -345,14 +345,12 @@
 //! | Postgres | [Rust-Postgres]       | `0.17`    | [`postgres::Client`]           | `postgres_pool`        |
 //! | Sqlite   | [Diesel]              | `1`       | [`diesel::SqliteConnection`]   | `diesel_sqlite_pool`   |
 //! | Sqlite   | [`Rusqlite`]          | `0.23`    | [`rusqlite::Connection`]       | `sqlite_pool`          |
-//! | Neo4j    | [`rusted_cypher`]     | `1`       | [`rusted_cypher::GraphClient`] | `cypher_pool`          |
 //! | Redis    | [`redis-rs`]          | `0.15`    | [`redis::Connection`]          | `redis_pool`           |
 //! | MongoDB  | [`mongodb`]           | `0.3.12`  | [`mongodb::db::Database`]      | `mongodb_pool`         |
 //! | Memcache | [`memcache`]          | `0.14`    | [`memcache::Client`]           | `memcache_pool`        |
 //!
 //! [Diesel]: https://diesel.rs
 //! [`redis::Connection`]: https://docs.rs/redis/0.15.0/redis/struct.Connection.html
-//! [`rusted_cypher::GraphClient`]: https://docs.rs/rusted_cypher/1.1.0/rusted_cypher/graph/struct.GraphClient.html
 //! [`rusqlite::Connection`]: https://docs.rs/rusqlite/0.23.0/rusqlite/struct.Connection.html
 //! [`diesel::SqliteConnection`]: http://docs.diesel.rs/diesel/prelude/struct.SqliteConnection.html
 //! [`postgres::Client`]: https://docs.rs/postgres/0.17/postgres/struct.Client.html
@@ -360,7 +358,6 @@
 //! [`mysql::Conn`]: https://docs.rs/mysql/18/mysql/struct.Conn.html
 //! [`diesel::MysqlConnection`]: http://docs.diesel.rs/diesel/mysql/struct.MysqlConnection.html
 //! [`redis-rs`]: https://github.com/mitsuhiko/redis-rs
-//! [`rusted_cypher`]: https://github.com/livioribeiro/rusted-cypher
 //! [`Rusqlite`]: https://github.com/jgallagher/rusqlite
 //! [Rust-Postgres]: https://github.com/sfackler/rust-postgres
 //! [`rust-mysql-simple`]: https://github.com/blackbeam/rust-mysql-simple
@@ -415,9 +412,6 @@ use self::r2d2::ManageConnection;
 
 #[cfg(feature = "sqlite_pool")] pub extern crate rusqlite;
 #[cfg(feature = "sqlite_pool")] pub extern crate r2d2_sqlite;
-
-#[cfg(feature = "cypher_pool")] pub extern crate rusted_cypher;
-#[cfg(feature = "cypher_pool")] pub extern crate r2d2_cypher;
 
 #[cfg(feature = "redis_pool")] pub extern crate redis;
 #[cfg(feature = "redis_pool")] pub extern crate r2d2_redis;
@@ -626,7 +620,6 @@ impl<'a> Display for ConfigError {
 ///   * `postgres::Connection`
 ///   * `mysql::Conn`
 ///   * `rusqlite::Connection`
-///   * `rusted_cypher::GraphClient`
 ///   * `redis::Connection`
 ///
 /// # Implementation Guide
@@ -786,17 +779,6 @@ impl Poolable for rusqlite::Connection {
     fn pool(config: DatabaseConfig<'_>) -> Result<r2d2::Pool<Self::Manager>, Self::Error> {
         let manager = r2d2_sqlite::SqliteConnectionManager::file(config.url);
 
-        r2d2::Pool::builder().max_size(config.pool_size).build(manager)
-    }
-}
-
-#[cfg(feature = "cypher_pool")]
-impl Poolable for rusted_cypher::GraphClient {
-    type Manager = r2d2_cypher::CypherConnectionManager;
-    type Error = r2d2::Error;
-
-    fn pool(config: DatabaseConfig<'_>) -> Result<r2d2::Pool<Self::Manager>, Self::Error> {
-        let manager = r2d2_cypher::CypherConnectionManager { url: config.url.to_string() };
         r2d2::Pool::builder().max_size(config.pool_size).build(manager)
     }
 }

--- a/core/http/Cargo.toml
+++ b/core/http/Cargo.toml
@@ -21,7 +21,7 @@ private-cookies = ["cookie/private", "cookie/key-expansion"]
 
 [dependencies]
 smallvec = "1.0"
-percent-encoding = "1"
+percent-encoding = "2"
 hyper = { version = "0.13.0", default-features = false }
 http = "0.2"
 mime = "0.3.13"

--- a/core/http/Cargo.toml
+++ b/core/http/Cargo.toml
@@ -28,7 +28,7 @@ mime = "0.3.13"
 time = "0.2.11"
 indexmap = "1.0"
 state = "0.4"
-tokio-rustls = { version = "0.12.0", optional = true }
+tokio-rustls = { version = "0.14.0", optional = true }
 tokio = { version = "0.2.9", features = ["sync", "tcp", "time"] }
 cookie = { version = "0.14.0", features = ["percent-encode"] }
 pear = "0.1"

--- a/core/http/src/parse/uri/mod.rs
+++ b/core/http/src/parse/uri/mod.rs
@@ -8,7 +8,7 @@ use crate::uri::{Uri, Origin, Absolute, Authority};
 use crate::parse::indexed::IndexedInput;
 use self::parser::{uri, origin, authority_only, absolute_only, rocket_route_origin};
 
-pub use self::tables::is_pchar;
+pub use self::tables::{is_pchar, PATH_SET};
 pub use self::error::Error;
 
 type RawInput<'a> = IndexedInput<'a, [u8]>;

--- a/core/http/src/uri/encoding.rs
+++ b/core/http/src/uri/encoding.rs
@@ -1,14 +1,17 @@
 use std::marker::PhantomData;
 use std::borrow::Cow;
 
-use percent_encoding::{EncodeSet, utf8_percent_encode};
+use percent_encoding::{AsciiSet, utf8_percent_encode};
 
 use crate::uri::{UriPart, Path, Query};
-use crate::parse::uri::is_pchar;
+use crate::parse::uri::PATH_SET;
 
 #[derive(Clone, Copy)]
 #[allow(non_camel_case_types)]
 pub struct UNSAFE_ENCODE_SET<P: UriPart>(PhantomData<P>);
+pub trait EncodeSet {
+    const SET: AsciiSet;
+}
 
 impl<P: UriPart> Default for UNSAFE_ENCODE_SET<P> {
     #[inline(always)]
@@ -16,17 +19,15 @@ impl<P: UriPart> Default for UNSAFE_ENCODE_SET<P> {
 }
 
 impl EncodeSet for UNSAFE_ENCODE_SET<Path> {
-    #[inline(always)]
-    fn contains(&self, byte: u8) -> bool {
-        !is_pchar(byte) || byte == b'%'
-    }
+    const SET: AsciiSet = PATH_SET
+        .add(b'%');
 }
 
 impl EncodeSet for UNSAFE_ENCODE_SET<Query> {
-    #[inline(always)]
-    fn contains(&self, byte: u8) -> bool {
-        (!is_pchar(byte) && (byte != b'?')) || byte == b'%' || byte == b'+'
-    }
+    const SET: AsciiSet = PATH_SET
+        .remove(b'?')
+        .add(b'%')
+        .add(b'+');
 }
 
 #[derive(Clone, Copy)]
@@ -34,20 +35,14 @@ impl EncodeSet for UNSAFE_ENCODE_SET<Query> {
 pub struct ENCODE_SET<P: UriPart>(PhantomData<P>);
 
 impl EncodeSet for ENCODE_SET<Path> {
-    #[inline(always)]
-    fn contains(&self, byte: u8) -> bool {
-        <UNSAFE_ENCODE_SET<Path>>::default().contains(byte) || byte == b'/'
-    }
+    const SET: AsciiSet = <UNSAFE_ENCODE_SET<Path>>::SET
+        .add(b'/');
 }
 
 impl EncodeSet for ENCODE_SET<Query> {
-    #[inline(always)]
-    fn contains(&self, byte: u8) -> bool {
-        <UNSAFE_ENCODE_SET<Query>>::default().contains(byte) || match byte {
-            b'&' | b'=' => true,
-            _ => false
-        }
-    }
+    const SET: AsciiSet = <UNSAFE_ENCODE_SET<Query>>::SET
+        .add(b'&')
+        .add(b'=');
 }
 
 #[derive(Default, Clone, Copy)]
@@ -55,11 +50,15 @@ impl EncodeSet for ENCODE_SET<Query> {
 pub struct DEFAULT_ENCODE_SET;
 
 impl EncodeSet for DEFAULT_ENCODE_SET {
-    #[inline(always)]
-    fn contains(&self, byte: u8) -> bool {
-        ENCODE_SET::<Path>(PhantomData).contains(byte) ||
-            ENCODE_SET::<Query>(PhantomData).contains(byte)
-    }
+    // DEFAULT_ENCODE_SET Includes:
+    // * ENCODE_SET<Path> (and UNSAFE_ENCODE_SET<Path>)
+    const SET: AsciiSet = <ENCODE_SET<Path>>::SET
+        // * UNSAFE_ENCODE_SET<Query>
+        .add(b'%')
+        .add(b'+')
+        // * ENCODE_SET<Query>
+        .add(b'&')
+        .add(b'=');
 }
 
 pub fn unsafe_percent_encode<P: UriPart>(string: &str) -> Cow<'_, str> {
@@ -71,5 +70,5 @@ pub fn unsafe_percent_encode<P: UriPart>(string: &str) -> Cow<'_, str> {
 }
 
 pub fn percent_encode<S: EncodeSet + Default>(string: &str) -> Cow<'_, str> {
-    utf8_percent_encode(string, S::default()).into()
+    utf8_percent_encode(string, &S::SET).into()
 }

--- a/examples/raw_sqlite/Cargo.toml
+++ b/examples/raw_sqlite/Cargo.toml
@@ -7,4 +7,4 @@ publish = false
 
 [dependencies]
 rocket = { path = "../../core/lib" }
-rusqlite = "0.16"
+rusqlite = "0.23"

--- a/examples/todo/Cargo.toml
+++ b/examples/todo/Cargo.toml
@@ -15,7 +15,7 @@ diesel_migrations = "1.3"
 log = "0.4"
 
 [dev-dependencies]
-parking_lot = { version = "0.10", features = ["nightly"] }
+parking_lot = "0.11"
 rand = "0.7"
 
 [dependencies.rocket_contrib]

--- a/examples/todo/src/tests.rs
+++ b/examples/todo/src/tests.rs
@@ -9,7 +9,7 @@ use rocket::http::{Status, ContentType};
 // We use a lock to synchronize between tests so DB operations don't collide.
 // For now. In the future, we'll have a nice way to run each test in a DB
 // transaction so we can regain concurrency.
-static DB_LOCK: Mutex<()> = Mutex::new(());
+static DB_LOCK: Mutex<()> = parking_lot::const_mutex(());
 
 macro_rules! run_test {
     (|$client:ident, $conn:ident| $block:expr) => ({

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -76,7 +76,6 @@ if [ "$1" = "--contrib" ]; then
     mysql_pool
     sqlite_pool
     redis_pool
-    mongodb_pool
     memcache_pool
     brotli_compression
     gzip_compression

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -75,7 +75,6 @@ if [ "$1" = "--contrib" ]; then
     postgres_pool
     mysql_pool
     sqlite_pool
-    cypher_pool
     redis_pool
     mongodb_pool
     memcache_pool

--- a/site/guide/6-state.md
+++ b/site/guide/6-state.md
@@ -236,7 +236,6 @@ Presently, Rocket provides built-in support for the following databases:
 | Sqlite   | [Diesel]              | `1`       | [`diesel::SqliteConnection`]   | `diesel_sqlite_pool`   |
 | Sqlite   | [`Rusqlite`]          | `0.23`    | [`rusqlite::Connection`]       | `sqlite_pool`          |
 | Redis    | [`redis-rs`]          | `0.15`    | [`redis::Connection`]          | `redis_pool`           |
-| MongoDB  | [`mongodb`]           | `0.3.12`  | [`mongodb::db::Database`]      | `mongodb_pool`         |
 | Memcache | [`memcache`]          | `0.14`    | [`memcache::Client`]           | `memcache_pool`        |
 
 [`r2d2`]: https://crates.io/crates/r2d2
@@ -253,8 +252,6 @@ Presently, Rocket provides built-in support for the following databases:
 [Rust-Postgres]: https://github.com/sfackler/rust-postgres
 [`rust-mysql-simple`]: https://github.com/blackbeam/rust-mysql-simple
 [`diesel::PgConnection`]: http://docs.diesel.rs/diesel/pg/struct.PgConnection.html
-[`mongodb`]: https://github.com/mongodb-labs/mongo-rust-driver-prototype
-[`mongodb::db::Database`]: https://docs.rs/mongodb/0.3.12/mongodb/db/type.Database.html
 [`memcache`]: https://github.com/aisk/rust-memcache
 [`memcache::Client`]: https://docs.rs/memcache/0.14/memcache/struct.Client.html
 

--- a/site/guide/6-state.md
+++ b/site/guide/6-state.md
@@ -230,7 +230,7 @@ Presently, Rocket provides built-in support for the following databases:
 | Kind     | Driver                | Version   | `Poolable` Type                | Feature                |
 |----------|-----------------------|-----------|--------------------------------|------------------------|
 | MySQL    | [Diesel]              | `1`       | [`diesel::MysqlConnection`]    | `diesel_mysql_pool`    |
-| MySQL    | [`rust-mysql-simple`] | `17`      | [`mysql::Conn`]                | `mysql_pool`           |
+| MySQL    | [`rust-mysql-simple`] | `18`      | [`mysql::Conn`]                | `mysql_pool`           |
 | Postgres | [Diesel]              | `1`       | [`diesel::PgConnection`]       | `diesel_postgres_pool` |
 | Postgres | [Rust-Postgres]       | `0.17`    | [`postgres::Client`]           | `postgres_pool`        |
 | Sqlite   | [Diesel]              | `1`       | [`diesel::SqliteConnection`]   | `diesel_sqlite_pool`   |
@@ -248,7 +248,7 @@ Presently, Rocket provides built-in support for the following databases:
 [`diesel::SqliteConnection`]: http://docs.diesel.rs/diesel/prelude/struct.SqliteConnection.html
 [`postgres::Client`]: https://docs.rs/postgres/0.17/postgres/struct.Client.html
 [`diesel::PgConnection`]: http://docs.diesel.rs/diesel/pg/struct.PgConnection.html
-[`mysql::Conn`]: https://docs.rs/mysql/17/mysql/struct.Conn.html
+[`mysql::Conn`]: https://docs.rs/mysql/18/mysql/struct.Conn.html
 [`diesel::MysqlConnection`]: http://docs.diesel.rs/diesel/mysql/struct.MysqlConnection.html
 [`redis-rs`]: https://github.com/mitsuhiko/redis-rs
 [`rusted_cypher`]: https://github.com/livioribeiro/rusted-cypher

--- a/site/guide/6-state.md
+++ b/site/guide/6-state.md
@@ -234,7 +234,7 @@ Presently, Rocket provides built-in support for the following databases:
 | Postgres | [Diesel]              | `1`       | [`diesel::PgConnection`]       | `diesel_postgres_pool` |
 | Postgres | [Rust-Postgres]       | `0.17`    | [`postgres::Client`]           | `postgres_pool`        |
 | Sqlite   | [Diesel]              | `1`       | [`diesel::SqliteConnection`]   | `diesel_sqlite_pool`   |
-| Sqlite   | [`Rusqlite`]          | `0.16`    | [`rusqlite::Connection`]       | `sqlite_pool`          |
+| Sqlite   | [`Rusqlite`]          | `0.23`    | [`rusqlite::Connection`]       | `sqlite_pool`          |
 | Neo4j    | [`rusted_cypher`]     | `1`       | [`rusted_cypher::GraphClient`] | `cypher_pool`          |
 | Redis    | [`redis-rs`]          | `0.13`    | [`redis::Connection`]          | `redis_pool`           |
 | MongoDB  | [`mongodb`]           | `0.3.12`  | [`mongodb::db::Database`]      | `mongodb_pool`         |
@@ -244,7 +244,7 @@ Presently, Rocket provides built-in support for the following databases:
 [Diesel]: https://diesel.rs
 [`redis::Connection`]: https://docs.rs/redis/0.13.0/redis/struct.Connection.html
 [`rusted_cypher::GraphClient`]: https://docs.rs/rusted_cypher/1.1.0/rusted_cypher/graph/struct.GraphClient.html
-[`rusqlite::Connection`]: https://docs.rs/rusqlite/0.16.0/rusqlite/struct.Connection.html
+[`rusqlite::Connection`]: https://docs.rs/rusqlite/0.23.0/rusqlite/struct.Connection.html
 [`diesel::SqliteConnection`]: http://docs.diesel.rs/diesel/prelude/struct.SqliteConnection.html
 [`postgres::Client`]: https://docs.rs/postgres/0.17/postgres/struct.Client.html
 [`diesel::PgConnection`]: http://docs.diesel.rs/diesel/pg/struct.PgConnection.html

--- a/site/guide/6-state.md
+++ b/site/guide/6-state.md
@@ -236,13 +236,13 @@ Presently, Rocket provides built-in support for the following databases:
 | Sqlite   | [Diesel]              | `1`       | [`diesel::SqliteConnection`]   | `diesel_sqlite_pool`   |
 | Sqlite   | [`Rusqlite`]          | `0.23`    | [`rusqlite::Connection`]       | `sqlite_pool`          |
 | Neo4j    | [`rusted_cypher`]     | `1`       | [`rusted_cypher::GraphClient`] | `cypher_pool`          |
-| Redis    | [`redis-rs`]          | `0.13`    | [`redis::Connection`]          | `redis_pool`           |
+| Redis    | [`redis-rs`]          | `0.15`    | [`redis::Connection`]          | `redis_pool`           |
 | MongoDB  | [`mongodb`]           | `0.3.12`  | [`mongodb::db::Database`]      | `mongodb_pool`         |
 | Memcache | [`memcache`]          | `0.14`    | [`memcache::Client`]           | `memcache_pool`        |
 
 [`r2d2`]: https://crates.io/crates/r2d2
 [Diesel]: https://diesel.rs
-[`redis::Connection`]: https://docs.rs/redis/0.13.0/redis/struct.Connection.html
+[`redis::Connection`]: https://docs.rs/redis/0.15.0/redis/struct.Connection.html
 [`rusted_cypher::GraphClient`]: https://docs.rs/rusted_cypher/1.1.0/rusted_cypher/graph/struct.GraphClient.html
 [`rusqlite::Connection`]: https://docs.rs/rusqlite/0.23.0/rusqlite/struct.Connection.html
 [`diesel::SqliteConnection`]: http://docs.diesel.rs/diesel/prelude/struct.SqliteConnection.html

--- a/site/guide/6-state.md
+++ b/site/guide/6-state.md
@@ -235,7 +235,6 @@ Presently, Rocket provides built-in support for the following databases:
 | Postgres | [Rust-Postgres]       | `0.17`    | [`postgres::Client`]           | `postgres_pool`        |
 | Sqlite   | [Diesel]              | `1`       | [`diesel::SqliteConnection`]   | `diesel_sqlite_pool`   |
 | Sqlite   | [`Rusqlite`]          | `0.23`    | [`rusqlite::Connection`]       | `sqlite_pool`          |
-| Neo4j    | [`rusted_cypher`]     | `1`       | [`rusted_cypher::GraphClient`] | `cypher_pool`          |
 | Redis    | [`redis-rs`]          | `0.15`    | [`redis::Connection`]          | `redis_pool`           |
 | MongoDB  | [`mongodb`]           | `0.3.12`  | [`mongodb::db::Database`]      | `mongodb_pool`         |
 | Memcache | [`memcache`]          | `0.14`    | [`memcache::Client`]           | `memcache_pool`        |
@@ -243,7 +242,6 @@ Presently, Rocket provides built-in support for the following databases:
 [`r2d2`]: https://crates.io/crates/r2d2
 [Diesel]: https://diesel.rs
 [`redis::Connection`]: https://docs.rs/redis/0.15.0/redis/struct.Connection.html
-[`rusted_cypher::GraphClient`]: https://docs.rs/rusted_cypher/1.1.0/rusted_cypher/graph/struct.GraphClient.html
 [`rusqlite::Connection`]: https://docs.rs/rusqlite/0.23.0/rusqlite/struct.Connection.html
 [`diesel::SqliteConnection`]: http://docs.diesel.rs/diesel/prelude/struct.SqliteConnection.html
 [`postgres::Client`]: https://docs.rs/postgres/0.17/postgres/struct.Client.html
@@ -251,7 +249,6 @@ Presently, Rocket provides built-in support for the following databases:
 [`mysql::Conn`]: https://docs.rs/mysql/18/mysql/struct.Conn.html
 [`diesel::MysqlConnection`]: http://docs.diesel.rs/diesel/mysql/struct.MysqlConnection.html
 [`redis-rs`]: https://github.com/mitsuhiko/redis-rs
-[`rusted_cypher`]: https://github.com/livioribeiro/rusted-cypher
 [`Rusqlite`]: https://github.com/jgallagher/rusqlite
 [Rust-Postgres]: https://github.com/sfackler/rust-postgres
 [`rust-mysql-simple`]: https://github.com/blackbeam/rust-mysql-simple


### PR DESCRIPTION
Includes a modified version of #1349.
Fixes #1341.
CC #1189.

This PR upgrades all direct dependencies except `toml` and `pear` (see #1353). It reduces the overall number of packages in `Cargo.lock` from 466 to 390 by my count.

* Removes `rusted_cypher`. It has a few old dependencies including hyper 0.10 and appears to be unmaintained for a few years now.
* Removes `mongodb`. The latest version of `mongodb` has `async`/`await` support and its own connection pooling, making it doubly unsuitable for the current implementation of `#[database]`.