### PR TITLE
Change Riot to Element

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,12 @@ Rocket is extensively documented:
 
 The official community support channels are [`#rocket:mozilla.org`] on Matrix
 and the bridged [`#rocket`] IRC channel on Freenode at `chat.freenode.net`. We
-recommend joining us on [Matrix via Riot]. If your prefer IRC, you can join via
-the [Kiwi IRC client] or a client of your own.
+recommend joining us on [Matrix via Element]. If your prefer IRC, you can join
+via the [Kiwi IRC client] or a client of your own.
 
 [`#rocket:mozilla.org`]: https://chat.mozilla.org/#/room/#rocket:mozilla.org
 [`#rocket`]: https://kiwiirc.com/client/chat.freenode.net/#rocket
-[Matrix via Riot]: https://chat.mozilla.org/#/room/#rocket:mozilla.org
+[Matrix via Element]: https://chat.mozilla.org/#/room/#rocket:mozilla.org
 [Kiwi IRC Client]: https://kiwiirc.com/client/chat.freenode.net/#rocket
 
 ## Examples

--- a/site/guide/11-conclusion.md
+++ b/site/guide/11-conclusion.md
@@ -10,12 +10,12 @@ we're happy to take the best ideas. If you have something in mind, please
 If you find yourself having trouble developing Rocket applications, you can get
 help via chat at [`#rocket:mozilla.org`] on Matrix or the bridged [`#rocket`]
 IRC channel on Freenode at `chat.freenode.net`. We recommend joining us on
-[Matrix via Riot]. If your prefer IRC, you can join via the [Kiwi IRC client] or
-a client of your own.
+[Matrix via Element]. If your prefer IRC, you can join via the [Kiwi IRC client]
+or a client of your own.
 
 [`#rocket:mozilla.org`]: https://chat.mozilla.org/#/room/#rocket:mozilla.org
 [`#rocket`]: https://kiwiirc.com/client/chat.freenode.net/#rocket
-[Matrix via Riot]: https://chat.mozilla.org/#/room/#rocket:mozilla.org
+[Matrix via Element]: https://chat.mozilla.org/#/room/#rocket:mozilla.org
 [Kiwi IRC Client]: https://kiwiirc.com/client/chat.freenode.net/#rocket
 
 ## What's next?

--- a/site/guide/index.md
+++ b/site/guide/index.md
@@ -35,10 +35,10 @@ aspect of Rocket. The sections are:
 
 The official community support channels are [`#rocket:mozilla.org`] on Matrix
 and the bridged [`#rocket`] IRC channel on Freenode at `chat.freenode.net`. We
-recommend joining us on [Matrix via Riot]. If your prefer IRC, you can join via
-the [Kiwi IRC client] or a client of your own.
+recommend joining us on [Matrix via Element]. If your prefer IRC, you can join
+via the [Kiwi IRC client] or a client of your own.
 
 [`#rocket:mozilla.org`]: https://chat.mozilla.org/#/room/#rocket:mozilla.org
 [`#rocket`]: https://kiwiirc.com/client/chat.freenode.net/#rocket
-[Matrix via Riot]: https://chat.mozilla.org/#/room/#rocket:mozilla.org
+[Matrix via Element]: https://chat.mozilla.org/#/room/#rocket:mozilla.org
 [Kiwi IRC Client]: https://kiwiirc.com/client/chat.freenode.net/#rocket


### PR DESCRIPTION
Riot was renamed to Element: https://element.io/blog/welcome-to-element/