### PR TITLE
impl (de)serialize for UUID

### DIFF
--- a/contrib/lib/Cargo.toml
+++ b/contrib/lib/Cargo.toml
@@ -30,6 +30,7 @@ serve = []
 compression = ["brotli_compression", "gzip_compression"]
 brotli_compression = ["brotli"]
 gzip_compression = ["flate2"]
+uuid = ["serde", "_uuid"]
 
 # The barage of user-facing database features.
 diesel_sqlite_pool = ["databases", "diesel/sqlite", "diesel/r2d2"]
@@ -59,9 +60,6 @@ tera = { version = "1.0.2", optional = true }
 notify = { version = "4.0.6", optional = true }
 normpath = { version = "0.2", optional = true }
 
-# UUID dependencies.
-uuid = { version = ">=0.7.0, <0.9.0", optional = true, features = ["serde"]}
-
 # Database dependencies
 diesel = { version = "1.0", default-features = false, optional = true }
 postgres = { version = "0.19", optional = true }
@@ -80,6 +78,12 @@ time = { version = "0.2.9", optional = true }
 # Compression dependencies
 brotli = { version = "3.3", optional = true }
 flate2 = { version = "1.0", optional = true }
+
+[dependencies._uuid]
+package = "uuid"
+version = ">=0.7.0, <0.9.0"
+optional = true
+features = ["serde"]
 
 [dev-dependencies]
 serde_test = "1.0.114"

--- a/contrib/lib/Cargo.toml
+++ b/contrib/lib/Cargo.toml
@@ -60,7 +60,7 @@ notify = { version = "4.0.6", optional = true }
 normpath = { version = "0.2", optional = true }
 
 # UUID dependencies.
-uuid = { version = ">=0.7.0, <0.9.0", optional = true }
+uuid = { version = ">=0.7.0, <0.9.0", optional = true, features = ["serde"]}
 
 # Database dependencies
 diesel = { version = "1.0", default-features = false, optional = true }
@@ -80,6 +80,9 @@ time = { version = "0.2.9", optional = true }
 # Compression dependencies
 brotli = { version = "3.3", optional = true }
 flate2 = { version = "1.0", optional = true }
+
+[dev-dependencies]
+serde_test = "1.0.114"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/contrib/lib/src/uuid.rs
+++ b/contrib/lib/src/uuid.rs
@@ -64,6 +64,7 @@ type ParseError = <self::uuid_crate::Uuid as FromStr>::Err;
 ///     format!("User ID: {}", id)
 /// }
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize), serde(transparent))]
 pub struct Uuid(uuid_crate::Uuid);
 
 impl Uuid {
@@ -182,5 +183,17 @@ mod test {
     fn test_from_param_invalid() {
         let uuid_str = "c1aa1e3b-9614-4895-9ebd-705255fa5bc2p";
         Uuid::from_param(uuid_str.into()).unwrap();
+    }
+
+    #[test]
+    fn test_ser_de() {
+        // The main reason for this test is to test that UUID only serializes as
+        // a string token, not anything else. Like a Struct with a named field...
+        use serde_test::{Token, assert_tokens, Configure};
+        let uuid: Uuid = "c1aa1e3b-9614-4895-9ebd-705255fa5bc2".parse().unwrap();
+
+        assert_tokens(&uuid.readable(), &[
+            Token::Str("c1aa1e3b-9614-4895-9ebd-705255fa5bc2"),
+        ]);
     }
 }

--- a/contrib/lib/src/uuid.rs
+++ b/contrib/lib/src/uuid.rs
@@ -14,11 +14,13 @@
 //! features = ["uuid"]
 //! ```
 
-pub extern crate uuid as uuid_crate;
+pub extern crate _uuid as uuid_crate;
 
 use std::fmt;
 use std::str::FromStr;
 use std::ops::Deref;
+
+use serde::{Deserialize, Serialize};
 
 use rocket::request::FromParam;
 use rocket::form::{self, FromFormField, ValueField};
@@ -63,8 +65,8 @@ type ParseError = <self::uuid_crate::Uuid as FromStr>::Err;
 /// fn user(id: Uuid) -> String {
 ///     format!("User ID: {}", id)
 /// }
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize), serde(transparent))]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Serialize, Deserialize)]
+#[serde(transparent)]
 pub struct Uuid(uuid_crate::Uuid);
 
 impl Uuid {


### PR DESCRIPTION
closes #1370

TODO: Think some discussion for the other options in the issue should be
discussed there before merging. This PR is mostly there for checking
what the implimitation could look like.

Also think we hit a limitation in cargo where we cant describe that we
want the feature rocket_conrtib::serde to be connected to the feature
flag of uuid::serde.