### PR TITLE
Refector TLS implementation

### DIFF
--- a/core/http/src/lib.rs
+++ b/core/http/src/lib.rs
@@ -20,7 +20,10 @@ pub mod ext;
 
 #[doc(hidden)]
 #[cfg(feature = "tls")]
-pub mod tls;
+mod tls;
+
+#[cfg(feature = "tls")]
+pub use tls::bind_tls;
 
 #[doc(hidden)]
 pub mod route;

--- a/core/lib/src/config/config.rs
+++ b/core/lib/src/config/config.rs
@@ -565,23 +565,18 @@ impl Config {
     /// ```
     #[cfg(feature = "tls")]
     pub fn set_tls(&mut self, certs_path: &str, key_path: &str) -> Result<()> {
-        use crate::http::tls::{load_certs, load_private_key, Error};
-
-        let pem_err = "malformed PEM file";
-
         // Load the certificates.
-        let certs = load_certs(self.root_relative(certs_path))
-            .map_err(|e| match e {
-                Error::Io(e) => ConfigError::Io(e, "tls.certs"),
-                _ => self.bad_type("tls", pem_err, "a valid certificates file")
-            })?;
+        // todo: validate certs
+        let certs = self.root_relative(certs_path);
+        if !certs.exists() {
+            return Err(ConfigError::BadFilePath(certs, "cert file doesn't exist."));
+        }
 
         // And now the private key.
-        let key = load_private_key(self.root_relative(key_path))
-            .map_err(|e| match e {
-                Error::Io(e) => ConfigError::Io(e, "tls.key"),
-                _ => self.bad_type("tls", pem_err, "a valid private key file")
-            })?;
+        let key = self.root_relative(key_path);
+        if !key.exists() {
+            return Err(ConfigError::BadFilePath(key, "key file doesn't exist."));
+        }
 
         self.tls = Some(TlsConfig { certs, key });
         Ok(())

--- a/core/lib/src/config/custom_values.rs
+++ b/core/lib/src/config/custom_values.rs
@@ -1,6 +1,5 @@
 use std::fmt;
-
-#[cfg(feature = "tls")] use crate::http::tls::{Certificate, PrivateKey};
+#[cfg(feature = "tls")] use std::path::PathBuf;
 
 use crate::http::private::cookie::Key;
 use crate::config::{Result, Config, Value, ConfigError, LoggingLevel};
@@ -48,8 +47,8 @@ impl fmt::Display for SecretKey {
 #[cfg(feature = "tls")]
 #[derive(Clone)]
 pub struct TlsConfig {
-    pub certs: Vec<Certificate>,
-    pub key: PrivateKey
+    pub certs: PathBuf,
+    pub key: PathBuf
 }
 
 #[cfg(not(feature = "tls"))]

--- a/core/lib/src/rocket.rs
+++ b/core/lib/src/rocket.rs
@@ -1009,7 +1009,7 @@ impl Rocket {
 
             #[cfg(feature = "tls")] {
                 if let Some(tls) = self.config.tls.clone() {
-                    listen_on!(crate::http::tls::bind_tls(addr, tls.certs, tls.key).await).boxed()
+                    listen_on!(crate::http::bind_tls(addr, tls.certs, tls.key).await).boxed()
                 } else {
                     listen_on!(crate::http::private::bind_tcp(addr).await).boxed()
                 }


### PR DESCRIPTION
Cleanup the code to reduce the exposure surface of TLS implementation.

1. Remove http::tls namespace
2. Expose bind_tls under http
3. Use path instead of Certificate type of configuration. Certificate is TLS implementation specific type.