### PR TITLE
Drop the 'local::asynchronous::Client' inside 'local::blocking::Client' on the runtime

### DIFF
--- a/core/lib/src/local/blocking/request.rs
+++ b/core/lib/src/local/blocking/request.rs
@@ -39,7 +39,7 @@ impl<'c> LocalRequest<'c> {
         method: Method,
         uri: Cow<'c, str>
     ) -> LocalRequest<'c> {
-        let inner = asynchronous::LocalRequest::new(&client.inner, method, uri);
+        let inner = asynchronous::LocalRequest::new(client.inner(), method, uri);
         Self { inner, client }
     }
 

--- a/core/lib/tests/local-client-access-runtime-in-drop.rs
+++ b/core/lib/tests/local-client-access-runtime-in-drop.rs
@@ -1,0 +1,14 @@
+use rocket::local::blocking::Client;
+
+struct SpawnBlockingOnDrop;
+
+impl Drop for SpawnBlockingOnDrop {
+    fn drop(&mut self) {
+        rocket::tokio::task::spawn_blocking(|| ());
+    }
+}
+
+#[test]
+fn test_access_runtime_in_state_drop() {
+    Client::tracked(rocket::ignite().manage(SpawnBlockingOnDrop)).unwrap();
+}


### PR DESCRIPTION
Currently the default `Drop` impl drops the `Client` "off-runtime", when other operations were done "on-runtime". This affects e.g. `#![database]`, which attempts to call `spawn_blocking` to safely drop the database pool.

This could probably be fixed or worked around in `#[database]` instead, in which case any other fairings or managed state that did blocking I/O on drop would need to implement a similar workaround separately.