### PR TITLE
use tera include in example

### DIFF
--- a/examples/templating/templates/tera/base.html.tera
+++ b/examples/templating/templates/tera/base.html.tera
@@ -5,7 +5,7 @@
     <title>Tera Demo - {{ title }}</title>
   </head>
   <body>
-    <a href="/tera/hello/Unknown">Hello</a> | <a href="/tera/about">About</a>
+    {% include "tera/nav" %}
 
     {% block content %}{% endblock content %}
 

--- a/examples/templating/templates/tera/nav.html.tera
+++ b/examples/templating/templates/tera/nav.html.tera
@@ -1,0 +1,1 @@
+<a href="/tera/hello/Unknown">Hello</a> | <a href="/tera/about">About</a>


### PR DESCRIPTION
This is my first PR in the project, so sorry for any issues in advance.
I've made a small improvement to the Tera template example: I've added an "include" statement, because I had some issues with figuring out the correct path to use in my own project, and I wanted to save others the hassle by adding it to the example. The official Tera website uses examples like `{% include "items.html" %}` but for Rocket it should be simply `{% include "items" %}`, even though the template file is named `items.html.tera`.
I've also added some extra tests to check if the context is properly passed between template and then displayed correctly. I know the "expected" value assert already checks the whole rendered HTML, but I presumed it's better to explicitly check if the context values are present. Let me know if you think it's too superfluous and I'll remove it.