### PR TITLE
Update 'memcache' dependency to 0.15.

### DIFF
--- a/contrib/lib/Cargo.toml
+++ b/contrib/lib/Cargo.toml
@@ -70,8 +70,8 @@ mysql = { version = "18.0", optional = true }
 r2d2_mysql = { version = "18.0", optional = true }
 rusqlite = { version = "0.23", optional = true }
 r2d2_sqlite = { version = "0.16", optional = true }
-memcache = { version = "0.14", optional = true }
-r2d2-memcache = { version = "0.5", optional = true }
+memcache = { version = "0.15", optional = true }
+r2d2-memcache = { version = "0.6", optional = true }
 
 # SpaceHelmet dependencies
 time = { version = "0.2.9", optional = true }

--- a/contrib/lib/src/databases.rs
+++ b/contrib/lib/src/databases.rs
@@ -325,7 +325,7 @@
 //! | Postgres | [Rust-Postgres]       | `0.17`    | [`postgres::Client`]           | `postgres_pool`        |
 //! | Sqlite   | [Diesel]              | `1`       | [`diesel::SqliteConnection`]   | `diesel_sqlite_pool`   |
 //! | Sqlite   | [`Rusqlite`]          | `0.23`    | [`rusqlite::Connection`]       | `sqlite_pool`          |
-//! | Memcache | [`memcache`]          | `0.14`    | [`memcache::Client`]           | `memcache_pool`        |
+//! | Memcache | [`memcache`]          | `0.15`    | [`memcache::Client`]           | `memcache_pool`        |
 //!
 //! [Diesel]: https://diesel.rs
 //! [`rusqlite::Connection`]: https://docs.rs/rusqlite/0.23.0/rusqlite/struct.Connection.html
@@ -339,7 +339,7 @@
 //! [`rust-mysql-simple`]: https://github.com/blackbeam/rust-mysql-simple
 //! [`diesel::PgConnection`]: http://docs.diesel.rs/diesel/pg/struct.PgConnection.html
 //! [`memcache`]: https://github.com/aisk/rust-memcache
-//! [`memcache::Client`]: https://docs.rs/memcache/0.14/memcache/struct.Client.html
+//! [`memcache::Client`]: https://docs.rs/memcache/0.15/memcache/struct.Client.html
 //!
 //! The above table lists all the supported database adapters in this library.
 //! In order to use particular `Poolable` type that's included in this library,

--- a/site/guide/6-state.md
+++ b/site/guide/6-state.md
@@ -234,7 +234,7 @@ Presently, Rocket provides built-in support for the following databases:
 | Postgres | [Rust-Postgres]       | `0.17`    | [`postgres::Client`]           | `postgres_pool`        |
 | Sqlite   | [Diesel]              | `1`       | [`diesel::SqliteConnection`]   | `diesel_sqlite_pool`   |
 | Sqlite   | [`Rusqlite`]          | `0.23`    | [`rusqlite::Connection`]       | `sqlite_pool`          |
-| Memcache | [`memcache`]          | `0.14`    | [`memcache::Client`]           | `memcache_pool`        |
+| Memcache | [`memcache`]          | `0.15`    | [`memcache::Client`]           | `memcache_pool`        |
 
 [`r2d2`]: https://crates.io/crates/r2d2
 [Diesel]: https://diesel.rs
@@ -249,7 +249,7 @@ Presently, Rocket provides built-in support for the following databases:
 [`rust-mysql-simple`]: https://github.com/blackbeam/rust-mysql-simple
 [`diesel::PgConnection`]: http://docs.diesel.rs/diesel/pg/struct.PgConnection.html
 [`memcache`]: https://github.com/aisk/rust-memcache
-[`memcache::Client`]: https://docs.rs/memcache/0.14/memcache/struct.Client.html
+[`memcache::Client`]: https://docs.rs/memcache/0.15/memcache/struct.Client.html
 
 ### Usage
 


### PR DESCRIPTION
This PR should partially unbreak CI (<https://github.com/SergioBenitez/Rocket/pull/1507#issuecomment-757348761>); we also need <https://github.com/SergioBenitez/Rocket/pull/1502/commits/87d39b6cc70ad62e5a715b03070d4c44a2186b29>.

> The CI failure is https://gitlab.com/antonok/enum_dispatch/-/issues/37 via `memcache`.

