### PR TITLE
Implement #1283 idea using typed headers

### DIFF
--- a/core/codegen/tests/ui-fail-nightly/responder-types.stderr
+++ b/core/codegen/tests/ui-fail-nightly/responder-types.stderr
@@ -6,15 +6,18 @@ error[E0277]: the trait bound `u8: Responder<'_, '_>` is not satisfied
   |
   = note: required by `respond_to`
 
-error[E0277]: the trait bound `Header<'_>: From<u8>` is not satisfied
+error[E0277]: the trait bound `Header<'_>: std::convert::From<u8>` is not satisfied
   --> $DIR/responder-types.rs:11:5
    |
 11 |     other: u8,
-   |     ^^^^^^^^^ the trait `From<u8>` is not implemented for `Header<'_>`
+   |     ^^^^^^^^^ the trait `std::convert::From<u8>` is not implemented for `Header<'_>`
    |
    = help: the following implementations were found:
-             <Header<'static> as From<&Cookie<'_>>>
-             <Header<'static> as From<Cookie<'_>>>
+             <Header<'static> as std::convert::From<&rocket::http::Cookie<'_>>>
+             <Header<'static> as std::convert::From<AcceptCharset>>
+             <Header<'static> as std::convert::From<AcceptEncoding>>
+             <Header<'static> as std::convert::From<AcceptLanguage>>
+           and 55 others
    = note: required because of the requirements on the impl of `Into<Header<'_>>` for `u8`
 
 error[E0277]: the trait bound `u8: Responder<'_, '_>` is not satisfied
@@ -25,26 +28,32 @@ error[E0277]: the trait bound `u8: Responder<'_, '_>` is not satisfied
    |
    = note: required by `respond_to`
 
-error[E0277]: the trait bound `Header<'_>: From<u8>` is not satisfied
+error[E0277]: the trait bound `Header<'_>: std::convert::From<u8>` is not satisfied
   --> $DIR/responder-types.rs:17:5
    |
 17 |     other: u8,
-   |     ^^^^^^^^^ the trait `From<u8>` is not implemented for `Header<'_>`
+   |     ^^^^^^^^^ the trait `std::convert::From<u8>` is not implemented for `Header<'_>`
    |
    = help: the following implementations were found:
-             <Header<'static> as From<&Cookie<'_>>>
-             <Header<'static> as From<Cookie<'_>>>
+             <Header<'static> as std::convert::From<&rocket::http::Cookie<'_>>>
+             <Header<'static> as std::convert::From<AcceptCharset>>
+             <Header<'static> as std::convert::From<AcceptEncoding>>
+             <Header<'static> as std::convert::From<AcceptLanguage>>
+           and 55 others
    = note: required because of the requirements on the impl of `Into<Header<'_>>` for `u8`
 
-error[E0277]: the trait bound `Header<'_>: From<std::string::String>` is not satisfied
+error[E0277]: the trait bound `Header<'_>: std::convert::From<std::string::String>` is not satisfied
   --> $DIR/responder-types.rs:24:5
    |
 24 |     then: String,
-   |     ^^^^^^^^^^^^ the trait `From<std::string::String>` is not implemented for `Header<'_>`
+   |     ^^^^^^^^^^^^ the trait `std::convert::From<std::string::String>` is not implemented for `Header<'_>`
    |
    = help: the following implementations were found:
-             <Header<'static> as From<&Cookie<'_>>>
-             <Header<'static> as From<Cookie<'_>>>
+             <Header<'static> as std::convert::From<&rocket::http::Cookie<'_>>>
+             <Header<'static> as std::convert::From<AcceptCharset>>
+             <Header<'static> as std::convert::From<AcceptEncoding>>
+             <Header<'static> as std::convert::From<AcceptLanguage>>
+           and 55 others
    = note: required because of the requirements on the impl of `Into<Header<'_>>` for `std::string::String`
 
 error[E0277]: the trait bound `usize: Responder<'_, '_>` is not satisfied
