### PR TITLE
Initialize synchronous database pools inside of `spawn_blocking`.

### DIFF
--- a/contrib/lib/Cargo.toml
+++ b/contrib/lib/Cargo.toml
@@ -42,7 +42,7 @@ diesel_mysql_pool = ["databases", "diesel/mysql", "diesel/r2d2"]
 
 [dependencies]
 # Global dependencies.
-tokio = { version = "1.0", optional = true }
+tokio = { version = "1.4", optional = true }
 rocket_contrib_codegen = { version = "0.5.0-dev", path = "../codegen", optional = true }
 rocket = { version = "0.5.0-dev", path = "../../core/lib/", default-features = false }
 log = "0.4"


### PR DESCRIPTION
One situation where this is noticeable is when initialization failure
leads to `Drop`; unlike in a successful initialization, `postgres`
detects and panics when `Drop` is called from within asynchronous code.
Several other database pools do not panic in this same situation, but
would still block the current thread.

Also sets the minimum version of `tokio` to 1.4 in `rocket_contrib`,
which is the version where `Handle::block_on` (used in `Drop` impls) was
introduced.

Fixes #1610.

---

This should be reviewed closely, since there have been several bugs and regressions in this area. The goal is thus:

Synchronous database pool and connection usage, *including* creation, usage, and `Drop`, should always be done inside some kind of "blocking-safe" environment. Since #1375 databases use `spawn_blocking`; alternatives include `block_in_place` (risky) or a dedicated thread with message passing to communicate between the async and sync code (safer, but probably not better than the status quo in terms of complexity to implement maintain or troubleshoot and likely still pretty bad ergonomically).

This problem is now addressed by starting the database pool inside a `spawn_blocking` closure. Usage of the database pool (i.e. acquiring connections) was already wrapped, along with usage of the connections themselves. This leaves `Drop`, which was also already wrapped properly -- aside from a race condition between server shutdown and handlers that were still running, which was recently fixed in e1307dd.