### PR TITLE
Add ArangoDB to rocket_contrib databases

### DIFF
--- a/contrib/lib/Cargo.toml
+++ b/contrib/lib/Cargo.toml
@@ -39,6 +39,7 @@ postgres_pool = ["databases", "postgres", "r2d2_postgres"]
 sqlite_pool = ["databases", "rusqlite", "r2d2_sqlite"]
 memcache_pool = ["databases", "memcache", "r2d2-memcache"]
 diesel_mysql_pool = ["databases", "diesel/mysql", "diesel/r2d2"]
+arango_pool = ["databases", "arangors", "r2d2_arangors"]
 
 [dependencies]
 # Global dependencies.
@@ -68,6 +69,9 @@ rusqlite = { version = "0.24", optional = true }
 r2d2_sqlite = { version = "0.17", optional = true }
 memcache = { version = "0.15", optional = true }
 r2d2-memcache = { version = "0.6", optional = true }
+arangors = { version = "0.5", default-features = false, features = ["reqwest_blocking", "rocksdb"], optional = true }
+#r2d2_arangors = { version = "0.2", optional = true }
+r2d2_arangors = { git = "https://github.com/Weasy666/r2d2-arangors", branch = "develop", optional = true }
 
 # SpaceHelmet dependencies
 time = { version = "0.2.9", optional = true }

--- a/contrib/lib/src/databases/mod.rs
+++ b/contrib/lib/src/databases/mod.rs
@@ -316,7 +316,7 @@
 //! The list below includes all presently supported database adapters and their
 //! corresponding [`Poolable`] type.
 //!
-// Note: Keep this table in sync with site/guite/6-state.md
+// Note: Keep this table in sync with site/guide/6-state.md
 //! | Kind     | Driver                | Version   | `Poolable` Type                | Feature                |
 //! |----------|-----------------------|-----------|--------------------------------|------------------------|
 //! | MySQL    | [Diesel]              | `1`       | [`diesel::MysqlConnection`]    | `diesel_mysql_pool`    |
@@ -325,6 +325,7 @@
 //! | Sqlite   | [Diesel]              | `1`       | [`diesel::SqliteConnection`]   | `diesel_sqlite_pool`   |
 //! | Sqlite   | [`Rusqlite`]          | `0.24`    | [`rusqlite::Connection`]       | `sqlite_pool`          |
 //! | Memcache | [`memcache`]          | `0.15`    | [`memcache::Client`]           | `memcache_pool`        |
+//! | ArangoDB | [`arangors`]          | `0.4`     | [`arangors::Connection`]       | `arango_pool`          |
 //!
 //! [Diesel]: https://diesel.rs
 //! [`rusqlite::Connection`]: https://docs.rs/rusqlite/0.23.0/rusqlite/struct.Connection.html
@@ -337,12 +338,33 @@
 //! [`diesel::PgConnection`]: http://docs.diesel.rs/diesel/pg/struct.PgConnection.html
 //! [`memcache`]: https://github.com/aisk/rust-memcache
 //! [`memcache::Client`]: https://docs.rs/memcache/0.15/memcache/struct.Client.html
+//! [`arangors`]: https://github.com/fMeow/arangors
+//! [`arangors::Connection`]: https://docs.rs/arangors/0.4.3/arangors/connection/index.html
 //!
 //! The above table lists all the supported database adapters in this library.
 //! In order to use particular `Poolable` type that's included in this library,
 //! you must first enable the feature listed in the "Feature" column. The
 //! interior type of your decorated database type should match the type in the
 //! "`Poolable` Type" column.
+//!
+//! ### arango_pool
+//!
+//! The [ArangoDB] adapter and its pool comes with extra configuration, just add
+//! the following config values to your `Rocket.toml`.
+//!
+//! ```toml
+//! [global.databases.mydb]
+//! url = "http://localhost:8529"
+//! username = "root"
+//! password = "super_secret_mega_heavy_secure_password"
+//! use_jwt = true
+//! ```
+//!
+//! The `url` should point to your [ArangoDB] instance. The username and password
+//! are used for authentication when connection to the database. If you add the
+//! `use_jwt = true` value, then the connection gains "super-user" access as
+//! mentioned in the [ArangoDB Docs], if you leave it out, it will default to
+//! `false`.
 //!
 //! ## Extending
 //!
@@ -354,6 +376,8 @@
 //! [`FromRequest`]: rocket::request::FromRequest
 //! [request guards]: rocket::request::FromRequest
 //! [`Poolable`]: crate::databases::Poolable
+//! [ArangoDB]: https://www.arangodb.com
+//! [ArangoDB Docs]: https://www.arangodb.com/docs/3.7/programs-starter-security.html#using-authentication-tokens
 
 pub extern crate r2d2;
 
@@ -372,6 +396,9 @@ pub extern crate diesel;
 
 #[cfg(feature = "memcache_pool")] pub extern crate memcache;
 #[cfg(feature = "memcache_pool")] pub extern crate r2d2_memcache;
+
+#[cfg(feature = "arango_pool")] pub extern crate arangors;
+#[cfg(feature = "arango_pool")] pub extern crate r2d2_arangors;
 
 mod poolable;
 mod config;

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -72,6 +72,7 @@ function test_contrib() {
     postgres_pool
     sqlite_pool
     memcache_pool
+    arango_pool
     brotli_compression
     gzip_compression
   )

--- a/site/guide/6-state.md
+++ b/site/guide/6-state.md
@@ -243,6 +243,7 @@ Presently, Rocket provides built-in support for the following databases:
 | Sqlite   | [Diesel]              | `1`       | [`diesel::SqliteConnection`]   | `diesel_sqlite_pool`   |
 | Sqlite   | [`Rusqlite`]          | `0.24`    | [`rusqlite::Connection`]       | `sqlite_pool`          |
 | Memcache | [`memcache`]          | `0.15`    | [`memcache::Client`]           | `memcache_pool`        |
+| ArangoDB | [`arangors`]          | `0.4`     | [`arangors::Connection`]       | `arango_pool`          |
 
 [`r2d2`]: https://crates.io/crates/r2d2
 [Diesel]: https://diesel.rs
@@ -256,6 +257,8 @@ Presently, Rocket provides built-in support for the following databases:
 [`diesel::PgConnection`]: https://docs.diesel.rs/diesel/pg/struct.PgConnection.html
 [`memcache`]: https://github.com/aisk/rust-memcache
 [`memcache::Client`]: https://docs.rs/memcache/0.15/memcache/struct.Client.html
+[`arangors`]: https://github.com/fMeow/arangors
+[`arangors::Connection`]: https://docs.rs/arangors/0.4.3/arangors/connection/index.html
 
 ### Usage
 


### PR DESCRIPTION
This PR adds support for [ArangoDB](https://www.arangodb.com/) by implementing `Poolable` for [arangors::Connection](https://github.com/fMeow/arangors/blob/master/src/connection/mod.rs#L145) in conjunction with [r2d2_arangors](https://github.com/inzanez/r2d2-arangors).

`arangors` expects a url, username and password for its `Connection::establish_...()` functions, so i had to make it mandatory, to include them into the Rocket.toml file. I hope that is ok, if not...another idea could be to use a `http://root:root@localhost:8529` url and extract the user and password from it.