@@ -53,4 +62,4 @@ error[E0277]: the trait bound `usize: Responder<'_, '_>` is not satisfied
 28 | fn foo() -> usize { 0 }
    |             ^^^^^ the trait `Responder<'_, '_>` is not implemented for `usize`
    |
-   = note: required by `handler::<impl rocket::outcome::Outcome<rocket::Response<'o>, Status, rocket::Data>>::from`
+   = note: required by `handler::<impl Outcome<rocket::Response<'o>, Status, rocket::Data>>::from`

--- a/core/codegen/tests/ui-fail-stable/responder-types.stderr
+++ b/core/codegen/tests/ui-fail-stable/responder-types.stderr
@@ -6,15 +6,18 @@ error[E0277]: the trait bound `u8: Responder<'_, '_>` is not satisfied
   |
   = note: required by `respond_to`
 
-error[E0277]: the trait bound `Header<'_>: From<u8>` is not satisfied
+error[E0277]: the trait bound `Header<'_>: std::convert::From<u8>` is not satisfied
   --> $DIR/responder-types.rs:11:5
    |
 11 |     other: u8,
-   |     ^^^^^ the trait `From<u8>` is not implemented for `Header<'_>`
+   |     ^^^^^ the trait `std::convert::From<u8>` is not implemented for `Header<'_>`
    |
    = help: the following implementations were found:
-             <Header<'static> as From<&Cookie<'_>>>
-             <Header<'static> as From<Cookie<'_>>>
+             <Header<'static> as std::convert::From<&rocket::http::Cookie<'_>>>
+             <Header<'static> as std::convert::From<AcceptCharset>>
+             <Header<'static> as std::convert::From<AcceptEncoding>>
+             <Header<'static> as std::convert::From<AcceptLanguage>>
+           and 55 others
    = note: required because of the requirements on the impl of `Into<Header<'_>>` for `u8`
 
 error[E0277]: the trait bound `u8: Responder<'_, '_>` is not satisfied
@@ -25,26 +28,32 @@ error[E0277]: the trait bound `u8: Responder<'_, '_>` is not satisfied
    |
    = note: required by `respond_to`
 
-error[E0277]: the trait bound `Header<'_>: From<u8>` is not satisfied
+error[E0277]: the trait bound `Header<'_>: std::convert::From<u8>` is not satisfied
   --> $DIR/responder-types.rs:17:5
    |
 17 |     other: u8,
-   |     ^^^^^ the trait `From<u8>` is not implemented for `Header<'_>`
+   |     ^^^^^ the trait `std::convert::From<u8>` is not implemented for `Header<'_>`
    |
    = help: the following implementations were found:
-             <Header<'static> as From<&Cookie<'_>>>
-             <Header<'static> as From<Cookie<'_>>>
+             <Header<'static> as std::convert::From<&rocket::http::Cookie<'_>>>
+             <Header<'static> as std::convert::From<AcceptCharset>>
+             <Header<'static> as std::convert::From<AcceptEncoding>>
+             <Header<'static> as std::convert::From<AcceptLanguage>>
+           and 55 others
    = note: required because of the requirements on the impl of `Into<Header<'_>>` for `u8`
 
-error[E0277]: the trait bound `Header<'_>: From<std::string::String>` is not satisfied
+error[E0277]: the trait bound `Header<'_>: std::convert::From<std::string::String>` is not satisfied
   --> $DIR/responder-types.rs:24:5
    |
 24 |     then: String,
-   |     ^^^^ the trait `From<std::string::String>` is not implemented for `Header<'_>`
+   |     ^^^^ the trait `std::convert::From<std::string::String>` is not implemented for `Header<'_>`
    |
    = help: the following implementations were found:
