### PR TITLE
Allow reading a TempFile without persisting it

### DIFF
--- a/core/lib/src/data/mod.rs
+++ b/core/lib/src/data/mod.rs
@@ -14,6 +14,6 @@ pub use self::from_data::{FromData, Outcome};
 pub use self::limits::Limits;
 pub use self::capped::{N, Capped};
 pub use ubyte::{ByteUnit, ToByteUnit};
-pub use temp_file::TempFile;
+pub use temp_file::{TempFile, TempFileRead};
 
 pub(crate) use self::data_stream::StreamReader;

--- a/core/lib/tests/temp_file_read.rs
+++ b/core/lib/tests/temp_file_read.rs
@@ -1,0 +1,40 @@
+use rocket::data::TempFileRead;
+use std::io::Cursor;
+use tokio::{fs::File, io::AsyncReadExt};
+
+#[tokio::test]
+async fn read_temp_file() {
+    let mut tfr = TempFileRead::File(File::open("Cargo.toml").await.unwrap());
+    let mut content = Vec::new();
+    tfr.read_to_end(&mut content).await.unwrap();
+    assert!(content.starts_with("[package]".as_bytes()));
+}
+
+#[tokio::test]
+async fn read_temp_buffer() {
+    let mut tfr = TempFileRead::Buffered(Cursor::new("Hello!World!".as_bytes()));
+    let mut content = Vec::new();
+    tfr.read_to_end(&mut content).await.unwrap();
+    assert_eq!(&content, "Hello!World!".as_bytes());
+}
+
+#[tokio::test]
+async fn read_temp_buffer_owned() {
+    let mut tfr = TempFileRead::BufferedOwned(Cursor::new("Hello!World!".as_bytes().to_vec()));
+    let mut content = Vec::new();
+    tfr.read_to_end(&mut content).await.unwrap();
+    assert_eq!(&content, "Hello!World!".as_bytes());
+}
+
+#[tokio::test]
+async fn read_temp_buffer_owned_position() {
+    let mut tfr = TempFileRead::Buffered(Cursor::new("Hello!World!".as_bytes()));
+    let mut start = [0; 6];
+    tfr.read_exact(&mut start).await.unwrap();
+    assert_eq!(&start, "Hello!".as_bytes());
+
+    let mut tfr = tfr.into_owned();
+    let mut end = Vec::new();
+    tfr.read_to_end(&mut end).await.unwrap();
+    assert_eq!(&end, "World!".as_bytes());
+}


### PR DESCRIPTION
This PR implements an old suggestion to make `TempFile` implement `AsyncRead`.

Technically it is an indirect implementation of `AyncRead`, and it allows conversion to `'static` lifetimes via `into_owned`.

If eventually one calls `into_owned` in the middle of reading operations (which is strongly discouraged though), then the reading continues where it was left, not at the beginning of the file.