### PR TITLE
Fix typo in route docs

### DIFF
--- a/core/codegen/src/lib.rs
+++ b/core/codegen/src/lib.rs
@@ -203,7 +203,7 @@ macro_rules! route_attribute {
         /// | path     | `<ident>`   | [`FromParam`]     |
         /// | path     | `<ident..>` | [`FromSegments`]  |
         /// | query    | `<ident>`   | [`FromForm`]      |
-        /// | query    | `<ident..>` | [`FromFrom`]      |
+        /// | query    | `<ident..>` | [`FromForm`]      |
         /// | data     | `<ident>`   | [`FromData`]      |
         ///
         /// The type of each function argument that _does not_ have a


### PR DESCRIPTION
Typo in docs caused hyperlink to be malformed:

![image](https://user-images.githubusercontent.com/15170378/112755183-e48f2f00-8fdf-11eb-883c-56c083232a72.png)