-             <Header<'static> as From<&Cookie<'_>>>
-             <Header<'static> as From<Cookie<'_>>>
+             <Header<'static> as std::convert::From<&rocket::http::Cookie<'_>>>
+             <Header<'static> as std::convert::From<AcceptCharset>>
+             <Header<'static> as std::convert::From<AcceptEncoding>>
+             <Header<'static> as std::convert::From<AcceptLanguage>>
+           and 55 others
    = note: required because of the requirements on the impl of `Into<Header<'_>>` for `std::string::String`
 
 error[E0277]: the trait bound `usize: Responder<'_, '_>` is not satisfied

--- a/core/http/Cargo.toml
+++ b/core/http/Cargo.toml
@@ -23,6 +23,7 @@ private-cookies = ["cookie/private", "cookie/key-expansion"]
 smallvec = "1.0"
 percent-encoding = "2"
 hyper = { version = "0.14", default-features = false, features = ["http1", "http2", "runtime", "server", "stream"] }
+hyperx = { version = "1.3.0" }
 http = "0.2"
 mime = "0.3.13"
 time = "0.2.11"

--- a/core/http/src/hyper.rs
+++ b/core/http/src/hyper.rs
@@ -23,7 +23,8 @@
 pub mod header {
     use super::super::header::Header;
     pub use hyperx::header::Header as HyperxHeaderTrait;
-
+    pub use hyperx::header::Raw;
+    
     macro_rules! import_http_headers {
         ($($name:ident),*) => ($(
             pub use http::header::$name as $name;

--- a/core/http/src/hyper.rs
+++ b/core/http/src/hyper.rs
@@ -118,7 +118,7 @@ pub mod header {
 mod tests {
     use crate::header::HeaderMap;
     use super::header::HyperxHeaderTrait; // Needed for Accept::header_name() below?!?!
-    
+
     #[test]
     fn add_typed_header() {
         use super::header::{Accept, QualityItem, q, qitem};

--- a/core/http/src/hyper.rs
+++ b/core/http/src/hyper.rs
@@ -24,7 +24,7 @@ pub mod header {
     use super::super::header::Header;
     pub use hyperx::header::Header as HyperxHeaderTrait;
     pub use hyperx::header::Raw;
-    
+
     macro_rules! import_http_headers {
         ($($name:ident),*) => ($(
             pub use http::header::$name as $name;

--- a/core/lib/Cargo.toml
+++ b/core/lib/Cargo.toml
@@ -56,6 +56,7 @@ version_check = "0.9.1"
 [dev-dependencies]
 bencher = "0.1"
 figment = { version = "0.10", features = ["test"] }
+language-tags = { version=">=0.2, <0.3" }
 
 [[bench]]
 name = "format-routing"

--- a/core/lib/src/request/from_request.rs
+++ b/core/lib/src/request/from_request.rs
@@ -480,7 +480,7 @@ macro_rules! from_typed_headers {
                     match $name::parse_header(& Raw::from(vv)) {
                         Ok(v) => Success(v),
                         Err(_) => Forward(())
-                    } 
+                    }
                 }
             }
         }
@@ -506,7 +506,7 @@ macro_rules! from_generic_typed_headers {
                     match $name::parse_header(& Raw::from(vv)) {
                         Ok(v) => Success(v),
                         Err(_) => Forward(())
-                    } 
+                    }
                 }
             }
         }

--- a/core/lib/tests/respond-with-typed-headers-1067.rs
+++ b/core/lib/tests/respond-with-typed-headers-1067.rs
@@ -1,0 +1,35 @@
+use rocket;
+
+use rocket::{get, routes};
+use rocket::response::Responder;
+use rocket::http::hyper::header::{ContentLanguage, qitem};
+use language_tags::langtag;
+
+#[derive(Responder)]
+struct DerivedResponder {
+    text: &'static str,
+    lang_header: ContentLanguage,
+}
+
+#[get("/")]
+fn index() -> DerivedResponder {
+    DerivedResponder {
+        text: "Fyr raketten af!",
+        lang_header: ContentLanguage(vec![
+            qitem(langtag!(da))
+        ])
+    }
+}
+
+#[test]
+fn test_derive_reexports() {
+    use rocket::local::blocking::Client;
+
+    let rocket = rocket::ignite().mount("/", routes![index]);
+    let client = Client::tracked(rocket).unwrap();
+
+    let response = client.get("/").dispatch();
+    let content_languages = response.headers().get_one("content-language");
+    assert_eq!(content_languages, Some("da"));
+    assert_eq!(response.into_string().unwrap(), "Fyr raketten af!");
+}

--- a/core/lib/tests/typed-header-param-1283.rs
+++ b/core/lib/tests/typed-header-param-1283.rs
@@ -1,0 +1,74 @@
+use rocket;
+
+use rocket::{get, routes};
+use rocket::http::Status;
+use rocket::local::blocking::Client;
+use rocket::http::hyper::header::{AcceptLanguage, qitem, Authorization, Bearer};
+use language_tags::langtag;
+
+#[get("/lang-required")]
+fn lang_required(lang: AcceptLanguage) -> String {
+    format!("Accept-Language: {}", lang)
+}
+
+#[get("/lang-required", rank = 2)]
+fn no_lang() -> Status {
+    Status::BadRequest
+}
+
+#[test]
+fn test_required_header() {
+    let rocket = rocket::ignite().mount("/", routes![lang_required, no_lang]);
+    let client = Client::tracked(rocket).unwrap();
+
+    // Will hit no_lang() above
+    let response = client.get("/lang-required").dispatch();
+    assert_eq!(response.status(), Status::BadRequest);
+
+    // Will hit the lang_required() route
+    let request = client.get("/lang-required");
+    let response = request.header(AcceptLanguage(vec![qitem(langtag!(da))])).dispatch();
+    assert_eq!(response.into_string().unwrap(), "Accept-Language: da");
+}
+
+#[get("/lang-optional")]
+fn lang_optional(lang: Option<AcceptLanguage>) -> String {
+    if let Some(lang) = lang {
+        format!("Accept-Language: {}", lang)
+    } else {
+        format!("English is the lingua franca of the internet")
+    }
+}
+
+#[test]
+fn test_optional_header() {
+    let rocket = rocket::ignite().mount("/", routes![lang_optional]);
+    let client = Client::tracked(rocket).unwrap();
+
+    // When header is present
+    let request = client.get("/lang-optional");
+    let response = request.header(AcceptLanguage(vec![qitem(langtag!(da))])).dispatch();
+    assert_eq!(response.into_string().unwrap(), "Accept-Language: da");
+
+    // When header is elided
+    let response = client.get("/lang-optional").dispatch();
+    assert_eq!(response.into_string().unwrap(), "English is the lingua franca of the internet");
+}
+
+#[get("/spill-beans")]
+fn spill_beans(auth: Authorization<Bearer>) -> String {
+    format!("I'll tell you secrets: {:?}", auth.0.token)
+}
+
+#[test]
+fn test_generic_header() {
+    let rocket = rocket::ignite().mount("/", routes![spill_beans]);
+    let client = Client::tracked(rocket).unwrap();
+
+    let request = client.get("/spill-beans");
+    let response = request.header(Authorization(Bearer {
+                    token: "aaa".to_owned()
+    })).dispatch();
+    assert_eq!(response.into_string().unwrap(), "I'll tell you secrets: \"aaa\"");
+}
+


### PR DESCRIPTION
This PR implements FromRequest for a number of the typed headers from the `hyperx`crate.
It depends on PR #1535.

It allows for constructs such as: 

```rust
use rocket::http::hyper::header::AcceptLanguage;

#[get("/poem")]
fn poem(lang: Option<AcceptLanguage>) -> String {
    if let Some(lang) = lang {
        format!("TODO: Write a poem in '{}'", lang)
    } else {
        format!("A poem in any other language would sound as sweet!")
    }
}
```

The list of headers may need to be looked at since a number of the supported typed headers are only used in responses.