### PR TITLE
Catch and gracefully handle panics in routes and catchers.

### DIFF
--- a/core/lib/tests/panic-handling.rs
+++ b/core/lib/tests/panic-handling.rs
@@ -1,0 +1,36 @@
+#[macro_use] extern crate rocket;
+
+use rocket::Rocket;
+use rocket::http::Status;
+use rocket::local::blocking::Client;
+
+#[get("/panic")]
+fn panic_route() -> &'static str {
+    panic!("Panic in route")
+}
+
+#[catch(404)]
+fn panic_catcher() -> &'static str {
+    panic!("Panic in catcher")
+}
+
+fn rocket() -> Rocket {
+    rocket::ignite()
+        .mount("/", routes![panic_route])
+        .register(catchers![panic_catcher])
+}
+
+#[test]
+fn catches_route_panic() {
+    let client = Client::tracked(rocket()).unwrap();
+    let response = client.get("/panic").dispatch();
+    assert_eq!(response.status(), Status::InternalServerError);
+
+}
+
+#[test]
+fn catches_catcher_panic() {
+    let client = Client::tracked(rocket()).unwrap();
+    let response = client.get("/noroute").dispatch();
+    assert_eq!(response.status(), Status::InternalServerError);
+}


### PR DESCRIPTION
Currently, panics are left uncaught and will be caught at the next `catch_unwind` (if any). Today this is in `tokio`, and a panic in a route looks like this:

```
thread 'rocket-worker-thread' panicked at 'explicit panic', examples/hello_world/src/main.rs:7:5
```

This PR adds a `catch_unwind` around calls to `Handler::handle` and `ErrorHandler::handle` and handles errors as 500s.

* A panic in a route handler will be handled as if it instead returned `Outcome::Failure(Status::InternalServerError)`
* A panic in a user-defined error handler will be handled by Rocket's built-in error handler as if it were an `InternalServerError`

TODO:
* [ ] add/remove `catch_unwind` sites
* [ ] limit and/or explain exactly where `AssertUnwindSafe` is placed. I put it directly at the `catch_unwind` site mostly out of convenience for testing if the approach would even work.