### PR TITLE
Change the template customization callback to return a Result

### DIFF
--- a/contrib/lib/src/templates/engine.rs
+++ b/contrib/lib/src/templates/engine.rs
@@ -41,6 +41,7 @@ pub(crate) trait Engine: Send + Sync + 'static {
 ///         // ...
 ///         .attach(Template::custom(|engines: &mut Engines| {
 ///             engines.tera.register_filter("my_filter", my_filter);
+///             Ok(())
 ///         }))
 ///         // ...
 ///         # ;

--- a/contrib/lib/src/templates/fairing.rs
+++ b/contrib/lib/src/templates/fairing.rs
@@ -90,7 +90,7 @@ mod context {
         /// reinitialized from disk and the user's customization callback is run
         /// again.
         pub fn reload_if_needed<F>(&self, custom_callback: F)
-            where F: Fn(&mut Engines) -> Result<(), Box<dyn std::error::Error + Send + Sync>>
+            where F: Fn(&mut Engines) -> Result<(), Box<dyn std::error::Error>>
         {
             self.watcher.as_ref().map(|w| {
                 let rx_lock = w.lock().expect("receive queue lock");
@@ -129,7 +129,7 @@ pub struct TemplateFairing {
     /// The user-provided customization callback, allowing the use of
     /// functionality specific to individual template engines. In debug mode,
     /// this callback might be run multiple times as templates are reloaded.
-    pub custom_callback: Box<dyn Fn(&mut Engines) -> Result<(), Box<dyn std::error::Error + Send + Sync>> + Send + Sync + 'static>,
+    pub custom_callback: Box<dyn Fn(&mut Engines) -> Result<(), Box<dyn std::error::Error>> + Send + Sync + 'static>,
 }
 
 #[rocket::async_trait]

--- a/contrib/lib/src/templates/mod.rs
+++ b/contrib/lib/src/templates/mod.rs
@@ -281,7 +281,7 @@ impl Template {
     /// }
     /// ```
     pub fn custom<F>(f: F) -> impl Fairing
-        where F: Fn(&mut Engines) -> Result<(), Box<dyn std::error::Error + Send + Sync>> + Send + Sync + 'static
+        where F: Fn(&mut Engines) -> Result<(), Box<dyn std::error::Error>> + Send + Sync + 'static
     {
         TemplateFairing { custom_callback: Box::new(f) }
     }

--- a/contrib/lib/tests/templates.rs
+++ b/contrib/lib/tests/templates.rs
@@ -35,6 +35,24 @@ mod templates_tests {
             .mount("/", routes![template_check, is_reloading])
     }
 
+    #[test]
+    fn test_customization_error() {
+        let rocket = rocket::ignite().attach(Template::custom(|engines| {
+            Err("error reloading templates!".into())
+        }));
+        match rocket::local::blocking::Client::new(rocket) {
+            Err(le) => {
+                match le.kind() {
+                    rocket::error::LaunchErrorKind::FailedFairings(failures) => {
+                        assert_eq!(failures[0], "Templates");
+                    }
+                    _ => panic!("Wrong kind of launch error"),
+                }
+            }
+            _ => panic!("Wrong kind of error"),
+        }
+    }
+
     #[cfg(feature = "tera_templates")]
     mod tera_tests {
         use super::*;

--- a/examples/handlebars_templates/src/main.rs
+++ b/examples/handlebars_templates/src/main.rs
@@ -72,5 +72,6 @@ fn rocket() -> rocket::Rocket {
         .register(catchers![not_found])
         .attach(Template::custom(|engines| {
             engines.handlebars.register_helper("wow", Box::new(wow_helper));
+            Ok(())
         }))
 }


### PR DESCRIPTION
The closure passed to `Template::custom` can now return an error.

* If the closure returns an error during launch, the fairing itself returns `Err(rocket)` and the launch is canceled.
* If the closure later returns an error during template reload (in debug mode), the error is logged and the existing templates are left alone (same as with an error in reloading itself).


Closes #1064.

## Unresolved
- [x] The error type is initially `Box<dyn Error + Send + Sync>`. Those `Send + Sync` bounds are probably unnecessary, actually. Or maybe it should be an entirely different trait, like `Box<dyn Debug>`?