### PR TITLE
Miscellaneous docs improvements.

### DIFF
--- a/contrib/lib/src/json.rs
+++ b/contrib/lib/src/json.rs
@@ -40,7 +40,7 @@ pub use serde_json::{json_internal, json_internal_vec};
 /// If you're receiving JSON data, simply add a `data` parameter to your route
 /// arguments and ensure the type of the parameter is a `Json<T>`, where `T` is
 /// some type you'd like to parse from JSON. `T` must implement [`Deserialize`]
-/// or from [`serde`]. The data is parsed from the HTTP request body.
+/// from [`serde`]. The data is parsed from the HTTP request body.
 ///
 /// ```rust
 /// # #[macro_use] extern crate rocket;

--- a/contrib/lib/src/serve.rs
+++ b/contrib/lib/src/serve.rs
@@ -126,7 +126,7 @@ impl std::ops::BitOr for Options {
 ///
 /// # Example
 ///
-/// To serve files from the `/static` local file system directory at the
+/// To serve files from the `/static` directory on the local file system at the
 /// `/public` path, allowing `index.html` files to be used to respond to
 /// requests for a directory (the default), you might write the following:
 ///
@@ -142,16 +142,16 @@ impl std::ops::BitOr for Options {
 /// ```
 ///
 /// With this, requests for files at `/public/<path..>` will be handled by
-/// returning the contents of `./static/<path..>`. Requests for _directories_ at
+/// returning the contents of `/static/<path..>`. Requests for _directories_ at
 /// `/public/<directory>` will be handled by returning the contents of
-/// `./static/<directory>/index.html`.
+/// `/static/<directory>/index.html`.
 ///
-/// If your static files are stored relative to your crate and your project is
-/// managed by Cargo, you should either use a relative path and ensure that your
-/// server is started in the crate's root directory or use the
-/// `CARGO_MANIFEST_DIR` to create an absolute path relative to your crate root.
-/// For example, to serve files in the `static` subdirectory of your crate at
-/// `/`, you might write:
+/// `/static` is an absolute path. If your static files are stored relative to
+/// your crate and your project is managed by Cargo, you should either use a
+/// relative path and ensure that your server is started in the crate's root
+/// directory or use the `CARGO_MANIFEST_DIR` to create an absolute path
+/// relative to your crate root.  For example, to serve files in the `static`
+/// subdirectory of your crate at `/`, you might write:
 ///
 /// ```rust,no_run
 /// # extern crate rocket;

--- a/core/lib/src/router/route.rs
+++ b/core/lib/src/router/route.rs
@@ -87,11 +87,11 @@ impl Route {
     /// # Ranking
     ///
     /// The route's rank is set so that routes with static paths (no dynamic
-    /// parameters) are ranked higher than routes with dynamic paths, routes
-    /// with query strings with static segments are ranked higher than routes
-    /// with fully dynamic queries, and routes with queries are ranked higher
-    /// than routes without queries. This default ranking is summarized by the
-    /// table below:
+    /// parameters) have lower ranks (higher precedence) than routes with
+    /// dynamic paths, routes with query strings with static segments have lower
+    /// ranks than routes with fully dynamic queries, and routes with queries
+    /// have lower ranks than routes without queries. This default ranking is
+    /// summarized by the table below:
     ///
     /// | static path | query         | rank |
     /// |-------------|---------------|------|

--- a/examples/content_types/Cargo.toml
+++ b/examples/content_types/Cargo.toml
@@ -8,6 +8,5 @@ publish = false
 [dependencies]
 tokio = { version = "0.2.0", features = ["io-util"] }
 rocket = { path = "../../core/lib" }
-serde = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_derive = "1.0"

--- a/examples/content_types/src/main.rs
+++ b/examples/content_types/src/main.rs
@@ -1,5 +1,4 @@
 #[macro_use] extern crate rocket;
-#[macro_use] extern crate serde_derive;
 
 #[cfg(test)] mod tests;
 
@@ -9,6 +8,8 @@ use tokio::io::AsyncReadExt;
 
 use rocket::{Request, data::Data};
 use rocket::response::{Debug, content::{Json, Html}};
+
+use serde::{Serialize, Deserialize};
 
 // NOTE: This example explicitly uses the `Json` type from `response::content`
 // for demonstration purposes. In a real application, _always_ prefer to use

--- a/examples/handlebars_templates/Cargo.toml
+++ b/examples/handlebars_templates/Cargo.toml
@@ -7,8 +7,7 @@ publish = false
 
 [dependencies]
 rocket = { path = "../../core/lib" }
-serde = "1.0"
-serde_derive = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 [dependencies.rocket_contrib]

--- a/examples/handlebars_templates/src/main.rs
+++ b/examples/handlebars_templates/src/main.rs
@@ -1,5 +1,4 @@
 #[macro_use] extern crate rocket;
-#[macro_use] extern crate serde_derive;
 
 #[cfg(test)] mod tests;
 
@@ -7,7 +6,7 @@ use rocket::Request;
 use rocket::response::Redirect;
 use rocket_contrib::templates::{Template, handlebars};
 
-#[derive(Serialize)]
+#[derive(serde::Serialize)]
 struct TemplateContext {
     title: &'static str,
     name: Option<String>,

--- a/examples/json/Cargo.toml
+++ b/examples/json/Cargo.toml
@@ -7,9 +7,8 @@ publish = false
 
 [dependencies]
 rocket = { path = "../../core/lib" }
-serde = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_derive = "1.0"
 
 [dependencies.rocket_contrib]
 path = "../../contrib/lib"

--- a/examples/json/src/main.rs
+++ b/examples/json/src/main.rs
@@ -1,6 +1,5 @@
 #[macro_use] extern crate rocket;
 #[macro_use] extern crate rocket_contrib;
-#[macro_use] extern crate serde_derive;
 
 #[cfg(test)] mod tests;
 
@@ -9,6 +8,8 @@ use std::collections::HashMap;
 
 use rocket::State;
 use rocket_contrib::json::{Json, JsonValue};
+
+use serde::{Serialize, Deserialize};
 
 // The type to represent the ID of a message.
 type ID = usize;

--- a/examples/msgpack/Cargo.toml
+++ b/examples/msgpack/Cargo.toml
@@ -7,8 +7,7 @@ publish = false
 
 [dependencies]
 rocket = { path = "../../core/lib" }
-serde = "1.0"
-serde_derive = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 
 [dependencies.rocket_contrib]
 path = "../../contrib/lib"

--- a/examples/msgpack/src/main.rs
+++ b/examples/msgpack/src/main.rs
@@ -1,9 +1,10 @@
 #[macro_use] extern crate rocket;
-#[macro_use] extern crate serde_derive;
 
 #[cfg(test)] mod tests;
 
 use rocket_contrib::msgpack::MsgPack;
+
+use serde::{Serialize, Deserialize};
 
 #[derive(Serialize, Deserialize)]
 struct Message<'r> {

--- a/examples/msgpack/src/tests.rs
+++ b/examples/msgpack/src/tests.rs
@@ -2,6 +2,8 @@ use crate::rocket;
 use rocket::local::blocking::Client;
 use rocket::http::{Status, ContentType};
 
+use serde::{Serialize, Deserialize};
+
 #[derive(Serialize, Deserialize)]
 struct Message {
     id: usize,

--- a/examples/tera_templates/Cargo.toml
+++ b/examples/tera_templates/Cargo.toml
@@ -7,8 +7,7 @@ publish = false
 
 [dependencies]
 rocket = { path = "../../core/lib" }
-serde = "1.0"
-serde_derive = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 [dependencies.rocket_contrib]

--- a/examples/tera_templates/src/main.rs
+++ b/examples/tera_templates/src/main.rs
@@ -1,5 +1,4 @@
 #[macro_use] extern crate rocket;
-#[macro_use] extern crate serde_derive;
 
 #[cfg(test)] mod tests;
 
@@ -9,7 +8,7 @@ use rocket::Request;
 use rocket::response::Redirect;
 use rocket_contrib::templates::Template;
 
-#[derive(Serialize)]
+#[derive(serde::Serialize)]
 struct TemplateContext {
     name: String,
     items: Vec<&'static str>

--- a/examples/todo/Cargo.toml
+++ b/examples/todo/Cargo.toml
@@ -7,9 +7,8 @@ publish = false
 
 [dependencies]
 rocket = { path = "../../core/lib" }
-serde = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_derive = "1.0"
 diesel = { version = "1.3", features = ["sqlite", "r2d2"] }
 diesel_migrations = "1.3"
 log = "0.4"

--- a/examples/todo/src/main.rs
+++ b/examples/todo/src/main.rs
@@ -2,7 +2,6 @@
 #[macro_use] extern crate diesel;
 #[macro_use] extern crate diesel_migrations;
 #[macro_use] extern crate log;
-#[macro_use] extern crate serde_derive;
 #[macro_use] extern crate rocket_contrib;
 
 mod task;
@@ -25,7 +24,7 @@ embed_migrations!();
 #[database("sqlite_database")]
 pub struct DbConn(SqliteConnection);
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, serde::Serialize)]
 struct Context<'a> {
     msg: Option<(&'a str, &'a str)>,
     tasks: Vec<Task>

--- a/examples/todo/src/task.rs
+++ b/examples/todo/src/task.rs
@@ -14,7 +14,7 @@ use self::schema::tasks;
 use self::schema::tasks::dsl::{tasks as all_tasks, completed as task_completed};
 
 #[table_name="tasks"]
-#[derive(Serialize, Queryable, Insertable, Debug, Clone)]
+#[derive(serde::Serialize, Queryable, Insertable, Debug, Clone)]
 pub struct Task {
     pub id: Option<i32>,
     pub description: String,

--- a/site/guide/5-responses.md
+++ b/site/guide/5-responses.md
@@ -70,10 +70,9 @@ fn json() -> content::Json<&'static str> {
 
 ### Errors
 
-Responders may fail; they need not _always_ generate a response. Instead, they
-can return an `Err` with a given status code. When this happens, Rocket forwards
-the request to the [error catcher](../requests/#error-catchers) for the
-given status code.
+Responders may fail instead of generating a response by returning an `Err` with
+a status code. When this happens, Rocket forwards the request to the [error
+catcher](../requests/#error-catchers) for that status code.
 
 If an error catcher has been registered for the given status code, Rocket will
 invoke it. The catcher creates and returns a response to the client. If no error


### PR DESCRIPTION
Fixes #1156 - `derive` feature of serde instead of `serde_derive`.
Fixes #1320 - extraneous "or"
CC #1351 - point out that `/static` is an absolute path. Not fixed yet, since a code change is mentioned there as well.
CC #1356 - simplify sentence containing "need not". Not fixed yet, since there is still a question about cookies (which is trickier)
Fixes #1360 - mention that lower rank = higher precedence.

## TODO:
* [ ] #1356 could be fixed entirely, by deciding where/how/if to document how cookie `Path`s work if unspecified.