### PR TITLE
`context` macro for creating rendering contexts

### DIFF
--- a/contrib/dyn_templates/src/lib.rs
+++ b/contrib/dyn_templates/src/lib.rs
@@ -26,7 +26,7 @@
 //!
 //!      ```rust
 //!      # #[macro_use] extern crate rocket;
-//!      use rocket_dyn_templates::Template;
+//!      use rocket_dyn_templates::{Template, context};
 //!
 //!      #[launch]
 //!      fn rocket() -> _ {
@@ -35,8 +35,7 @@
 //!
 //!      #[get("/")]
 //!      fn index() -> Template {
-//!          # let context = ();
-//!          Template::render("template-name", &context)
+//!          Template::render("template-name", context! { })
 //!      }
 //!      ```
 //!
@@ -119,7 +118,8 @@
 //! Templates are rendered with the `render` method. The method takes in the
 //! name of a template and a context to render the template with. The context
 //! can be any type that implements [`Serialize`] and would serialize to an
-//! `Object` value.
+//! `Object` value. The [`context!`] macro can also be used to create inline
+//! `Serialize`-able context objects.
 //!
 //! ## Automatic Reloading
 //!
@@ -166,6 +166,9 @@ use self::context::{Context, ContextManager};
 
 use std::borrow::Cow;
 use std::path::PathBuf;
+
+#[doc(hidden)]
+pub use rocket::serde;
 
 use rocket::{Rocket, Orbit, Ignite, Sentinel};
 use rocket::request::Request;
@@ -301,10 +304,24 @@ impl Template {
     }
 
     /// Render the template named `name` with the context `context`. The
-    /// `context` can be of any type that implements `Serialize`. This is
-    /// typically a `HashMap` or a custom `struct`.
+    /// `context` is typically created using the [`context!`] macro, but it can
+    /// be of any type that implements `Serialize`, such as `HashMap` or a
+    /// custom `struct`.
     ///
-    /// # Example
+    /// # Examples
+    ///
+    /// Using the `context` macro:
+    ///
+    /// ```rust
+    /// use rocket_dyn_templates::{Template, context};
+    ///
+    /// # #[allow(unused_variables)]
+    /// let template = Template::render("index", context! {
+    ///     foo: "Hello world",
+    /// });
+    /// ```
+    ///
+    /// Using a `HashMap` as the context:
     ///
     /// ```rust
     /// use std::collections::HashMap;
@@ -434,4 +451,106 @@ impl Sentinel for Template {
 
         false
     }
+}
+
+/// A macro to easily create a template rendering context.
+///
+/// Invocations of this macro expand to a value of an anonymous type which
+/// implements [`serde::Serialize`]. Fields can be literal expressions or
+/// variables captured from a surrounding scope, as long as all fields implement
+/// `Serialize`.
+///
+/// # Examples
+///
+/// The following code:
+///
+/// ```rust
+/// # #[macro_use] extern crate rocket;
+/// # use rocket_dyn_templates::{Template, context};
+/// #[get("/<foo>")]
+/// fn render_index(foo: u64) -> Template {
+///     Template::render("index", context! {
+///         // Note that shorthand field syntax is allowed.
+///         // This is the same as `foo: foo,`
+///         foo,
+///         bar: "Hello world",
+///     })
+/// }
+/// ```
+///
+/// is equivalent to the following, but without the need to manually define an
+/// `IndexContext` struct:
+///
+/// ```rust
+/// # use rocket_dyn_templates::Template;
+/// # use rocket::serde::Serialize;
+/// # use rocket::get;
+/// #[derive(Serialize)]
+/// # #[serde(crate = "rocket::serde")]
+/// struct IndexContext<'a> {
+///     foo: u64,
+///     bar: &'a str,
+/// }
+///
+/// #[get("/<foo>")]
+/// fn render_index(foo: u64) -> Template {
+///     Template::render("index", IndexContext {
+///         foo,
+///         bar: "Hello world",
+///     })
+/// }
+/// ```
+///
+/// ## Nesting
+///
+/// Nested objects can be created by nesting calls to `context!`:
+///
+/// ```rust
+/// # use rocket_dyn_templates::context;
+/// # fn main() {
+/// let ctx = context! {
+///     planet: "Earth",
+///     info: context! {
+///         mass: 5.97e24,
+///         radius: "6371 km",
+///         moons: 1,
+///     },
+/// };
+/// # }
+/// ```
+#[macro_export]
+macro_rules! context {
+    ($($key:ident $(: $value:expr)?),*$(,)?) => {{
+        use $crate::serde::ser::{Serialize, Serializer, SerializeMap};
+        use ::std::fmt::{Debug, Formatter};
+
+        #[allow(non_camel_case_types)]
+        struct ContextMacroCtxObject<$($key: Serialize),*> {
+            $($key: $key),*
+        }
+
+        #[allow(non_camel_case_types)]
+        impl<$($key: Serialize),*> Serialize for ContextMacroCtxObject<$($key),*> {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+                where S: Serializer,
+            {
+                let mut map = serializer.serialize_map(None)?;
+                $(map.serialize_entry(stringify!($key), &self.$key)?;)*
+                map.end()
+            }
+        }
+
+        #[allow(non_camel_case_types)]
+        impl<$($key: Debug + Serialize),*> Debug for ContextMacroCtxObject<$($key),*> {
+            fn fmt(&self, f: &mut Formatter<'_>) -> ::std::fmt::Result {
+                f.debug_struct("context!")
+                    $(.field(stringify!($key), &self.$key))*
+                    .finish()
+            }
+        }
+
+        ContextMacroCtxObject {
+            $($key $(: $value)?),*
+        }
+    }};
 }

