### PR TITLE
Disable rustfmt

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,3 @@
+# rustfmt produces badly formatted code so it is
+# disabled
+ignore = ["/"]


### PR DESCRIPTION
Rocket does not use rustfmt because it still has some bugs and sometimes
produces badly formatted code. However, some IDEs and editors
automatically run rustfmt in background, polluting PRs with unrelated
formatting changes.

This patch avoids that specific problem by adding syntactically invalid
rustfmt config. That way rustfmt will immediately crash and will not
modify sources.