### PR TITLE
Support selecting TLS cipher suites and protocol versions

### DIFF
--- a/core/lib/src/config/tls.rs
+++ b/core/lib/src/config/tls.rs
@@ -1,36 +1,117 @@
+use std::collections::HashSet;
+
 use figment::value::magic::{Either, RelativePathBuf};
 use serde::{Deserialize, Serialize};
 
-/// TLS configuration: a certificate chain and a private key.
+/// TLS configuration: a certificate chain, a private key, client/server ciphers order preference, 1.2 cipher suites, and 1.3 cipher suites.
 ///
 /// Both `certs` and `key` can be configured as a path or as raw bytes. `certs`
 /// must be a DER-encoded X.509 TLS certificate chain, while `key` must be a
 /// DER-encoded ASN.1 key in either PKCS#8 or PKCS#1 format.
 ///
+/// When a path is configured in a file source, such as `Rocket.toml`, relative
+/// paths are interpreted as being relative to the source file's directory.
+///
+/// If `prefer_server_ciphers_order` is set to true then client's ciphersuite order is ignored and the top ciphersuite in `v12_ciphers` and `v13_ciphers`
+/// which is supported by the client is chosen. Note in that case that v13_ciphers` are prioritized over `v12_ciphers`. Otherwise prefer client order.
+///
+/// `v12_ciphers` and `v13_ciphers` contains ciphers accepted by the server for TLS 1.2 and TLS 1.3 respectively.
+/// Refer to `V12Ciphers` and `V13Ciphers` for supported ciphers.
+///
 /// The following example illustrates manual configuration:
 ///
 /// ```rust
 /// use rocket::Config;
+/// use rocket::config::{V12Ciphers, V13Ciphers};
 ///
 /// let figment = rocket::Config::figment()
 ///     .merge(("tls.certs", "strings/are/paths/certs.pem"))
-///     .merge(("tls.key", vec![0; 32]));
+///     .merge(("tls.key", vec![0; 32]))
+///     .merge(("tls.prefer_server_ciphers_order", true))
+///     .merge(("tls.v12_ciphers", Vec::<V12Ciphers>::new()))
+///     .merge(("tls.v13_ciphers", vec![V13Ciphers::Aes128GcmSha256]));
 ///
 /// let config = rocket::Config::from(figment);
 /// let tls_config = config.tls.as_ref().unwrap();
 /// assert!(tls_config.certs().is_left());
 /// assert!(tls_config.key().is_right());
+/// assert_eq!(tls_config.prefer_server_ciphers_order, true);
+/// assert_eq!(tls_config.v12_ciphers, vec![]);
+/// assert_eq!(tls_config.v13_ciphers, vec![V13Ciphers::Aes128GcmSha256]);
 /// ```
 ///
-/// When a path is configured in a file source, such as `Rocket.toml`, relative
-/// paths are interpreted as being relative to the source file's directory.
 #[derive(PartialEq, Debug, Clone, Deserialize, Serialize)]
