### PR TITLE
Add description to mimic Rocket's config behaviour

### DIFF
--- a/core/lib/src/config/mod.rs
+++ b/core/lib/src/config/mod.rs
@@ -92,10 +92,21 @@
 //! }
 //! ```
 //!
+//! If the application's config should behave like the configuration of Rocket,
+//! i.e. use the same [`Profile`]s and behaviour, you need to instead merge them as follows:
+//!
+//! ```rust,ignore
+//! let figment = Figment::from(rocket::Config::default())
+//!     .merge(Serialized::defaults(Config::default()))
+//!     .merge(Toml::file(Env::var_or("APP_CONFIG", "App.toml")).nested())
+//!     .merge(Env::prefixed("APP_").global());
+//! ```
+//!
 //! [`rocket::custom()`]: crate::custom()
 //! [`rocket::ignite()`]: crate::ignite()
 //! [`Toml`]: figment::providers::Toml
 //! [`Env`]: figment::providers::Env
+//! [`Profile`]: https://docs.rs/figment/0.9/figment/struct.Profile.html
 
 mod secret_key;
 mod config;

--- a/site/guide/9-configuration.md
+++ b/site/guide/9-configuration.md
@@ -340,6 +340,16 @@ Rocket will extract it's configuration from the configured provider. This means
 that if values like `port` and `address` are configured in `Config`, `App.toml`
 or `APP_` environment variables, Rocket will make use of them. The application
 can also extract its configuration, done here via the `Adhoc::config()` fairing.
+If the application's config should behave like the Rocket's config,i.e. use the
+same [`Profile`]s and behaviour, you need to instead merge them like this:
+
+```rust,ignore
+let figment = Figment::from(rocket::Config::default())
+    .merge(Serialized::defaults(Config::default()))
+    .merge(Toml::file(Env::var_or("APP_CONFIG", "App.toml")).nested())
+    .merge(Env::prefixed("APP_").global());
+```
 
 [`rocket::custom()`]: @api/rocket/fn.custom.html
 [`rocket::ignite()`]: @api/rocket/fn.custom.html
+[`Profile`]: @figment/struct.Profile.html


### PR DESCRIPTION
When using Rocket with the new config system, i had to wrestle a little bit with it.
I followed the guide and API docs, i used Rockets default configs, merged them with my own config defaults and then pointed them to my `TOML` file and....was wondering why the `port` was still Rocket's default. It took me a little while to understand, that i had to also replicate the profiles and merge with `.nested()`. it makes absolute sense if you have a certain basic knowledge about `Figment`, but i think adding that to the guide and rustdocs is helpful for people that are just starting with it.