### PR TITLE
Derive Clone for Template

### DIFF
--- a/contrib/lib/src/templates/mod.rs
+++ b/contrib/lib/src/templates/mod.rs
@@ -197,7 +197,7 @@ const DEFAULT_TEMPLATE_DIR: &str = "templates";
 /// You may use the [`Template::custom()`] method to construct a fairing with
 /// customized templating engines. Among other things, this method allows you to
 /// register template helpers and register templates from strings.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Template {
     name: Cow<'static, str>,
     value: Option<Value>


### PR DESCRIPTION
I was trying to set up an in-memory cache for rendered `Template`s, but found that this is made much more difficult by `Template` not implementing `Clone`. So I made it do dat.