### PR TITLE
Provide the way to mount multiple routes on docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,4 +43,5 @@ members = [
   "examples/tls",
   "examples/fairings",
   "examples/hello_2018",
+  "examples/hello_and_hi",
 ]

--- a/examples/hello_and_hi/Cargo.toml
+++ b/examples/hello_and_hi/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "hello_and_hi"
+version = "0.0.0"
+workspace = "../../"
+publish = false
+edition = "2018"
+
+[dependencies]
+rocket = { path = "../../core/lib" }

--- a/examples/hello_and_hi/src/main.rs
+++ b/examples/hello_and_hi/src/main.rs
@@ -1,0 +1,23 @@
+#![feature(proc_macro_hygiene, decl_macro)]
+#[macro_use]
+extern crate rocket;
+
+#[cfg(test)]
+mod tests;
+
+#[get("/")]
+fn world() -> &'static str {
+    "hello, world!"
+}
+
+#[get("/")]
+fn japan() -> &'static str {
+    "hi, japan!"
+}
+
+fn main() {
+    rocket::ignite()
+        .mount("/hello", routes![world])
+        .mount("/hi", routes![japan])
+        .launch();
+}

--- a/examples/hello_and_hi/src/tests.rs
+++ b/examples/hello_and_hi/src/tests.rs
@@ -1,0 +1,38 @@
+use super::rocket;
+use rocket::http::Status;
+use rocket::local::Client;
+
+fn client() -> Client {
+    Client::new(
+        rocket::ignite()
+            .mount("/hello", routes![super::world])
+            .mount("/hi", routes![super::japan]),
+    )
+    .unwrap()
+}
+
+fn test_ok(uri: &str, expected: &str) {
+    let client = client();
+    assert_eq!(
+        client.get(uri).dispatch().body_string(),
+        Some(expected.to_string())
+    );
+}
+
+#[test]
+fn test_hello() {
+    test_ok("/hello", "hello, world!");
+}
+
+#[test]
+fn test_hi() {
+    test_ok("/hi", "hi, japan!");
+}
+
+#[test]
+fn test_not_found() {
+    let test_none = client().get("/").dispatch().status();
+    let test_invalid = client().get("/invalid").dispatch().status();
+    assert_eq!(test_none, Status::NotFound);
+    assert_eq!(test_invalid, Status::NotFound);
+}

--- a/site/guide/3-overview.md
+++ b/site/guide/3-overview.md
@@ -156,6 +156,9 @@ In case multiple routes are required, each route needs to be properly mounted.
 
 Suppose these functions are declared:
 ```rust
+# #![feature(proc_macro_hygiene, decl_macro)]
+# #[macro_use] extern crate rocket;
+
 #[get("/hello")]
 fn world() -> &'static str {
     "hello, world!"
@@ -169,6 +172,19 @@ fn japan() -> &'static str {
 
 We could mount each route as follows:
 ```rust
+# #![feature(proc_macro_hygiene, decl_macro)]
+# #[macro_use] extern crate rocket;
+
+# #[get("/hello")]
+# fn world() -> &'static str {
+#     "hello, world!"
+# }
+
+# #[get("/hi")]
+# fn japan() -> &'static str {
+#     "hi, japan!"
+# }
+
 fn main() {
     rocket::ignite()
         .mount("/hello", routes![world])

--- a/site/guide/3-overview.md
+++ b/site/guide/3-overview.md
@@ -159,12 +159,12 @@ Suppose these functions are declared:
 # #![feature(proc_macro_hygiene, decl_macro)]
 # #[macro_use] extern crate rocket;
 
-#[get("/hello")]
+#[get("/")]
 fn world() -> &'static str {
     "hello, world!"
 }
 
-#[get("/hi")]
+#[get("/")]
 fn japan() -> &'static str {
     "hi, japan!"
 }
@@ -175,12 +175,12 @@ We could mount each route as follows:
 # #![feature(proc_macro_hygiene, decl_macro)]
 # #[macro_use] extern crate rocket;
 
-# #[get("/hello")]
+# #[get("/")]
 # fn world() -> &'static str {
 #     "hello, world!"
 # }
 
-# #[get("/hi")]
+# #[get("/")]
 # fn japan() -> &'static str {
 #     "hi, japan!"
 # }

--- a/site/guide/3-overview.md
+++ b/site/guide/3-overview.md
@@ -150,6 +150,32 @@ is to refer to the route using a namespaced path instead:
 rocket::ignite().mount("/hello", routes![hello, other::world]);
 ```
 
+### Mounting Multiple Paths
+
+In case multiple routes are required, each route needs to be properly mounted.
+
+Suppose these functions are declared:
+```rust
+#[get("/hello")]
+fn world() -> &'static str {
+	"hello, world!"
+}
+
+#[get("/hi")]
+fn japan() -> &'static str {
+	"hi, japan!"
+}
+```
+
+We could mount each route as follows:
+```rust
+fn main() {
+	rocket::ignite()
+		.mount("/hello", routes![world])
+		.mount("/hi", routes![japan]);
+}
+```
+
 ## Launching
 
 Now that Rocket knows about the route, you can tell Rocket to start accepting

--- a/site/guide/3-overview.md
+++ b/site/guide/3-overview.md
@@ -150,7 +150,7 @@ is to refer to the route using a namespaced path instead:
 rocket::ignite().mount("/hello", routes![hello, other::world]);
 ```
 
-### Mounting Multiple Paths
+### Mounting Multiple Routes
 
 In case multiple routes are required, each route needs to be properly mounted.
 

--- a/site/guide/3-overview.md
+++ b/site/guide/3-overview.md
@@ -158,21 +158,21 @@ Suppose these functions are declared:
 ```rust
 #[get("/hello")]
 fn world() -> &'static str {
-	"hello, world!"
+    "hello, world!"
 }
 
 #[get("/hi")]
 fn japan() -> &'static str {
-	"hi, japan!"
+    "hi, japan!"
 }
 ```
 
 We could mount each route as follows:
 ```rust
 fn main() {
-	rocket::ignite()
-		.mount("/hello", routes![world])
-		.mount("/hi", routes![japan]);
+    rocket::ignite()
+        .mount("/hello", routes![world])
+        .mount("/hi", routes![japan]);
 }
 ```
 


### PR DESCRIPTION
This PR aims to resolve the [#1458: [Request] Provide Explicit Examples/Docs of Mounting Multiple Paths](https://github.com/SergioBenitez/Rocket/issues/1458).  

## What I have done
* Added a subsection `Mounting Multiple Routes` to the sectioon `Mounting`
* Provide the examples about mounting multiple routes.  

This is my first time to contribute OSS.  
So please let me know if there are any improvements.