### PR TITLE
Add HTTP upgrade support to Rocket

### DIFF
--- a/core/http/src/hyper.rs
+++ b/core/http/src/hyper.rs
@@ -9,6 +9,7 @@
 #[doc(hidden)] pub use hyper::rt::Executor;
 #[doc(hidden)] pub use hyper::server::Server;
 #[doc(hidden)] pub use hyper::service::{make_service_fn, service_fn, Service};
+#[doc(hidden)] pub use hyper::upgrade;
 
 #[doc(hidden)] pub use http::header::HeaderMap;
 #[doc(hidden)] pub use http::header::HeaderName as HeaderName;

--- a/core/lib/src/response/mod.rs
+++ b/core/lib/src/response/mod.rs
@@ -35,6 +35,7 @@ pub(crate) mod flash;
 pub mod content;
 pub mod status;
 pub mod stream;
+pub mod upgrade;
 
 #[doc(hidden)]
 pub use rocket_codegen::Responder;

--- a/core/lib/src/response/response.rs
+++ b/core/lib/src/response/response.rs
@@ -282,7 +282,7 @@ impl<'r> Builder<'r> {
         self.response.set_max_chunk_size(size);
         self
     }
-    
+
     /// Adds an upgrade response to this response. It overwrites any existing upgrade responses,
     /// and is mutually exclusive with a response body.
     ///

--- a/core/lib/src/response/upgrade.rs
+++ b/core/lib/src/response/upgrade.rs
@@ -32,12 +32,10 @@ pub(crate) fn upgrade_pending(upgradable: Option<Box<dyn UpgradeResponder>>)
                 match on_upgrade.await {
                     Ok(upgraded) => {
                         if let Err(e) = upgradable.on_upgrade(upgraded).await {
-                            eprintln!("server foobar io error: {}", e)
-                        }else {
-                            println!("Socket handler finished");
-                        };
+                            error_!("Error in upgraded connection: {}", e)
+                        }
                     }
-                    Err(e) => eprintln!("upgrade error: {:?}", e),
+                    Err(e) => error_!("Failed to upgrade connection: {:?}", e),
                 }
             }
         });

--- a/core/lib/src/response/upgrade.rs
+++ b/core/lib/src/response/upgrade.rs
@@ -1,0 +1,49 @@
+//! HTTP upgrade traits and objects.
+//!
+//! Executing an HTTP upgrade requires creating a response with the upgrade agent.
+
+use async_trait::async_trait;
+use rocket_http::hyper::upgrade::OnUpgrade;
+use tokio::sync::oneshot;
+
+/// Upgraded connection, implements AsyncRead + AsyncWrite for reading and writing
+pub use rocket_http::hyper::upgrade::Upgraded;
+
+/// Respresents an object that handles a connection after an HTTP upgrade has taken place.
+///
+/// TODO: add example
+#[async_trait]
+pub trait UpgradeResponder: Send + Unpin {
+    async fn on_upgrade(self: Box<Self>, upgrade_obj: Upgraded) -> std::io::Result<()>;
+}
+
+/// Creates a pending upgrade task, if upgradable is Some.
+///
+/// If the return value is Some(tx), this function will wait for the `OnUpgrade` object, so sending
+/// should never fail.
+///
+/// When upgradable is None, this does nothing.
+pub(crate) fn upgrade_pending(upgradable: Option<Box<dyn UpgradeResponder>>) -> Option<oneshot::Sender<OnUpgrade>> {
+    if let Some(upgradable) = upgradable {
+        let (tx, rx) = oneshot::channel();
+        tokio::spawn(async move {
+            if let Ok(on_upgrade) = rx.await {
+                match on_upgrade.await {
+                    Ok(upgraded) => {
+                        if let Err(e) = upgradable.on_upgrade(upgraded).await {
+                            eprintln!("server foobar io error: {}", e)
+                        }else {
+                            println!("Socket handler finished");
+                        };
+                    }
+                    Err(e) => eprintln!("upgrade error: {:?}", e),
+                }
+            }
+        });
+        Some(tx)
+    }else {
+        None
+    }
+}
+
+

--- a/core/lib/src/response/upgrade.rs
+++ b/core/lib/src/response/upgrade.rs
@@ -23,7 +23,8 @@ pub trait UpgradeResponder: Send + Unpin {
 /// should never fail.
 ///
 /// When upgradable is None, this does nothing.
-pub(crate) fn upgrade_pending(upgradable: Option<Box<dyn UpgradeResponder>>) -> Option<oneshot::Sender<OnUpgrade>> {
+pub(crate) fn upgrade_pending(upgradable: Option<Box<dyn UpgradeResponder>>)
+        -> Option<oneshot::Sender<OnUpgrade>> {
     if let Some(upgradable) = upgradable {
         let (tx, rx) = oneshot::channel();
         tokio::spawn(async move {

--- a/core/lib/src/server.rs
+++ b/core/lib/src/server.rs
@@ -132,7 +132,8 @@ impl Rocket<Orbit> {
     ) -> io::Result<()> {
         let upgrade_pending = upgrade_pending(response.take_upgradable());
         if let Some(upgrade_pending) = upgrade_pending {
-            upgrade_pending.send(on_upgrade).expect("`upgrade_pending()` should always wait for an `OnUpgrade`");
+            upgrade_pending.send(on_upgrade)
+                .expect("`upgrade_pending()` should always wait for an `OnUpgrade`");
         }
 
         let mut hyp_res = hyper::Response::builder()


### PR DESCRIPTION
Adds HTTP upgrade support to Rocket, by exposing the underlying hyper object. For an example of how this might be adapted to the Websocket protocol, see [the10thwiz/rocket-tungstenite](https://github.com/the10thWiz/rocket-tungstenite).

I don't think Websocket support should be part of the base Rocket crate, but either a seperate crate that implements `Responder` and `UpgradeResponder`, such as the one linked above, or part of rocket-contrib, in the same role.

I tried my best to implement this in a powerful way, yet relatively simple way. I'm not sure how much I succeeded, since the external API for handling the Upgrade process is somewhat tricky and laborious, but I don't think there is a better way to implement it. I also don't expect most users to need to implement it themselves, since most, if not all, users will be able to use crate like rocket-tungstenite.