### PR TITLE
Generate FromUriParam<Query> impls for some Option types

### DIFF
--- a/core/codegen/tests/typed-uris.rs
+++ b/core/codegen/tests/typed-uris.rs
@@ -365,6 +365,12 @@ fn optionals(
     rest: Option<Form<Third<'_>>>
 ) { }
 
+#[post("/<foo>?<bar>")]
+fn optionals2(
+    foo: String,
+    bar: Option<usize>
+){ }
+
 #[test]
 fn test_optional_uri_parameters() {
     assert_uri_eq! {
@@ -409,5 +415,13 @@ fn test_optional_uri_parameters() {
             q1 = _,
             rest = _,
         ) => "/10/hi%20there",
+
+        uri!(optionals2: "a", Some(1)) => "/a?bar=1",
+        uri!(optionals2: "a", &Some(1)) => "/a?bar=1",
+        uri!(optionals2: "a", &mut Some(1)) => "/a?bar=1",
+
+        uri!(optionals2: "a", None) => "/a?",
+        uri!(optionals2: "a", &None) => "/a?",
+        uri!(optionals2: "a", &mut None) => "/a?",
     }
 }

--- a/core/http/src/uri/from_uri_param.rs
+++ b/core/http/src/uri/from_uri_param.rs
@@ -96,6 +96,13 @@ use crate::uri::{self, UriPart, UriDisplay};
 ///   * `&str` to `PathBuf`
 ///   * `PathBuf` to `&Path`
 ///
+/// The following types have _identity_ implementations _only in [`Query`]_:
+///
+///   * `Option<T>` where `T` is one of:
+///     * `String`, `i8`, `i16`, `i32`, `i64`, `i128`, `isize`, `u8`, `u16`,
+///       `u32`, `u64`, `u128`, `usize`, `f32`, `f64`, `bool`, `IpAddr`,
+///       `Ipv4Addr`, `Ipv6Addr`
+///
 /// See [Foreign Impls](#foreign-impls) for all provided implementations.
 ///
 /// # Implementing
@@ -190,6 +197,7 @@ use crate::uri::{self, UriPart, UriDisplay};
 /// [`UriDisplay`]: crate::uri::UriDisplay
 /// [`FromUriParam::Target`]: crate::uri::FromUriParam::Target
 /// [`Path`]: crate::uri::Path
+/// [`Query`]: crate::uri::Query
 pub trait FromUriParam<P: UriPart, T> {
     /// The resulting type of this conversion.
     type Target: UriDisplay<P>;
@@ -315,6 +323,18 @@ impl_from_uri_param_identity!([uri::Path] PathBuf);
 impl_conversion_ref! {
     [uri::Path] ('a) &'a Path => PathBuf,
     [uri::Path] ('a) PathBuf => &'a Path
+}
+
+macro_rules! impl_from_uri_param_option_identity {
+    ($($T:ty),*) => ($( impl_conversion_ref!([uri::Query] Option<$T> => Option<$T>); )*);
+}
+
+impl_from_uri_param_option_identity! {
+    String,
+    i8, i16, i32, i64, i128, isize,
+    u8, u16, u32, u64, u128, usize,
+    f32, f64, bool,
+    IpAddr, Ipv4Addr, Ipv6Addr
 }
 
 /// A no cost conversion allowing an `&str` to be used in place of a `PathBuf`.


### PR DESCRIPTION
I ran into this issue when trying to create next/prev page links while reusing existing optional parameters, something like

```rust
#[get("/route?<page>&<other>"]
fn route(page: usize, other: Option<String>) {
    let next = uri!(route, page + 1, other);
}
```

cc https://github.com/SergioBenitez/Rocket/issues/998#issuecomment-544169526, it allows forms `a` and `b` for the added types

I tried creating a blanket impl for `Option<T>`, however that conflicts with the `T -> Option<T>` forwarding, so instead generate them for individual types using a macro

`Option<&str>`, `Option<&RawStr>` and `Option<Cow<str>>` are not included because they also generated conflicts with existing impls