### PR TITLE
Update pastebin document

### DIFF
--- a/site/guide/10-pastebin.md
+++ b/site/guide/10-pastebin.md
@@ -410,12 +410,13 @@ the `retrieve` route, preventing attacks on the `retrieve` route:
 ```rust
 # #[macro_use] extern crate rocket;
 
+# use std::borrow::Cow;
 # use rocket::tokio::fs::File;
 
-# type PasteId = usize;
+# type PasteId<'a> = Cow<'a, str>;
 
 #[get("/<id>")]
-async fn retrieve(id: PasteId) -> Option<File> {
+async fn retrieve(id: PasteId<'_>) -> Option<File> {
     let filename = format!("upload/{id}", id = id);
     File::open(&filename).await.ok()
 }


### PR DESCRIPTION
After we change to async, PasteId has to postfix with an explicit lifetime parameter. Change the document to reflect it.