### PR TITLE
Remove appendix from Apache license

### DIFF
--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -174,28 +174,3 @@ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
    of your accepting any such warranty or additional liability.
 
 END OF TERMS AND CONDITIONS
-
-APPENDIX: How to apply the Apache License to your work.
-
-   To apply the Apache License to your work, attach the following
-   boilerplate notice, with the fields enclosed by brackets "[]"
-   replaced with your own identifying information. (Don't include
-   the brackets!)  The text should be enclosed in the appropriate
-   comment syntax for the file format. We also recommend that a
-   file or class name and description of purpose be included on the
-   same "printed page" as the copyright notice for easier
-   identification within third-party archives.
-
-Copyright 2016 Sergio Benitez
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-	http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.


### PR DESCRIPTION
From what I understand, the boilerplate notice in the Apache license's appendix is just meant to be part of the instruction on how to apply the license on a program file and not to actually be modified with the copyright year and owner of the open source project (as in ac4cca7). It should be kept as:

```
Copyright [yyyy] [name of copyright owner]
```

But people often and understandably get confused by it and think it needs to be updated. To avoid confusion, we can simply remove the appendix. The license doesn't actually require that section in the distribution, and other projects have removed it (e.g. see rust-lang/rust#67734). As highlighted in that Rust PR, it is safe to remove:

> "License" shall mean the terms and conditions for use, reproduction,
> and distribution as defined by Sections 1 through 9 of this document.

It was removed from the Rust project for a different reason — they don't practice putting a license header at the top of each file so they removed it to avoid that confusion.

Alternatively, we can keep the appendix and just revert the change in ac4cca7. Let me know if you'd like me to update this PR to do just that. Or, we can keep things as it is, and just close this PR and move on to more important issues.
