### PR TITLE
Fix hidden lifetime parameters in types are deprecated

### DIFF
--- a/core/codegen/src/attribute/catch.rs
+++ b/core/codegen/src/attribute/catch.rs
@@ -127,7 +127,7 @@ pub fn _catch(
             fn from(_: #user_catcher_fn_name) -> #StaticCatcherInfo {
                 fn monomorphized_function<'_b>(
                     #status: #Status,
-                    #req: &'_b #Request
+                    #req: &'_b #Request<'_>
                 ) -> #ErrorHandlerFuture<'_b> {
                     #_Box::pin(async move {
                         let __response = #catcher_response;

--- a/core/codegen/src/attribute/route.rs
+++ b/core/codegen/src/attribute/route.rs
@@ -432,7 +432,7 @@ fn codegen_route(route: Route) -> Result<TokenStream> {
         impl From<#user_handler_fn_name> for #StaticRouteInfo {
             fn from(_: #user_handler_fn_name) -> #StaticRouteInfo {
                 fn monomorphized_function<'_b>(
-                    #req: &'_b #Request,
+                    #req: &'_b #Request<'_>,
                     #data: #Data
                 ) -> #HandlerFuture<'_b> {
                     #_Box::pin(async move {

--- a/examples/hello_2018/src/main.rs
+++ b/examples/hello_2018/src/main.rs
@@ -1,3 +1,4 @@
+#![warn(rust_2018_idioms)]
 #[cfg(test)] mod tests;
 
 #[rocket::get("/")]
@@ -8,4 +9,9 @@ fn hello() -> &'static str {
 #[rocket::launch]
 fn rocket() -> rocket::Rocket {
     rocket::ignite().mount("/", rocket::routes![hello])
+}
+
+#[rocket::catch(404)]
+fn not_foundr(_req: &'_ rocket::Request<'_>) -> String {
+    "404 Not Found".to_owned()
 }


### PR DESCRIPTION
Currently the catch macro throws `warning: hidden lifetime parameters in types are deprecated` with `#![warn(rust_2018_idioms)]`

This PR adds an anonymous lifetime to the `Request` types in `monomorphized_function` which seems to fix the issue as `Request` expects a lifetime.
The route macro seems to have the same problems, but I did not encounter it. But I fixed it there too, to keep consistency.

Fixes #1547