--- a/contrib/dyn_templates/src/metadata.rs
+++ b/contrib/dyn_templates/src/metadata.rs
@@ -14,17 +14,15 @@ use crate::context::ContextManager;
 /// ```rust
 /// # #[macro_use] extern crate rocket;
 /// # #[macro_use] extern crate rocket_dyn_templates;
-/// use rocket_dyn_templates::{Template, Metadata};
+/// use rocket_dyn_templates::{Template, Metadata, context};
 ///
 /// #[get("/")]
 /// fn homepage(metadata: Metadata) -> Template {
-///     # use std::collections::HashMap;
-///     # let context: HashMap<String, String> = HashMap::new();
 ///     // Conditionally render a template if it's available.
 ///     if metadata.contains_template("some-template") {
-///         Template::render("some-template", &context)
+///         Template::render("some-template", context! { })
 ///     } else {
-///         Template::render("fallback", &context)
+///         Template::render("fallback", context! { })
 ///     }
 /// }
 ///

--- a/examples/cookies/src/message.rs
+++ b/examples/cookies/src/message.rs
@@ -1,9 +1,7 @@
-use std::collections::HashMap;
-
 use rocket::form::Form;
 use rocket::response::Redirect;
 use rocket::http::{Cookie, CookieJar};
-use rocket_dyn_templates::Template;
+use rocket_dyn_templates::{Template, context};
 
 #[macro_export]
 macro_rules! message_uri {
@@ -21,12 +19,10 @@ fn submit(cookies: &CookieJar<'_>, message: Form<&str>) -> Redirect {
 #[get("/")]
 fn index(cookies: &CookieJar<'_>) -> Template {
     let cookie = cookies.get("message");
-    let mut context = HashMap::new();
-    if let Some(ref cookie) = cookie {
-        context.insert("message", cookie.value());
-    }
 
-    Template::render("message", &context)
+    Template::render("message", context! {
+        message: cookie.map(|c| c.value()),
+    })
 }
 
 pub fn routes() -> Vec<rocket::Route> {

--- a/examples/cookies/src/session.rs
+++ b/examples/cookies/src/session.rs
@@ -1,12 +1,10 @@
-use std::collections::HashMap;
-
 use rocket::outcome::IntoOutcome;
 use rocket::request::{self, FlashMessage, FromRequest, Request};
 use rocket::response::{Redirect, Flash};
 use rocket::http::{Cookie, CookieJar};
 use rocket::form::Form;
 
-use rocket_dyn_templates::Template;
+use rocket_dyn_templates::{Template, context};
 
 #[derive(FromForm)]
 struct Login<'r> {
@@ -39,9 +37,9 @@ pub use session_uri as uri;
 
 #[get("/")]
 fn index(user: User) -> Template {
-    let mut context = HashMap::new();
-    context.insert("user_id", user.0);
-    Template::render("session", &context)
+    Template::render("session", context! {
+        user_id: user.0,
+    })
 }
 
 #[get("/", rank = 2)]

--- a/examples/templating/src/hbs.rs
+++ b/examples/templating/src/hbs.rs
@@ -1,20 +1,9 @@
 use rocket::Request;
 use rocket::response::Redirect;
-use rocket::serde::Serialize;
 
-use rocket_dyn_templates::{Template, handlebars};
+use rocket_dyn_templates::{Template, handlebars, context};
 
 use self::handlebars::{Handlebars, JsonRender};
-
-#[derive(Serialize)]
-#[serde(crate = "rocket::serde")]
-struct TemplateContext<'r> {
-    title: &'r str,
-    name: Option<&'r str>,
-    items: Vec<&'r str>,
-    // This special key tells handlebars which template is the parent.
-    parent: &'static str,
-}
 
 #[get("/")]
 pub fn index() -> Redirect {
@@ -23,27 +12,28 @@ pub fn index() -> Redirect {
 
 #[get("/hello/<name>")]
 pub fn hello(name: &str) -> Template {
-    Template::render("hbs/index", &TemplateContext {
+    Template::render("hbs/index", context! {
         title: "Hello",
         name: Some(name),
         items: vec!["One", "Two", "Three"],
+        // This special key tells handlebars which template is the parent.
         parent: "hbs/layout",
     })
 }
 
 #[get("/about")]
 pub fn about() -> Template {
-    let mut map = std::collections::HashMap::new();
-    map.insert("title", "About");
-    map.insert("parent", "hbs/layout");
-    Template::render("hbs/about.html", &map)
+    Template::render("hbs/about.html", context! {
+        title: "About",
+        parent: "hbs/layout",
+    })
 }
 
 #[catch(404)]
 pub fn not_found(req: &Request<'_>) -> Template {
-    let mut map = std::collections::HashMap::new();
-    map.insert("path", req.uri().path().raw());
-    Template::render("hbs/error/404", &map)
+    Template::render("hbs/error/404", context! {
+        path: req.uri().path().raw(),
+    })
 }
 
 fn wow_helper(

--- a/examples/templating/src/tera.rs
+++ b/examples/templating/src/tera.rs
@@ -1,18 +1,7 @@
-use std::collections::HashMap;
-
 use rocket::Request;
 use rocket::response::Redirect;
-use rocket::serde::Serialize;
 
-use rocket_dyn_templates::{Template, tera::Tera};
-
-#[derive(Serialize)]
-#[serde(crate = "rocket::serde")]
-struct TemplateContext<'r> {
-    title: &'r str,
-    name: Option<&'r str>,
-    items: Vec<&'r str>
-}
+use rocket_dyn_templates::{Template, tera::Tera, context};
 
 #[get("/")]
 pub fn index() -> Redirect {
@@ -21,7 +10,7 @@ pub fn index() -> Redirect {
 
 #[get("/hello/<name>")]
 pub fn hello(name: &str) -> Template {
-    Template::render("tera/index", &TemplateContext {
+    Template::render("tera/index", context! {
         title: "Hello",
         name: Some(name),
         items: vec!["One", "Two", "Three"],
@@ -30,16 +19,16 @@ pub fn hello(name: &str) -> Template {
 
 #[get("/about")]
 pub fn about() -> Template {
-    let mut map = HashMap::new();
-    map.insert("title", "About");
-    Template::render("tera/about.html", &map)
+    Template::render("tera/about.html", context! {
+        title: "About",
+    })
 }
 
 #[catch(404)]
 pub fn not_found(req: &Request<'_>) -> Template {
-    let mut map = HashMap::new();
-    map.insert("path", req.uri().path().raw());
-    Template::render("tera/error/404", &map)
+    Template::render("tera/error/404", context! {
+        path: req.uri().path().raw(),
+    })
 }
 
 pub fn customize(tera: &mut Tera) {

--- a/site/guide/5-responses.md
+++ b/site/guide/5-responses.md
@@ -441,6 +441,23 @@ a template and a context to render the template with. The context can be any
 type that implements `Serialize` and serializes into an `Object` value, such as
 structs, `HashMaps`, and others.
 
+You can also use [`context!`] to create ad-hoc context objects without defining a new type:
+
+```rust
+# #[macro_use] extern crate rocket;
+# #[macro_use] extern crate rocket_dyn_templates;
+# fn main() {}
+
+use rocket_dyn_templates::Template;
+
+#[get("/")]
+fn index() -> Template {
+    Template::render("index", context! {
+        foo: 123,
+    })
+}
+```
+
 For a template to be renderable, it must first be registered. The `Template`
 fairing automatically registers all discoverable templates when attached. The
 [Fairings](../fairings) sections of the guide provides more information on
@@ -471,6 +488,8 @@ used.
   For a template file named `index.html.tera`, call `render("index")` and use
   the name `"index"` in templates, i.e, `{% extends "index" %}` or `{% extends
   "base" %}` for `base.html.tera`.
+
+[`context`]: @api/rocket_dyn_templates/macro.context.html
 
 ### Live Reloading
 


### PR DESCRIPTION
Adds a macro that can be used when rendering templates, like so:
```rust
#[get("/")]
fn index() -> Template {
    Template::render("index", context!{
        foo: "Hello world",
        bar: 83,
    })
}
```

Which is equivalent to:
```rust
#[derive(Serialize)]
struct IndexContext<'a> {
    foo: &'a str,
    bar: u64,
}

#[get("/")]
fn index() -> Template {
    Template::render("index", IndexContext {
        foo: "Hello world",
        bar: 83,
    })
}
```