### PR TITLE
Ran cargo-diet to reduce download size from crates.io

### DIFF
--- a/contrib/codegen/Cargo.toml
+++ b/contrib/codegen/Cargo.toml
@@ -10,6 +10,7 @@ readme = "../../README.md"
 keywords = ["rocket", "contrib", "code", "generation", "proc-macro"]
 license = "MIT OR Apache-2.0"
 edition = "2018"
+include = ["src/**/*"]
 
 [features]
 database_attribute = []

--- a/contrib/lib/Cargo.toml
+++ b/contrib/lib/Cargo.toml
@@ -10,6 +10,7 @@ readme = "../../README.md"
 keywords = ["rocket", "web", "framework", "contrib", "contributed"]
 license = "MIT OR Apache-2.0"
 edition = "2018"
+include = ["src/**/*"]
 
 [features]
 # Internal use only.

--- a/core/codegen/Cargo.toml
+++ b/core/codegen/Cargo.toml
@@ -10,6 +10,7 @@ readme = "../../README.md"
 keywords = ["rocket", "web", "framework", "code", "generation"]
 license = "MIT OR Apache-2.0"
 edition = "2018"
+include = ["src/**/*"]
 
 [lib]
 proc-macro = true

--- a/core/lib/Cargo.toml
+++ b/core/lib/Cargo.toml
@@ -14,6 +14,7 @@ license = "MIT OR Apache-2.0"
 build = "build.rs"
 categories = ["web-programming::http-server"]
 edition = "2018"
+include = ["src/**/*", "build.rs"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
This makes sure to only add the needed files for cargo packages, so that they download faster. The gains come mostly from not including tests on every package:

contrib/codegen:
```
Saved 43% or 6.6 KB in 11 files (of 15.3 KB and 14 files in entire crate)
```

contrib/lib:
```
Saved 21% or 40.0 KB in 19 files (of 192.9 KB and 39 files in entire crate)
```

core/codegen:
```
Saved 65% or 228.9 KB in 104 files (of 354.3 KB and 123 files in entire crate)
```

core/lib:
```
Saved 7% or 43.4 KB in 30 files (of 665.1 KB and 97 files in entire crate)
```
