### PR TITLE
XML support in contrib using quick-xml

### DIFF
--- a/contrib/lib/Cargo.toml
+++ b/contrib/lib/Cargo.toml
@@ -23,6 +23,7 @@ databases = [
 default = ["json", "serve"]
 json = ["serde", "serde_json", "tokio/io-util"]
 msgpack = ["serde", "rmp-serde", "tokio/io-util"]
+xml = ["serde", "quick-xml", "tokio/io-util"]
 tera_templates = ["tera", "templates"]
 handlebars_templates = ["handlebars", "templates"]
 helmet = ["time"]
@@ -51,6 +52,7 @@ log = "0.4"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 serde_json = { version = "1.0.26", optional = true }
 rmp-serde = { version = "0.15.0", optional = true }
+quick-xml = { version = "0.22.0", optional = true, features = ["serialize"] }
 
 # Templating dependencies.
 handlebars = { version = "3.0", optional = true }

--- a/contrib/lib/src/lib.rs
+++ b/contrib/lib/src/lib.rs
@@ -19,6 +19,7 @@
 //! * [json*](type@json) - JSON (de)serialization
 //! * [serve*](serve) - Static File Serving
 //! * [msgpack](msgpack) - MessagePack (de)serialization
+//! * [xml](type@xml) - XML (de)serialization
 //! * [handlebars_templates](templates) - Handlebars Templating
 //! * [tera_templates](templates) - Tera Templating
 //! * [uuid](uuid) - UUID (de)serialization

--- a/contrib/lib/src/lib.rs
+++ b/contrib/lib/src/lib.rs
@@ -46,10 +46,11 @@
 #[cfg(feature="json")] #[macro_use] pub mod json;
 #[cfg(feature="serve")] pub mod serve;
 #[cfg(feature="msgpack")] pub mod msgpack;
+#[cfg(feature="xml")] pub mod xml;
 #[cfg(feature="templates")] pub mod templates;
 #[cfg(feature="uuid")] pub mod uuid;
 #[cfg(feature="databases")] pub mod databases;
-#[cfg(feature = "helmet")] pub mod helmet;
+#[cfg(feature="helmet")] pub mod helmet;
 // TODO.async: Migrate compression, reenable this, tests, and add to docs.
 //#[cfg(any(feature="brotli_compression", feature="gzip_compression"))] pub mod compression;
 

--- a/contrib/lib/src/xml.rs
+++ b/contrib/lib/src/xml.rs
@@ -26,7 +26,6 @@ use rocket::form::prelude as form;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 
-#[doc(hidden)]
 pub use quick_xml::DeError as Error;
 use quick_xml::Error as XmlError;
 

--- a/contrib/lib/src/xml.rs
+++ b/contrib/lib/src/xml.rs
@@ -1,0 +1,123 @@
+//! Automatic Xml (de)serialization support.
+//!
+//! See the [`Xml`](crate::xml::Xml) type for further details.
+//!
+//! # Enabling
+//!
+//! This module is only available when the `xml` feature is enabled. Enable it
+//! in `Cargo.toml` as follows:
+//!
+//! ```toml
+//! [dependencies.rocket_contrib]
+//! version = "0.5.0-dev"
+//! default-features = false
+//! features = ["xml"]
+//! ```
+
+use rocket::data::{ByteUnit, FromData, Outcome};
+use rocket::response::{self, Responder, content};
+use rocket::request::Request;
+use rocket::http::Status;
+use rocket::{Data, form};
+pub use quick_xml::DeError as Error;
+use quick_xml::Error as XmlError;
+use std::io;
+
+use serde::{Serialize, Serializer};
+use serde::de::{Deserialize, DeserializeOwned, Deserializer};
+use std::ops::{Deref, DerefMut};
+
+// TODO Struct docs
+#[derive(Debug)]
+pub struct Xml<T>(pub T);
+
+const DEFAULT_LIMIT: ByteUnit = ByteUnit::Mebibyte(1);
+
+impl<T> Xml<T> {
+    /// Consumes the XML wrapper and returns the wrapped item.
+    ///
+    /// # Example
+    /// ```rust
+    /// # use rocket_contrib::xml::Xml;
+    /// let string = "Hello".to_string();
+    /// let my_xml = Xml(string);
+    /// assert_eq!(my_xml.into_inner(), "Hello".to_string());
+    /// ```
+    #[inline(always)]
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+}
+
+impl<'r, T: DeserializeOwned> Xml<T> {
+    fn from_str(s: &'r str) -> Result<Self, Error> {
+        // TODO: Should the error handling here be improved? Different Error type?
+        quick_xml::de::from_str(s).map(Xml)
+    }
+
+    async fn from_req_data(req: &'r Request<'_>, data: Data) -> Result<Self, Error> {
+        let size_limit = req.limits().get("xml").unwrap_or(DEFAULT_LIMIT);
+        let string = match data.open(size_limit).into_string().await {
+            Ok(s) if s.is_complete() => s.into_inner(),
+            Ok(_) => {
+                let eof = io::ErrorKind::UnexpectedEof;
+                return Err(Error::Xml(XmlError::Io(io::Error::new(eof, "data limit exceeded"))));
+            },
+            Err(e) => return Err(Error::Xml(XmlError::Io(e))),
+        };
+
+        Self::from_str(local_cache!(req, string))
+    }
+}
+
+#[rocket::async_trait]
+impl<'r, T: DeserializeOwned> FromData<'r> for Xml<T> {
+    type Error = Error;
+
+    async fn from_data(req: &'r Request<'_>, data: Data) -> Outcome<Self, Self::Error> {
+        match Self::from_req_data(req, data).await {
+            Ok(value) => Outcome::Success(value),
+            Err(Error::Xml(XmlError::Io(e))) if e.kind() == io::ErrorKind::UnexpectedEof => {
+                Outcome::Failure((Status::PayloadTooLarge, Error::Xml(XmlError::Io(e))))
+            },
+            Err(e) => Outcome::Failure((Status::BadRequest, e)),
+        }
+    }
+}
+
+/// Serializes the wrapped value into XML. Returns a response with Content-Type
+/// XML and a fixed-size body with the serialized value. If serialization
+/// fails, an `Err` of `Status::InternalServerError` is returned.
+impl<'r, T: Serialize> Responder<'r, 'static> for Xml<T> {
+    fn respond_to(self, req: &'r Request<'_>) -> response::Result<'static> {
+        let string = quick_xml::se::to_string(&self.0)
+            .map_err(|e| {
+                error_!("XML failed to serialize: {:?}", e);
+                Status::InternalServerError
+            })?;
+
+        content::Xml(string).respond_to(req)
+    }
+}
+
+impl<T> From<T> for Xml<T> {
+    fn from(value: T) -> Self {
+        Xml(value)
+    }
+}
+
+impl<T> Deref for Xml<T> {
+    type Target = T;
+
+    #[inline(always)]
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}
+
+impl<T> DerefMut for Xml<T> {
+    #[inline(always)]
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.0
+    }
+}


### PR DESCRIPTION
This PR should add XML support to `contrib` along the lines of the already existing `contrib::json` and `contrib::msgpack` modules, using [quick-xml](https://crates.io/crates/quick-xml).

One thing to consider is that `quick-xml` only implements `DeserializeOwned` and not `Deserialize<'de>`. [xml-rs](https://crates.io/crates/xml-rs) does, but is much less performant than `quick-xml`.

Note that, of course, this adds a new dependency to the project.

(This is my first PR, if it is not of sufficient quality, feel free to reject it, I implemented this quickly because I'm communicating with an XML client in a recent project.)