### PR TITLE
Allow clippy::unit_arg lint in generated code

### DIFF
--- a/core/codegen/src/attribute/route.rs
+++ b/core/codegen/src/attribute/route.rs
@@ -431,6 +431,7 @@ fn codegen_route(route: Route) -> Result<TokenStream> {
         /// Rocket code generated proxy static conversion implementation.
         impl From<#user_handler_fn_name> for #StaticRouteInfo {
             fn from(_: #user_handler_fn_name) -> #StaticRouteInfo {
+                #[allow(clippy::unit_arg)]
                 fn monomorphized_function<'_b>(
                     #req: &'_b #Request,
                     #data: #Data


### PR DESCRIPTION
Fixes #1495.

This PR can be verified with `cargo clippy -p request_local_state -- --no-deps`, which shows two `unit_arg` warnings in the example before this PR and no warnings after.

This is tricky to test in CI in the current state, since we have some failing clippy lints in `rocket`, `rocket_http`, etc (some of which are "errors" in the default configuration).