### PR TITLE
Add 'RouteUri' struct and use instead of base/path/uri on 'Route'

### DIFF
--- a/core/lib/benches/simple-routing.rs
+++ b/core/lib/benches/simple-routing.rs
@@ -95,7 +95,7 @@ fn bench_simple_routing(b: &mut Bencher) {
     // Hold all of the requests we're going to make during the benchmark.
     let mut requests = vec![];
     for route in client.rocket().routes() {
-        let request = client.req(route.method, route.uri.path().as_str());
+        let request = client.req(route.method, route.uri.path());
         requests.push(request);
     }
 

--- a/core/lib/src/error.rs
+++ b/core/lib/src/error.rs
@@ -212,30 +212,3 @@ impl Drop for Error {
         }
     }
 }
-
-use crate::http::uri;
-use crate::http::ext::IntoOwned;
-
-/// Error returned by [`Route::map_base()`] on invalid URIs.
-#[derive(Debug)]
-pub enum RouteUriError {
-    /// The route URI is not a valid URI.
-    Uri(uri::Error<'static>),
-    /// The base (mount point) contains dynamic segments.
-    DynamicBase,
-}
-
-impl<'a> From<uri::Error<'a>> for RouteUriError {
-    fn from(error: uri::Error<'a>) -> Self {
-        RouteUriError::Uri(error.into_owned())
-    }
-}
-
-impl fmt::Display for RouteUriError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            RouteUriError::DynamicBase => write!(f, "Mount point contains dynamic parameters."),
-            RouteUriError::Uri(error) => write!(f, "Malformed URI: {}", error)
-        }
-    }
-}

