### PR TITLE
Implement Template::render_without_context for a simple interface, 

### DIFF
--- a/contrib/lib/src/templates/mod.rs
+++ b/contrib/lib/src/templates/mod.rs
@@ -355,7 +355,7 @@ impl Template {
         S: Into<Cow<'static, str>>,
     {
         let context: HashMap<&str, &str> = HashMap::new();
-        render("index", &context)
+        Template::render(name, &context)
     }
 
     /// Render the template named `name` with the context `context` into a

--- a/contrib/lib/src/templates/mod.rs
+++ b/contrib/lib/src/templates/mod.rs
@@ -134,6 +134,7 @@ use serde::Serialize;
 use serde_json::{Value, to_value};
 
 use std::borrow::Cow;
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::error::Error;
 
@@ -335,6 +336,26 @@ impl Template {
         where S: Into<Cow<'static, str>>, C: Serialize
     {
         Template { name: name.into(), value: to_value(context).ok() }
+    }
+
+    /// Render the template named `name` without any context.
+    ///
+    /// # Example
+    ///
+    ///
+    /// ```rust
+    /// use rocket_contrib::templates::Template;
+    ///
+    /// # #[allow(unused_variables)]
+    /// let template = Template::render_without_context("index");
+    /// ```
+    #[inline]
+    pub fn render_without_context<S>(name: S) -> Template
+    where
+        S: Into<Cow<'static, str>>,
+    {
+        let context: HashMap<&str, &str> = HashMap::new();
+        render("index", &context)
     }
 
     /// Render the template named `name` with the context `context` into a


### PR DESCRIPTION
If we don't have a `context` and want to use `Template` for `rendering` , 
we need to write the following described in #169, #1225

```rust
use std::collections::HashMap;
...
fn index() -> Template {
    let context: HashMap<&str, &str> = HashMap::new();
    Template::render("home", &context)
}
```

This one seems to be a little bit redundant, so I implemented `redner_without_context`.
Using this, we can write as follows, which I think that it will be quite simple.

```rust
fn index() -> Template {
    Template::render_without_context("home")
}
```


