### PR TITLE
Added DerefMut impl to Form and LenientForm

### DIFF
--- a/core/lib/src/request/form/form.rs
+++ b/core/lib/src/request/form/form.rs
@@ -1,4 +1,4 @@
-use std::ops::Deref;
+use std::ops::{Deref, DerefMut};
 
 use crate::outcome::Outcome::*;
 use crate::request::{Request, form::{FromForm, FormItems, FormDataError}};
@@ -141,6 +141,12 @@ impl<T> Deref for Form<T> {
 
     fn deref(&self) -> &T {
         &self.0
+    }
+}
+
+impl<T> DerefMut for Form<T> {
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.0
     }
 }
 

--- a/core/lib/src/request/form/form.rs
+++ b/core/lib/src/request/form/form.rs
@@ -47,8 +47,8 @@ use crate::http::{Status, uri::{Query, FromUriParam}};
 /// # fn main() {  }
 /// ```
 ///
-/// A type of `Form<T>` automatically dereferences into an `&T`, though you can
-/// also transform a `Form<T>` into a `T` by calling
+/// A type of `Form<T>` automatically dereferences into an `&T` or `&mut T`,
+/// though you can also transform a `Form<T>` into a `T` by calling
 /// [`into_inner()`](Form::into_inner()). Thanks to automatic dereferencing, you
 /// can access fields of `T` transparently through a `Form<T>`, as seen above
 /// with `user_input.value`.

--- a/core/lib/src/request/form/lenient.rs
+++ b/core/lib/src/request/form/lenient.rs
@@ -1,4 +1,4 @@
-use std::ops::Deref;
+use std::ops::{Deref, DerefMut};
 
 use crate::request::{Request, form::{Form, FormDataError, FromForm}};
 use crate::data::{Data, Transformed, FromTransformedData, TransformFuture, FromDataFuture};
@@ -90,6 +90,12 @@ impl<T> Deref for LenientForm<T> {
 
     fn deref(&self) -> &T {
         &self.0
+    }
+}
+
+impl<T> DerefMut for LenientForm<T> {
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.0
     }
 }
 


### PR DESCRIPTION
I ran into a limitation with `Form` where I needed to modify the inner data, but the `DerefMut` implementation was missing. I have also added `DerefMut` to `LenientForm` for consistency.