### PR TITLE
Update 'smallvec' to v1.6.1

### DIFF
--- a/core/http/Cargo.toml
+++ b/core/http/Cargo.toml
@@ -20,7 +20,7 @@ tls = ["tokio-rustls"]
 private-cookies = ["cookie/private", "cookie/key-expansion"]
 
 [dependencies]
-smallvec = "1.0"
+smallvec = "1.6.1"
 percent-encoding = "2"
 hyper = { version = "0.14", default-features = false, features = ["http1", "http2", "runtime", "server", "stream"] }
 http = "0.2"


### PR DESCRIPTION
Howdy, cargo-audit gave me the following:

```
error: Vulnerable crates found!

ID:       RUSTSEC-2021-0003
Crate:    smallvec
Version:  1.5.1
Date:     2021-01-08
URL:      https://rustsec.org/advisories/RUSTSEC-2021-0003
Title:    Buffer overflow in SmallVec::insert_many
Solution:  upgrade to >= 0.6.14, < 1.0.0 OR >= 1.6.1
Dependency tree:
smallvec 1.5.1
├── rocket_http 0.4.6
│   ├── rocket_codegen 0.4.6
│   │   └── rocket 0.4.6
│   │       ├── rust-risk 0.1.14
│   │       ├── rocket_oauth2 0.4.1
│   │       │   └── rust-risk 0.1.14
│   │       └── rocket_contrib 0.4.6
│   │           └── rust-risk 0.1.14
│   └── rocket 0.4.6
(truncated for only relevant sections)
```
Updated http's Cargo.toml file to 1.6.1 and `cargo test` gave no errors. 
Here are the smallvec release notes: https://github.com/servo/rust-smallvec/releases/tag/v1.6.1

Best,
Mautamu