### PR TITLE
Remove TLS warning

### DIFF
--- a/site/guide/9-configuration.md
+++ b/site/guide/9-configuration.md
@@ -286,9 +286,6 @@ being ignored.
 
 ## Configuring TLS
 
-! warning: Rocket's built-in TLS is **not** considered ready for production use.
-  It is intended for development use _only_.
-
 Rocket includes built-in, native support for TLS >= 1.2 (Transport Layer
 Security). In order for TLS support to be enabled, Rocket must be compiled with
 the `"tls"` feature. To do this, add the `"tls"` feature to the `rocket`


### PR DESCRIPTION
based on the discussion here #1404, remove the warning of TLS from the document. Rocket is using a production quality of TLS lib.