### PR TITLE
Fix for forms that contain structures affected by encoding (such as SocketAddrV4) failing to parse

### DIFF
--- a/core/lib/src/request/form/from_form_value.rs
+++ b/core/lib/src/request/form/from_form_value.rs
@@ -243,7 +243,24 @@ impl_with_fromstr!(
     f32, f64, isize, i8, i16, i32, i64, i128, usize, u8, u16, u32, u64, u128,
     NonZeroI8, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI128, NonZeroIsize,
     NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU128, NonZeroUsize,
-    IpAddr, Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6, SocketAddr
+    Ipv4Addr
+);
+
+macro_rules! impl_with_fromstr_encoded {
+    ($($T:ident),+) => ($(
+        impl<'v> FromFormValue<'v> for $T {
+            type Error = &'v RawStr;
+
+            #[inline(always)]
+            fn from_form_value(v: &'v RawStr) -> Result<Self, Self::Error> {
+                $T::from_str(&v.url_decode().map_err(|_| v)?).map_err(|_| v)
+            }
+        }
+    )+)
+}
+
+impl_with_fromstr_encoded!(
+    IpAddr, Ipv6Addr, SocketAddrV4, SocketAddrV6, SocketAddr
 );
 
 impl<'v, T: FromFormValue<'v>> FromFormValue<'v> for Option<T> {

--- a/core/lib/tests/form_value_from_encoded_str-issue-1425.rs
+++ b/core/lib/tests/form_value_from_encoded_str-issue-1425.rs
@@ -1,0 +1,39 @@
+extern crate rocket;
+
+use rocket::http::RawStr;
+use rocket::request::FromFormValue;
+use std::fmt::Debug;
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6};
+
+mod tests {
+    use super::*;
+
+    fn check_from_form_value_encoded<'a, T>(encoded_str: &'static str, expected: T)
+    where
+        T: FromFormValue<'a> + PartialEq + Debug,
+        <T as FromFormValue<'a>>::Error: Debug,
+    {
+        let value = T::from_form_value(RawStr::from_str(encoded_str));
+
+        assert!(value.is_ok());
+        assert_eq!(value.unwrap(), expected);
+    }
+
+    #[test]
+    fn test_from_form_value_encoded() {
+        check_from_form_value_encoded(
+            "127.0.0.1:80",
+            SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 80),
+        );
+
+        check_from_form_value_encoded(
+            "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+            Ipv6Addr::new(0x2001, 0x0db8, 0x85a3, 0, 0, 0x8a2e, 0x0370, 0x7334),
+        );
+
+        check_from_form_value_encoded(
+            "[2001:db8::1]:8080",
+            SocketAddrV6::new(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1), 8080, 0, 0),
+        );
+    }
+}

--- a/core/lib/tests/form_value_from_encoded_str-issue-1425.rs
+++ b/core/lib/tests/form_value_from_encoded_str-issue-1425.rs
@@ -22,17 +22,17 @@ mod tests {
     #[test]
     fn test_from_form_value_encoded() {
         check_from_form_value_encoded(
-            "127.0.0.1:80",
+            "127.0.0.1%3A80",
             SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 80),
         );
 
         check_from_form_value_encoded(
-            "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+            "2001%3A0db8%3A85a3%3A0000%3A0000%3A8a2e%3A0370%3A7334",
             Ipv6Addr::new(0x2001, 0x0db8, 0x85a3, 0, 0, 0x8a2e, 0x0370, 0x7334),
         );
 
         check_from_form_value_encoded(
-            "[2001:db8::1]:8080",
+            "%5B2001%3Adb8%3A%3A1%5D%3A8080",
             SocketAddrV6::new(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1), 8080, 0, 0),
         );
     }


### PR DESCRIPTION
Create new macro impl_with_fromstr_encoded to implement FromFormValue for structures that contain characters affected by encoding (especially colons ':'), such as ipv6 addresses and ipv4 + port combos

Fixes #1425 