### PR TITLE
Fixes #1454: Remove unnecessary .as_str()

### DIFF
--- a/site/guide/4-requests.md
+++ b/site/guide/4-requests.md
@@ -81,7 +81,7 @@ use rocket::http::RawStr;
 
 #[get("/hello/<name>")]
 fn hello(name: &RawStr) -> String {
-    format!("Hello, {}!", name.as_str())
+    format!("Hello, {}!", name)
 }
 ```
 


### PR DESCRIPTION
From Dynamic Paths section