--- a/core/lib/src/request/request.rs
+++ b/core/lib/src/request/request.rs
@@ -792,7 +792,7 @@ impl<'r> Request<'r> {
     #[inline]
     pub fn routed_segments(&self, n: RangeFrom<usize>) -> Segments<'_> {
         let mount_segments = self.route()
-            .map(|r| r.base.path_segments().len())
+            .map(|r| r.uri.metadata.base_segs.len())
             .unwrap_or(0);
 
         self.uri().path_segments().skip(mount_segments + n.start)

--- a/core/lib/src/rocket.rs
+++ b/core/lib/src/rocket.rs
@@ -222,16 +222,16 @@ impl Rocket {
               Paint::magenta(":"));
 
         for route in routes.into() {
-            let old_route = route.clone();
-            let route = route.map_base(|old| format!("{}{}", base, old))
+            let mounted_route = route.clone()
+                .map_base(|old| format!("{}{}", base, old))
                 .unwrap_or_else(|e| {
-                    error_!("Route `{}` has a malformed URI.", old_route);
+                    error_!("Route `{}` has a malformed URI.", route);
                     error_!("{}", e);
                     panic!("Invalid route URI.");
                 });
 
-            info_!("{}", route);
-            self.router.add(route);
+            info_!("{}", mounted_route);
+            self.router.add(mounted_route);
         }
 
         self

--- a/core/lib/src/rocket.rs
+++ b/core/lib/src/rocket.rs
@@ -433,7 +433,7 @@ impl Rocket {
     ///         .mount("/hi", routes![hello]);
     ///
     ///     for route in rocket.routes() {
-    ///         match route.base() {
+    ///         match route.uri.base() {
     ///             "/" => assert_eq!(route.uri.path(), "/hello"),
     ///             "/hi" => assert_eq!(route.uri.path(), "/hi/hello"),
     ///             _ => unreachable!("only /hello, /hi/hello are expected")

--- a/core/lib/src/router/collider.rs
+++ b/core/lib/src/router/collider.rs
@@ -46,12 +46,12 @@ impl Route {
 }
 
 fn paths_collide(route: &Route, other: &Route) -> bool {
-    if route.metadata.wild_path || other.metadata.wild_path {
+    if route.uri.metadata.wild_path || other.uri.metadata.wild_path {
         return true;
     }
 
-    let a_segments = &route.metadata.path_segs;
-    let b_segments = &other.metadata.path_segs;
+    let a_segments = &route.uri.metadata.path_segs;
+    let b_segments = &other.uri.metadata.path_segs;
     for (seg_a, seg_b) in a_segments.iter().zip(b_segments.iter()) {
         if seg_a.trailing || seg_b.trailing {
             return true;
@@ -70,13 +70,13 @@ fn paths_collide(route: &Route, other: &Route) -> bool {
 }
 
 fn paths_match(route: &Route, req: &Request<'_>) -> bool {
-    let route_segments = &route.metadata.path_segs;
+    let route_segments = &route.uri.metadata.path_segs;
     let req_segments = req.routed_segments(0..);
     if route_segments.len() > req_segments.len() + 1 {
         return false;
     }
 
-    if route.metadata.wild_path {
+    if route.uri.metadata.wild_path {
         return true;
     }
 
@@ -95,11 +95,11 @@ fn paths_match(route: &Route, req: &Request<'_>) -> bool {
 }
 
 fn queries_match(route: &Route, req: &Request<'_>) -> bool {
-    if route.metadata.wild_query {
+    if route.uri.metadata.wild_query {
         return true;
     }
 
-    let route_query_fields = route.metadata.static_query_fields.iter()
+    let route_query_fields = route.uri.metadata.static_query_fields.iter()
         .map(|(k, v)| (k.as_str(), v.as_str()));
 
     for route_seg in route_query_fields {
@@ -482,7 +482,7 @@ mod tests {
     fn req_route_path_match(a: &'static str, b: &'static str) -> bool {
         let rocket = Rocket::custom(Config::default());
         let req = Request::new(&rocket, Get, Origin::parse(a).expect("valid URI"));
-        let route = Route::ranked(0, Get, b.to_string(), dummy);
+        let route = Route::ranked(0, Get, b, dummy);
         route.matches(&req)
     }
 

--- a/core/lib/src/router/mod.rs
+++ b/core/lib/src/router/mod.rs
@@ -1,6 +1,7 @@
 mod collider;
 mod route;
 mod segment;
+mod uri;
 
 use std::collections::HashMap;
 
@@ -10,6 +11,7 @@ use crate::handler::dummy;
 
 pub use self::route::Route;
 pub use self::segment::Segment;
+pub use self::uri::RouteUri;
 
 // type Selector = (Method, usize);
 type Selector = Method;
@@ -108,7 +110,7 @@ mod test {
     fn router_with_routes(routes: &[&'static str]) -> Router {
         let mut router = Router::new();
         for route in routes {
-            let route = Route::new(Get, route.to_string(), dummy);
+            let route = Route::new(Get, route, dummy);
             router.add(route);
         }
 
@@ -118,7 +120,7 @@ mod test {
     fn router_with_ranked_routes(routes: &[(isize, &'static str)]) -> Router {
         let mut router = Router::new();
         for &(rank, route) in routes {
-            let route = Route::ranked(rank, Get, route.to_string(), dummy);
+            let route = Route::ranked(rank, Get, route, dummy);
             router.add(route);
         }
 
@@ -128,7 +130,7 @@ mod test {
     fn router_with_rankless_routes(routes: &[&'static str]) -> Router {
         let mut router = Router::new();
         for route in routes {
-            let route = Route::ranked(0, Get, route.to_string(), dummy);
+            let route = Route::ranked(0, Get, route, dummy);
             router.add(route);
         }
 
@@ -300,9 +302,9 @@ mod test {
         assert!(route(&router, Get, "/jdlk/asdij").is_some());
 
         let mut router = Router::new();
-        router.add(Route::new(Put, "/hello".to_string(), dummy));
-        router.add(Route::new(Post, "/hello".to_string(), dummy));
-        router.add(Route::new(Delete, "/hello".to_string(), dummy));
+        router.add(Route::new(Put, "/hello", dummy));
+        router.add(Route::new(Post, "/hello", dummy));
+        router.add(Route::new(Delete, "/hello", dummy));
         assert!(route(&router, Put, "/hello").is_some());
         assert!(route(&router, Post, "/hello").is_some());
         assert!(route(&router, Delete, "/hello").is_some());

--- a/core/lib/src/router/route.rs
+++ b/core/lib/src/router/route.rs
@@ -136,13 +136,13 @@ impl Route {
     /// # use rocket::handler::{dummy as handler, Outcome, HandlerFuture};
     ///
     /// let index = Route::new(Method::Get, "/foo/bar", handler);
-    /// assert_eq!(index.base(), "/");
-    /// assert_eq!(index.path().path(), "/foo/bar");
+    /// assert_eq!(index.uri.base(), "/");
+    /// assert_eq!(index.uri.unmounted_origin.path(), "/foo/bar");
     /// assert_eq!(index.uri.path(), "/foo/bar");
     ///
     /// let index = index.map_base(|base| format!("{}{}", "/boo", base)).unwrap();
-    /// assert_eq!(index.base(), "/boo");
-    /// assert_eq!(index.path().path(), "/foo/bar");
+    /// assert_eq!(index.uri.base(), "/boo");
+    /// assert_eq!(index.uri.unmounted_origin.path(), "/foo/bar");
     /// assert_eq!(index.uri.path(), "/boo/foo/bar");
     /// ```
     pub fn map_base<'a, F>(mut self, mapper: F) -> Result<Self, uri::Error<'static>>

--- a/core/lib/src/router/uri.rs
+++ b/core/lib/src/router/uri.rs
@@ -1,0 +1,227 @@
+use std::fmt;
+use std::borrow::Cow;
+
+use crate::http::uri::{self, Origin};
+use crate::http::ext::IntoOwned;
+use crate::router::Segment;
+use crate::form::ValueField;
+
+#[derive(Clone)]
+pub struct RouteUri<'a> {
+    /// The source string for this URI.
+    source: Cow<'a, str>,
+    /// The mount point of this `Route`.
+    pub base: Origin<'a>,
+    /// The URI _without_ the `base`.
+    pub unmounted_origin: Origin<'a>,
+    /// The URI _with_ the base. This is the canoncical route URI.
+    pub origin: Origin<'a>,
+    /// Cached metadata about this URI.
+    pub(crate) metadata: Metadata,
+}
+
+#[derive(Debug, Default, Clone)]
+pub(crate) struct Metadata {
+    /// Segments in the base.
+    pub base_segs: Vec<Segment>,
+    /// Segments in the path, including base.
+    pub path_segs: Vec<Segment>,
+    /// Segments in the query.
+    pub query_segs: Vec<Segment>,
+    /// `(name, value)` of the query segments that are static.
+    pub static_query_fields: Vec<(String, String)>,
+    /// Whether the path is completely static.
+    pub static_path: bool,
+    /// Whether the path is completely dynamic.
+    pub wild_path: bool,
+    /// Whether the path has a `<trailing..>` parameter.
+    pub trailing_path: bool,
+    /// Whether the query is completely dynamic.
+    pub wild_query: bool,
+}
+
+type Result<T> = std::result::Result<T, uri::Error<'static>>;
+
+impl<'a> RouteUri<'a> {
+    /// Create a new `RouteUri`. Don't panic.
+    pub(crate) fn try_new(base: &str, uri: &str) -> Result<RouteUri<'static>> {
+        let mut base = Origin::parse(base)
+            .map_err(|e| e.into_owned())?
+            .into_normalized()
+            .into_owned();
+
+        base.clear_query();
+
+        let unmounted_origin = Origin::parse_route(uri)
+            .map_err(|e| e.into_owned())?
+            .into_normalized()
+            .into_owned();
+
+        let origin = Origin::parse_route(&format!("{}/{}", base, unmounted_origin))
+            .map_err(|e| e.into_owned())?
+            .into_normalized()
+            .into_owned();
+
+        let source = origin.to_string().into();
+        let metadata = Metadata::from(&base, &origin);
+
+        Ok(RouteUri { source, unmounted_origin, base, origin, metadata })
+    }
+
+    /// Create a new `RouteUri`. Panic.
+    pub(crate) fn new(base: &str, uri: &str) -> RouteUri<'static> {
+        Self::try_new(base, uri).expect("FIXME MSG")
+    }
+
+    /// The path of the base mount point of this route URI as an `&str`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use rocket::RouteUri;
+    ///
+    /// let index = RouteUri::new("/foo/bar?a=1");
+    /// let index = index.map_base(|base| format!("{}{}", "/boo", base)).unwrap();
+    /// assert_eq!(index.uri(), "/boo/foo/bar");
+    /// assert_eq!(index.base(), "/boo");
+    /// assert_eq!(index.path(), "/foo/bar");
+    /// assert_eq!(index.query().unwrap(), "a=1");
+    /// assert_eq!(index.as_str(), "/boo/foo/bar?a=1");
+    /// ```
+    #[inline(always)]
+    pub fn base(&self) -> &str {
+        self.base.path().as_str()
+    }
+
+    /// The path part of this route URI as an `&str`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use rocket::RouteUri;
+    ///
+    /// let index = RouteUri::new("/foo/bar?a=1");
+    /// let index = index.map_base(|base| format!("{}{}", "/boo", base)).unwrap();
+    /// assert_eq!(index.uri(), "/boo/foo/bar");
+    /// assert_eq!(index.base(), "/boo");
+    /// assert_eq!(index.path(), "/foo/bar");
+    /// assert_eq!(index.query().unwrap(), "a=1");
+    /// assert_eq!(index.as_str(), "/boo/foo/bar?a=1");
+    /// ```
+    #[inline(always)]
+    pub fn path(&self) -> &str {
+        self.origin.path().as_str()
+    }
+
+    /// The query part of this route URI as an `Option<&str>`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use rocket::RouteUri;
+    ///
+    /// let index = RouteUri::new("/foo/bar?a=1");
+    /// let index = index.map_base(|base| format!("{}{}", "/boo", base)).unwrap();
+    /// assert_eq!(index.uri(), "/boo/foo/bar");
+    /// assert_eq!(index.base(), "/boo");
+    /// assert_eq!(index.path(), "/foo/bar");
+    /// assert_eq!(index.query().unwrap(), "a=1");
+    /// assert_eq!(index.as_str(), "/boo/foo/bar?a=1");
+    /// ```
+    #[inline(always)]
+    pub fn query(&self) -> Option<&str> {
+        self.origin.query().map(|q| q.as_str())
+    }
+
+    /// The full URI as an `&str`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use rocket::RouteUri;
+    ///
+    /// let index = RouteUri::new("/foo/bar?a=1");
+    /// let index = index.map_base(|base| format!("{}{}", "/boo", base)).unwrap();
+    /// assert_eq!(index.uri(), "/boo/foo/bar");
+    /// assert_eq!(index.base(), "/boo");
+    /// assert_eq!(index.path(), "/foo/bar");
+    /// assert_eq!(index.query().unwrap(), "a=1");
+    /// assert_eq!(index.as_str(), "/boo/foo/bar?a=1");
+    /// ```
+    #[inline(always)]
+    pub fn as_str(&self) -> &str {
+        &self.source
+    }
+
+    #[inline(always)]
+    pub fn as_origin(&self) -> &Origin<'a> {
+        &self.origin
+    }
+
+    pub fn default_rank(&self) -> isize {
+        let static_path = self.metadata.static_path;
+        let wild_query = self.query().map(|_| self.metadata.wild_query);
+        match (static_path, wild_query) {
+            (true, Some(false)) => -6,   // static path, partly static query
+            (true, Some(true)) => -5,    // static path, fully dynamic query
+            (true, None) => -4,          // static path, no query
+            (false, Some(false)) => -3,  // dynamic path, partly static query
+            (false, Some(true)) => -2,   // dynamic path, fully dynamic query
+            (false, None) => -1,         // dynamic path, no query
+        }
+    }
+}
+
+impl Metadata {
+    fn from(base: &Origin<'_>, origin: &Origin<'_>) -> Self {
+        let base_segs = base.raw_path_segments()
+            .map(Segment::from)
+            .collect::<Vec<_>>();
+
+        let path_segs = origin.raw_path_segments()
+            .map(Segment::from)
+            .collect::<Vec<_>>();
+
+        let query_segs = origin.raw_query_segments()
+            .map(Segment::from)
+            .collect::<Vec<_>>();
+
+        Metadata {
+            static_path: path_segs.iter().all(|s| !s.dynamic),
+            wild_path: path_segs.iter().all(|s| s.dynamic)
+                && path_segs.last().map_or(false, |p| p.trailing),
+            trailing_path: path_segs.last().map_or(false, |p| p.trailing),
+            wild_query: query_segs.iter().all(|s| s.dynamic),
+            static_query_fields: query_segs.iter().filter(|s| !s.dynamic)
+                .map(|s| ValueField::parse(&s.value))
+                .map(|f| (f.name.source().to_string(), f.value.to_string()))
+                .collect(),
+            path_segs,
+            query_segs,
+            base_segs,
+        }
+    }
+}
+
+impl<'a> std::ops::Deref for RouteUri<'a> {
+    type Target = Origin<'a>;
+
+    fn deref(&self) -> &Self::Target {
+        self.as_origin()
+    }
+}
+
+impl fmt::Display for RouteUri<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.origin.fmt(f)
+    }
+}
+
+impl fmt::Debug for RouteUri<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RouteUri")
+            .field("base", &self.base)
+            .field("uri", &self.as_origin())
+            .finish()
+    }
+}

--- a/core/lib/tests/route_guard.rs
+++ b/core/lib/tests/route_guard.rs
@@ -6,7 +6,7 @@ use rocket::Route;
 
 #[get("/<path..>")]
 fn files(route: &Route, path: PathBuf) -> String {
-    Path::new(route.base()).join(path).normalized_str().to_string()
+    Path::new(route.uri.base()).join(path).normalized_str().to_string()
 }
 
 mod route_guard_tests {


### PR DESCRIPTION
This PR adds a new `RouteUri` struct (based on the suggestions in #1575) which consolidates the various `base`, `path`, and 'complete' `uri` subsets of a route's URI, and also provides access to the 'complete' URI as a '&str' by storing the full URI as a `String` on the `RouteUri` struct.

Questions:

- do you agree with the changes to 'base', 'path' and 'uri'? This does change the API somewhat, requiring users to go through the `RouteUri` struct to get hold of these things. I can add back the old `base` and `path` methods on `Route` if desired.
- should `RouteUri` be exported as `rocket::RouteUri`? or just `rocket::routes::RouteUri`?
- I'm not sure about the naming of the 'uri' and 'origin' fields/methods - any ideas?

TODO:

- [ ] Add docstring to `RouteUri`
- [ ] Add better docstring to `RouteUri::new`

Closes #1575. 