+#[serde(try_from = "NonValidatedTlsConfig")]
 pub struct TlsConfig {
     /// Path or raw bytes for the DER-encoded X.509 TLS certificate chain.
     pub(crate) certs: Either<RelativePathBuf, Vec<u8>>,
     /// Path or raw bytes to DER-encoded ASN.1 key in either PKCS#8 or PKCS#1
     /// format.
     pub(crate) key: Either<RelativePathBuf, Vec<u8>>,
+    /// Ignore the client order and choose the top ciphersuite in `v12_ciphers` and `v13_ciphers` which is supported by the client
+    pub prefer_server_ciphers_order: bool,
+    /// Ordered list of all the TLS1.2 cipher suites accepted by server.
+    pub v12_ciphers: Vec<V12Ciphers>,
+    /// Ordered list of all the TLS1.3 cipher suites accepted by server.
+    pub v13_ciphers: Vec<V13Ciphers>,
+}
+
+// Shadow type used for validation
+#[derive(Deserialize, Serialize)]
+struct NonValidatedTlsConfig {
+    certs: Either<RelativePathBuf, Vec<u8>>,
+    key: Either<RelativePathBuf, Vec<u8>>,
+    prefer_server_ciphers_order: bool,
+    v12_ciphers: Vec<V12Ciphers>,
+    v13_ciphers: Vec<V13Ciphers>,
+}
+
+impl std::convert::TryFrom<NonValidatedTlsConfig> for TlsConfig {
+    type Error = &'static str;
+    fn try_from(non_validated_config: NonValidatedTlsConfig) -> Result<Self, Self::Error> {
+        if non_validated_config.v12_ciphers.is_empty() && non_validated_config.v13_ciphers.is_empty() {
+            return Err("Both v12 and v13 ciphers are empty: there should be at least 1 cipher enabled");
+        }
+
+        if non_validated_config.v12_ciphers.len() != non_validated_config.v12_ciphers.iter().copied().collect::<HashSet<_>>().len() {
+            return Err("v12 ciphers should not contain repeated ciphers");
+        }
+
+        if non_validated_config.v13_ciphers.len() != non_validated_config.v13_ciphers.iter().copied().collect::<HashSet<_>>().len() {
+            return Err("v13 ciphers should not contain repeated ciphers");
+        }
+
+        Ok(TlsConfig {
+            certs: non_validated_config.certs,
+            key: non_validated_config.key,
+            prefer_server_ciphers_order: non_validated_config.prefer_server_ciphers_order,
+            v12_ciphers: non_validated_config.v12_ciphers,
+            v13_ciphers: non_validated_config.v13_ciphers,
+        })
+    }
+}
+
+/// This enum is used in `TlsConfig` to determine which TLS 1.2 cipher suite to accept in the server.
+/// It contains only TlS 1.2 cipher suites supported by Rocket.
+// This list is based on cipher suites supported by rustls, they can be found at rustls::ALL_CIPHERSUITES
+#[derive(PartialEq, Eq, Hash, Debug, Clone, Copy, Deserialize, Serialize)]
+pub enum V12Ciphers {
+    EcdheEcdsaWithChacha20Poly1305Sha256,
+    EcdheRsaWithChacha20Poly1305Sha256,
+    EcdheEcdsaWithAes256GcmSha384,
+    EcdheEcdsaWithAes128GcmSha256,
+    EcdheRsaWithAes256GcmSha384,
+    EcdheRsaWithAes128GcmSha256,
+}
+
+/// This enum is used in `TlsConfig` to determine which 1.3 cipher suite to accept in the server.
+/// It contains only TlS 1.3 cipher suites supported by Rocket.
+// This list is based on cipher suites supported by rustls, they can be found at rustls::ALL_CIPHERSUITES
+#[derive(PartialEq, Eq, Hash, Debug, Clone, Copy, Deserialize, Serialize)]
+pub enum V13Ciphers {
+    Chacha20Poly1305Sha256,
+    Aes256GcmSha384,
+    Aes128GcmSha256,
 }
 
 impl TlsConfig {
@@ -42,15 +123,27 @@ impl TlsConfig {
     ///
     /// ```rust
     /// use rocket::config::TlsConfig;
+    /// use rocket::config::V13Ciphers;
     ///
-    /// let tls_config = TlsConfig::from_paths("/ssl/certs.pem", "/ssl/key.pem");
+    /// let v12_ciphers = vec![];
+    /// let v13_ciphers = vec![V13Ciphers::Aes128GcmSha256, V13Ciphers::Aes256GcmSha384];
+    /// let tls_config = TlsConfig::from_paths("/ssl/certs.pem", "/ssl/key.pem", false, v12_ciphers, v13_ciphers);
     /// ```
-    pub fn from_paths<C, K>(certs: C, key: K) -> Self
+    ///
+    /// # Panics
+    /// Panics if both v12_ciphers and v13_ciphers are empty.
+    ///
+    pub fn from_paths<C, K>(certs: C, key: K, prefer_server_ciphers_order: bool, v12_ciphers: Vec<V12Ciphers>, v13_ciphers: Vec<V13Ciphers>) -> Self
         where C: AsRef<std::path::Path>, K: AsRef<std::path::Path>
     {
+        assert!(!v12_ciphers.is_empty() || !v13_ciphers.is_empty());
+
         TlsConfig {
             certs: Either::Left(certs.as_ref().to_path_buf().into()),
-            key: Either::Left(key.as_ref().to_path_buf().into())
+            key: Either::Left(key.as_ref().to_path_buf().into()),
+            prefer_server_ciphers_order,
+            v12_ciphers,
+            v13_ciphers,
         }
     }
 
@@ -63,15 +156,27 @@ impl TlsConfig {
     ///
     /// ```rust
     /// use rocket::config::TlsConfig;
+    /// use rocket::config::V13Ciphers;
     ///
+    /// let v12_ciphers = vec![];
+    /// let v13_ciphers = vec![V13Ciphers::Aes128GcmSha256, V13Ciphers::Aes256GcmSha384];
     /// # let certs_buf = &[];
     /// # let key_buf = &[];
-    /// let tls_config = TlsConfig::from_bytes(certs_buf, key_buf);
+    /// let tls_config = TlsConfig::from_bytes(certs_buf, key_buf, false, v12_ciphers, v13_ciphers);
     /// ```
-    pub fn from_bytes(certs: &[u8], key: &[u8]) -> Self {
+    ///
+    /// # Panics
+    /// Panics if both v12_ciphers and v13_ciphers are empty.
+    ///
+    pub fn from_bytes(certs: &[u8], key: &[u8], prefer_server_ciphers_order: bool, v12_ciphers: Vec<V12Ciphers>, v13_ciphers: Vec<V13Ciphers>) -> Self {
+        assert!(!v12_ciphers.is_empty() || !v13_ciphers.is_empty());
+
         TlsConfig {
             certs: Either::Right(certs.to_vec().into()),
-            key: Either::Right(key.to_vec().into())
+            key: Either::Right(key.to_vec().into()),
+            prefer_server_ciphers_order,
+            v12_ciphers,
+            v13_ciphers,
         }
     }
 
@@ -81,10 +186,14 @@ impl TlsConfig {
     ///
     /// ```rust
     /// use rocket::Config;
+    /// use rocket::config::{V12Ciphers, V13Ciphers};
     ///
     /// let figment = Config::figment()
     ///     .merge(("tls.certs", vec![0; 32]))
-    ///     .merge(("tls.key", "/etc/ssl/key.pem"));
+    ///     .merge(("tls.key", "/etc/ssl/key.pem"))
+    ///     .merge(("tls.prefer_server_ciphers_order", true))
+    ///     .merge(("tls.v12_ciphers", Vec::<V12Ciphers>::new()))
+    ///     .merge(("tls.v13_ciphers", vec![V13Ciphers::Aes128GcmSha256]));
     ///
     /// let config = rocket::Config::from(figment);
     /// let tls_config = config.tls.as_ref().unwrap();
@@ -105,10 +214,14 @@ impl TlsConfig {
     /// ```rust
     /// use std::path::Path;
     /// use rocket::Config;
+    /// use rocket::config::{V12Ciphers, V13Ciphers};
     ///
     /// let figment = Config::figment()
     ///     .merge(("tls.certs", vec![0; 32]))
-    ///     .merge(("tls.key", "/etc/ssl/key.pem"));
+    ///     .merge(("tls.key", "/etc/ssl/key.pem"))
+    ///     .merge(("tls.prefer_server_ciphers_order", true))
+    ///     .merge(("tls.v12_ciphers", Vec::<V12Ciphers>::new()))
+    ///     .merge(("tls.v13_ciphers", vec![V13Ciphers::Aes128GcmSha256]));
     ///
     /// let config = rocket::Config::from(figment);
     /// let tls_config = config.tls.as_ref().unwrap();

--- a/core/lib/tests/tls-config-from-source-1503.rs
+++ b/core/lib/tests/tls-config-from-source-1503.rs
@@ -1,19 +1,22 @@
 macro_rules! crate_relative {
     ($path:expr) => {
-        std::path::Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/", $path))
+        std::path::Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/../../", $path))
     };
 }
 
 #[test]
-fn tls_config_from_soruce() {
-    use rocket::config::{Config, TlsConfig};
+fn tls_config_from_source() {
+    use rocket::config::{Config, TlsConfig, V12Ciphers, V13Ciphers};
     use rocket::figment::Figment;
 
-    let cert_path = crate_relative!("examples/tls/private/cert.pem");
-    let key_path = crate_relative!("examples/tls/private/key.pem");
+    let cert_path = crate_relative!("examples/tls/private/rsa_sha256_cert.pem");
+    let key_path = crate_relative!("examples/tls/private/rsa_sha256_key.pem");
+    let prefer_server_ciphers_order = true;
+    let v12_ciphers = vec![V12Ciphers::EcdheRsaWithAes256GcmSha384];
+    let v13_ciphers = vec![V13Ciphers::Aes128GcmSha256];
 
     let rocket_config = Config {
-        tls: Some(TlsConfig::from_paths(cert_path, key_path)),
+        tls: Some(TlsConfig::from_paths(cert_path, key_path, true, v12_ciphers.clone(), v13_ciphers.clone())),
         ..Default::default()
     };
 
@@ -21,4 +24,7 @@ fn tls_config_from_soruce() {
     let tls = config.tls.expect("have TLS config");
     assert_eq!(tls.certs().unwrap_left(), cert_path);
     assert_eq!(tls.key().unwrap_left(), key_path);
+    assert_eq!(tls.prefer_server_ciphers_order, prefer_server_ciphers_order);
+    assert_eq!(tls.v12_ciphers, v12_ciphers);
+    assert_eq!(tls.v13_ciphers, v13_ciphers);
 }

--- a/core/lib/tests/tls-launch-successfully.rs
+++ b/core/lib/tests/tls-launch-successfully.rs
@@ -1,0 +1,28 @@
+use rocket::config::{Config, TlsConfig, V12Ciphers, V13Ciphers};
+
+macro_rules! crate_relative {
+    ($path:expr) => {
+        std::path::Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/../../", $path))
+    };
+}
+
+#[rocket::async_test]
+async fn tls_launch_successfully() {
+    let cert_path = crate_relative!("examples/tls/private/rsa_sha256_cert.pem");
+    let key_path = crate_relative!("examples/tls/private/rsa_sha256_key.pem");
+
+    let v12_ciphers = vec![V12Ciphers::EcdheRsaWithAes256GcmSha384];
+    let v13_ciphers = vec![V13Ciphers::Aes128GcmSha256];
+
+    let tls = Some(TlsConfig::from_paths(cert_path, key_path, true, v12_ciphers, v13_ciphers));
+
+    let rocket = rocket::custom(Config { tls, ..Config::debug_default() });
+
+    let shutdown_handle = rocket.shutdown();
+
+    let join_handle = rocket::tokio::spawn(rocket.launch());
+
+    shutdown_handle.shutdown();
+
+    join_handle.await.unwrap().unwrap();
+}

--- a/examples/tls/Rocket.toml
+++ b/examples/tls/Rocket.toml
@@ -7,6 +7,9 @@
 [default.tls]
 certs = "private/rsa_sha256_cert.pem"
 key = "private/rsa_sha256_key.pem"
+prefer_server_ciphers_order = true
+v12_ciphers = []
+v13_ciphers = ["Aes256GcmSha384", "Aes128GcmSha256"]
 
 [rsa_sha256.tls]
 certs = "private/rsa_sha256_cert.pem"

--- a/site/guide/9-configuration.md
+++ b/site/guide/9-configuration.md
@@ -17,21 +17,26 @@ is configured with. This means that no matter which configuration provider
 Rocket is asked to use, it must be able to read the following configuration
 values:
 
-| key            | kind            | description                                     | debug/release default |
-|----------------|-----------------|-------------------------------------------------|-----------------------|
-| `address`      | `IpAddr`        | IP address to serve on                          | `127.0.0.1`           |
-| `port`         | `u16`           | Port to serve on.                               | `8000`                |
-| `workers`      | `usize`         | Number of threads to use for executing futures. | cpu core count        |
-| `keep_alive`   | `u32`           | Keep-alive timeout seconds; disabled when `0`.  | `5`                   |
-| `log_level`    | `LogLevel`      | Max level to log. (off/normal/debug/critical)   | `normal`/`critical`   |
-| `cli_colors`   | `bool`          | Whether to use colors and emoji when logging.   | `true`                |
-| `secret_key`   | `SecretKey`     | Secret key for signing and encrypting values.   | `None`                |
-| `tls`          | `TlsConfig`     | TLS configuration, if any.                      | `None`                |
-| `tls.key`      | `&[u8]`/`&Path` | Path/bytes to DER-encoded ASN.1 PKCS#1/#8 key.  |                       |
-| `tls.certs`    | `&[u8]`/`&Path` | Path/bytes to DER-encoded X.509 TLS cert chain. |                       |
-| `limits`       | `Limits`        | Streaming read size limits.                     | [`Limits::default()`] |
-| `limits.$name` | `&str`/`uint`   | Read limit for `$name`.                         | forms = "32KiB"       |
-| `ctrlc`        | `bool`          | Whether `ctrl-c` initiates a server shutdown.   | `true`                |
+| key                               | kind            | description                                     | debug/release default |
+|-----------------------------------|-----------------|-------------------------------------------------|-----------------------|
+| `address`                         | `IpAddr`        | IP address to serve on                          | `127.0.0.1`           |
+| `port`                            | `u16`           | Port to serve on.                               | `8000`                |
+| `workers`                         | `usize`         | Number of threads to use for executing futures. | cpu core count        |
+| `keep_alive`                      | `u32`           | Keep-alive timeout seconds; disabled when `0`.  | `5`                   |
+| `log_level`                       | `LogLevel`      | Max level to log. (off/normal/debug/critical)   | `normal`/`critical`   |
+| `cli_colors`                      | `bool`          | Whether to use colors and emoji when logging.   | `true`                |
+| `secret_key`                      | `SecretKey`     | Secret key for signing and encrypting values.   | `None`                |
+| `tls`                             | `TlsConfig`     | TLS configuration, if any.                      | `None`                |
+| `tls.key`                         | `&[u8]`/`&Path` | Path/bytes to DER-encoded ASN.1 PKCS#1/#8 key.  |                       |
+| `tls.certs`                       | `&[u8]`/`&Path` | Path/bytes to DER-encoded X.509 TLS cert chain. |                       |
+| `tls.prefer_server_ciphers_order` | `bool`          | Ignore the client order and choose the top      |                       |
+|                                   |                 | ciphersuite in `v12_ciphers` and `v13_ciphers`  |                       |
+|                                   |                 | which is supported by the client.               |                       |
+| `tls.v12_ciphers`                 | `[V12Ciphers]`  | Ordered list of accepted TLS1.2 cipher suites.  |                       |
+| `tls.v13_ciphers`                 | `[V13Ciphers]`  | Ordered list of accepted TLS1.3 cipher suites.  |                       |
+| `limits`                          | `Limits`        | Streaming read size limits.                     | [`Limits::default()`] |
+| `limits.$name`                    | `&str`/`uint`   | Read limit for `$name`.                         | forms = "32KiB"       |
+| `ctrlc`                           | `bool`          | Whether `ctrl-c` initiates a server shutdown.   | `true`                |
 
 ### Profiles
 
@@ -101,11 +106,26 @@ rocket = { version = "0.5.0-dev", features = ["tls"] }
 ```
 
 TLS is configured through the `tls` configuration parameter. The value of `tls`
-is a dictionary with two keys: `certs` and `key`, described in the table above.
-Each key's value may be either a path to a file or raw bytes corresponding to
+is a dictionary with five keys: `certs`, `key`, `prefer_server_ciphers_order`,
+`v12_ciphers`, `v13_ciphers`, described in the table above.
+`certs` and `key`'s value may be either a path to a file or raw bytes corresponding to
 the expected value. When a path is configured in a file source, such as
 `Rocket.toml`, relative paths are interpreted as being relative to the source
 file's directory.
+
+If `prefer_server_ciphers_order` is set to true then client's ciphersuite order is ignored
+and the top ciphersuite in `v12_ciphers` and `v13_ciphers` which is supported by the client
+is chosen. Note in that case that `v13_ciphers` are prioritized over `v12_ciphers`.
+Otherwise prefer client order.
+
+`v12_ciphers` and `v13_ciphers` contains ordered list of ciphers accepted by the server
+for TLS 1.2 and TLS 1.3 respectively.
+
+`v12_ciphers` support the following ciphers: `EcdheEcdsaWithChacha20Poly1305Sha256`,
+`EcdheRsaWithChacha20Poly1305Sha256`,`EcdheEcdsaWithAes256GcmSha384`,
+`EcdheEcdsaWithAes128GcmSha256`, `EcdheRsaWithAes256GcmSha384`, and `EcdheRsaWithAes128GcmSha256`.
+
+`v13_ciphers` support the following ciphers: `Chacha20Poly1305Sha256`, `Aes256GcmSha384` and `Aes128GcmSha256`.
 
 ! warning: Rocket's built-in TLS implements only TLS 1.2 and 1.3. As such, it
   may not be suitable for production use.


### PR DESCRIPTION
**This my first pull request ever, sorry for any mistakes.**

**To summarize the major changes:**

- I have created a public enum 'Version" to indicate TLS protocol version which contains only 1.2 and 1.3
  -  rustls only support version 1.2 and 1.3 however their enum [ProtocolVersion](https://docs.rs/rustls/0.19.0/rustls/enum.ProtocolVersion.html) includes all TLS and SSL versions.
- I have created a public enum 'CipherSuite' to indicate supported cipher suites.
  - rustls currently support 9 cipher, they are stored in a static array [here](https://docs.rs/rustls/0.19.0/rustls/static.ALL_CIPHERSUITES.html)
- I have added two more members in TlsConfig which are both Vec of the previous enums. They can be set via the following parameters tls.ciphersuites and tls.versions.

I am not sure where to add tests. I have added doc examples for the added functions, changed an existing doc example and modified the TLS example to set "tls.ciphersuites" and "tls.versions" from Rocket.toml.