### PR TITLE
Change From<> to a normal method

### DIFF
--- a/core/codegen/src/attribute/route/mod.rs
+++ b/core/codegen/src/attribute/route/mod.rs
@@ -336,7 +336,7 @@ fn codegen_route(route: Route) -> Result<TokenStream> {
         #vis struct #handler_fn_name {  }
 
         /// Rocket code generated proxy static conversion implementation.
-        impl #handler_fn_name { 
+        impl #handler_fn_name {
             #[allow(non_snake_case, unreachable_patterns, unreachable_code)]
             fn into_info(self) -> #_route::StaticInfo {
                 fn monomorphized_function<'_b>(

--- a/core/codegen/src/attribute/route/mod.rs
+++ b/core/codegen/src/attribute/route/mod.rs
@@ -336,9 +336,9 @@ fn codegen_route(route: Route) -> Result<TokenStream> {
         #vis struct #handler_fn_name {  }
 
         /// Rocket code generated proxy static conversion implementation.
-        impl From<#handler_fn_name> for #_route::StaticInfo {
+        impl #handler_fn_name { 
             #[allow(non_snake_case, unreachable_patterns, unreachable_code)]
-            fn from(_: #handler_fn_name) -> #_route::StaticInfo {
+            fn into_info(self) -> #_route::StaticInfo {
                 fn monomorphized_function<'_b>(
                     #__req: &'_b #Request<'_>,
                     #__data: #Data
@@ -363,13 +363,8 @@ fn codegen_route(route: Route) -> Result<TokenStream> {
                     sentinels: #sentinels,
                 }
             }
-        }
-
-        /// Rocket code generated proxy conversion implementation.
-        impl From<#handler_fn_name> for #Route {
-            #[inline]
-            fn from(_: #handler_fn_name) -> #Route {
-                #_route::StaticInfo::from(#handler_fn_name {}).into()
+            pub fn into(self) -> #Route {
+                self.into_info().into()
             }
         }
 


### PR DESCRIPTION
Changes the codegen for routes to use a method on the proxy object,
rather than implementing a trait on the proxy object. This helps rustc
identify unused routes, although it may break compatibility for some
specific use cases.

See https://github.com/SergioBenitez/Rocket/issues/1598 for more info.