### PR TITLE
Uri serde Implementation

### DIFF
--- a/core/http/src/uri/absolute.rs
+++ b/core/http/src/uri/absolute.rs
@@ -64,6 +64,20 @@ use crate::uri::{Authority, Path, Query, Data, Error, as_utf8_unchecked, fmt};
 /// #   assert!(!Absolute::parse(uri).unwrap().is_normalized());
 /// # }
 /// ```
+///
+/// ## Serde
+///
+/// For convience, `Absolute` implements `Serialize` and `Deserialize`.
+/// Because `Absolute` has a lifetime parameter, serde requires a borrow
+/// attribute for the derive macro to work.
+///
+/// ```ignore
+/// #[derive(Deserialize)]
+/// struct Uris<'a> {
+///     #[serde(borrow)]
+///     absolute: Absolute<'a>,
+/// }
+/// ```
 #[derive(Debug, Clone)]
 pub struct Absolute<'a> {
     pub(crate) source: Option<Cow<'a, str>>,

--- a/core/http/src/uri/absolute.rs
+++ b/core/http/src/uri/absolute.rs
@@ -403,6 +403,7 @@ impl<'a> Absolute<'a> {
     }
 
     /// PRIVATE. Used by codegen.
+    #[doc(hidden)]
     pub const fn const_new(
         scheme: &'a str,
         authority: Option<Authority<'a>>,
@@ -515,8 +516,8 @@ mod serde {
         }
     }
 
-    impl<'a> Deserialize<'a> for Absolute<'a> {
-        fn deserialize<D: Deserializer<'a>>(deserializer: D) -> Result<Self, D::Error> {
+    impl<'a, 'de: 'a> Deserialize<'de> for Absolute<'a> {
+        fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
             deserializer.deserialize_str(AbsoluteVistor)
         }
     }

--- a/core/http/src/uri/absolute.rs
+++ b/core/http/src/uri/absolute.rs
@@ -146,8 +146,7 @@ impl<'a> Absolute<'a> {
     ///
     /// let source = format!("https://rocket.rs/foo/{}/three", 2);
     /// let uri = Absolute::parse_owned(source).expect("valid URI");
-    /// assert_eq!(uri.scheme(), "https");
-    /// assert_eq!(uri.host(), "rocket.rs");
+    /// assert_eq!(uri.authority().unwrap().host(), "rocket.rs");
     /// assert_eq!(uri.path(), "/foo/2/three");
     /// assert!(uri.query().is_none());
     /// ```

--- a/core/http/src/uri/absolute.rs
+++ b/core/http/src/uri/absolute.rs
@@ -132,6 +132,8 @@ impl<'a> Absolute<'a> {
     /// Parses the string `string` into an `Absolute`. Parsing will never
     /// May allocate on error.
     ///
+    /// TODO: avoid allocation
+    ///
     /// This method should be used instead of [`Absolute::parse()`] when
     /// the source URI is already a `String`. Returns an `Error` if `string` is
     /// not a valid absolute URI.

--- a/core/http/src/uri/absolute.rs
+++ b/core/http/src/uri/absolute.rs
@@ -130,10 +130,25 @@ impl<'a> Absolute<'a> {
     }
 
     /// Parses the string `string` into an `Absolute`. Parsing will never
-    /// allocate. This method should be used instead of
-    /// [`Absolute::parse()`](crate::uri::Absolute::parse()) when the source URI is
-    /// already a `String`. Returns an `Error` if `string` is not a valid absolute
-    /// URI.
+    /// May allocate on error.
+    ///
+    /// This method should be used instead of [`Absolute::parse()`] when
+    /// the source URI is already a `String`. Returns an `Error` if `string` is
+    /// not a valid absolute URI.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # extern crate rocket;
+    /// use rocket::http::uri::Absolute;
+    ///
+    /// let source = format!("https://rocket.rs/foo/{}/three", 2);
+    /// let uri = Absolute::parse_owned(source).expect("valid URI");
+    /// assert_eq!(uri.scheme(), "https");
+    /// assert_eq!(uri.host(), "rocket.rs");
+    /// assert_eq!(uri.path(), "/foo/2/three");
+    /// assert!(uri.query().is_none());
+    /// ```
     pub fn parse_owned(string: String) -> Result<Absolute<'static>, Error<'static>> {
         let absolute = Absolute::parse(&string).map_err(|e| e.into_owned())?;
         debug_assert!(absolute.source.is_some(), "Origin source parsed w/o source");
@@ -514,7 +529,7 @@ mod serde {
     impl<'a> Visitor<'a> for AbsoluteVistor {
         type Value = Absolute<'a>;
         fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-            write!(formatter, "Expecting a valid URI string")
+            write!(formatter, "absolute Uri")
         }
 
         fn visit_str<E: Error>(self, v: &str) -> Result<Self::Value, E> {

--- a/core/http/src/uri/absolute.rs
+++ b/core/http/src/uri/absolute.rs
@@ -69,7 +69,8 @@ use crate::uri::{Authority, Path, Query, Data, Error, as_utf8_unchecked, fmt};
 ///
 /// For convience, `Absolute` implements `Serialize` and `Deserialize`.
 /// Because `Absolute` has a lifetime parameter, serde requires a borrow
-/// attribute for the derive macro to work.
+/// attribute for the derive macro to work. If you want to own the Uri,
+/// rather than borrow from the deserializer, use `'static`.
 ///
 /// ```ignore
 /// #[derive(Deserialize)]

--- a/core/http/src/uri/asterisk.rs
+++ b/core/http/src/uri/asterisk.rs
@@ -42,8 +42,8 @@ mod serde {
         }
     }
 
-    impl<'a> Deserialize<'a> for Asterisk {
-        fn deserialize<D: Deserializer<'a>>(deserializer: D) -> Result<Self, D::Error> {
+    impl<'de> Deserialize<'de> for Asterisk {
+        fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
             deserializer.deserialize_str(AsteriskVistor)
         }
     }

--- a/core/http/src/uri/asterisk.rs
+++ b/core/http/src/uri/asterisk.rs
@@ -30,7 +30,7 @@ mod serde {
     impl<'a> Visitor<'a> for AsteriskVistor {
         type Value = Asterisk;
         fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-            write!(formatter, "Expecting a valid Asterisk URI")
+            write!(formatter, "asterisk Uri")
         }
 
         // This method should be the only one that needs to be implemented, since the

--- a/core/http/src/uri/asterisk.rs
+++ b/core/http/src/uri/asterisk.rs
@@ -1,4 +1,8 @@
 /// The literal `*` URI.
+///
+/// ## Serde
+///
+/// For convience, `Asterisk` implements `Serialize` and `Deserialize`.
 #[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
 pub struct Asterisk;
 

--- a/core/http/src/uri/authority.rs
+++ b/core/http/src/uri/authority.rs
@@ -25,7 +25,8 @@ use crate::uri::{as_utf8_unchecked, error::Error};
 ///
 /// For convience, `Authority` implements `Serialize` and `Deserialize`.
 /// Because `Authority` has a lifetime parameter, serde requires a borrow
-/// attribute for the derive macro to work.
+/// attribute for the derive macro to work. If you want to own the Uri,
+/// rather than borrow from the deserializer, use `'static`.
 ///
 /// ```ignore
 /// #[derive(Deserialize)]

--- a/core/http/src/uri/authority.rs
+++ b/core/http/src/uri/authority.rs
@@ -20,6 +20,20 @@ use crate::uri::{as_utf8_unchecked, error::Error};
 /// ```
 ///
 /// Only the host part of the URI is required.
+///
+/// ## Serde
+///
+/// For convience, `Authority` implements `Serialize` and `Deserialize`.
+/// Because `Authority` has a lifetime parameter, serde requires a borrow
+/// attribute for the derive macro to work.
+///
+/// ```ignore
+/// #[derive(Deserialize)]
+/// struct Uris<'a> {
+///     #[serde(borrow)]
+///     authority: Authority<'a>,
+/// }
+/// ```
 #[derive(Debug, Clone)]
 pub struct Authority<'a> {
     pub(crate) source: Option<Cow<'a, str>>,

--- a/core/http/src/uri/authority.rs
+++ b/core/http/src/uri/authority.rs
@@ -261,8 +261,8 @@ mod serde {
         }
     }
 
-    impl<'a> Deserialize<'a> for Authority<'a> {
-        fn deserialize<D: Deserializer<'a>>(deserializer: D) -> Result<Self, D::Error> {
+    impl<'a, 'de: 'a> Deserialize<'de> for Authority<'a> {
+        fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
             deserializer.deserialize_str(AuthorityVistor)
         }
     }

--- a/core/http/src/uri/authority.rs
+++ b/core/http/src/uri/authority.rs
@@ -259,7 +259,7 @@ mod serde {
     impl<'a> Visitor<'a> for AuthorityVistor {
         type Value = Authority<'a>;
         fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-            write!(formatter, "Expecting a valid Authority URI")
+            write!(formatter, "authority Uri")
         }
 
         fn visit_str<E: Error>(self, v: &str) -> Result<Self::Value, E> {

--- a/core/http/src/uri/authority.rs
+++ b/core/http/src/uri/authority.rs
@@ -109,6 +109,42 @@ impl<'a> Authority<'a> {
         crate::parse::uri::authority_from_str(string)
     }
 
+    /// Parses the string `string` into an `Authority`. Parsing will never
+    /// allocate. This method should be used instead of
+    /// [`Authority::parse()`](crate::uri::Authority::parse()) when the source URI is
+    /// already a `String`. Returns an `Error` if `string` is not a valid authority
+    /// URI.
+    pub fn parse_owned(string: String) -> Result<Authority<'static>, Error<'static>> {
+        // We create a copy of a pointer to `string` to escape the borrow
+        // checker. This is so that we can "move out of the borrow" later.
+        //
+        // For this to be correct and safe, we need to ensure that:
+        //
+        //  1. No `&mut` references to `string` are created after this line.
+        //  2. `string` isn't dropped while `copy_of_str` is live.
+        //
+        // These two facts can be easily verified. An `&mut` can't be created
+        // because `string` isn't `mut`. Then, `string` is clearly not dropped
+        // since it's passed in to `source`.
+        // let copy_of_str = unsafe { &*(string.as_str() as *const str) };
+        let copy_of_str = unsafe { &*(string.as_str() as *const str) };
+        let authority = Authority::parse(copy_of_str)?;
+        debug_assert!(authority.source.is_some(), "Origin source parsed w/o source");
+
+        let authority = Authority {
+            host: authority.host.into_owned(),
+            user_info: authority.user_info.into_owned(),
+            port: authority.port,
+            // At this point, it's impossible for anything to be borrowing
+            // `string` except for `source`, even though Rust doesn't know it.
+            // Because we're replacing `source` here, there can't possibly be a
+            // borrow remaining, it's safe to "move out of the borrow".
+            source: Some(Cow::Owned(string)),
+        };
+
+        Ok(authority)
+    }
+
     /// Returns the user info part of the authority URI, if there is one.
     ///
     /// # Example
@@ -205,5 +241,46 @@ impl<'a> TryFrom<&'a str> for Authority<'a> {
 
     fn try_from(value: &'a str) -> Result<Self, Self::Error> {
         Authority::parse(value)
+    }
+}
+
+#[cfg(feature = "serde")]
+mod serde {
+    use std::fmt;
+
+    use super::Authority;
+    use _serde::{ser::{Serialize, Serializer}, de::{Deserialize, Deserializer, Error, Visitor}};
+
+    impl<'a> Serialize for Authority<'a> {
+        fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            serializer.serialize_str(&self.to_string())
+        }
+    }
+
+    struct AuthorityVistor;
+
+    impl<'a> Visitor<'a> for AuthorityVistor {
+        type Value = Authority<'a>;
+        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(formatter, "Expecting a valid URI string")
+        }
+
+        fn visit_str<E: Error>(self, v: &str) -> Result<Self::Value, E> {
+            Authority::parse_owned(v.to_string()).map_err(Error::custom)
+        }
+
+        fn visit_string<E: Error>(self, v: String) -> Result<Self::Value, E> {
+            Authority::parse_owned(v).map_err(Error::custom)
+        }
+
+        fn visit_borrowed_str<E: Error>(self, v: &'a str) -> Result<Self::Value, E> {
+            Authority::parse(v).map_err(Error::custom)
+        }
+    }
+
+    impl<'a> Deserialize<'a> for Authority<'a> {
+        fn deserialize<D: Deserializer<'a>>(deserializer: D) -> Result<Self, D::Error> {
+            deserializer.deserialize_str(AuthorityVistor)
+        }
     }
 }

--- a/core/http/src/uri/authority.rs
+++ b/core/http/src/uri/authority.rs
@@ -124,10 +124,23 @@ impl<'a> Authority<'a> {
     }
 
     /// Parses the string `string` into an `Authority`. Parsing will never
-    /// allocate. This method should be used instead of
-    /// [`Authority::parse()`](crate::uri::Authority::parse()) when the source URI is
-    /// already a `String`. Returns an `Error` if `string` is not a valid authority
-    /// URI.
+    /// May allocate on error.
+    ///
+    /// This method should be used instead of [`Authority::parse()`] when
+    /// the source URI is already a `String`. Returns an `Error` if `string` is
+    /// not a valid authority URI.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # extern crate rocket;
+    /// use rocket::http::uri::Authority;
+    ///
+    /// let source = format!("/foo/{}/three", 2);
+    /// let uri = Authority::parse_owned(source).expect("valid URI");
+    /// assert_eq!(uri.path(), "/foo/2/three");
+    /// assert!(uri.query().is_none());
+    /// ```
     pub fn parse_owned(string: String) -> Result<Authority<'static>, Error<'static>> {
         let authority = Authority::parse(&string).map_err(|e| e.into_owned())?;
         debug_assert!(authority.source.is_some(), "Origin source parsed w/o source");

--- a/core/http/src/uri/authority.rs
+++ b/core/http/src/uri/authority.rs
@@ -123,7 +123,7 @@ impl<'a> Authority<'a> {
         crate::parse::uri::authority_from_str(string)
     }
 
-    /// Parses the string `string` into an `Authority`. Parsing will never
+    /// Parses the string `string` into an `Authority`. Parsing will never allocate.
     /// May allocate on error.
     ///
     /// This method should be used instead of [`Authority::parse()`] when

--- a/core/http/src/uri/authority.rs
+++ b/core/http/src/uri/authority.rs
@@ -136,10 +136,11 @@ impl<'a> Authority<'a> {
     /// # extern crate rocket;
     /// use rocket::http::uri::Authority;
     ///
-    /// let source = format!("/foo/{}/three", 2);
+    /// let source = format!("rocket.rs:8000");
     /// let uri = Authority::parse_owned(source).expect("valid URI");
-    /// assert_eq!(uri.path(), "/foo/2/three");
-    /// assert!(uri.query().is_none());
+    /// assert!(uri.user_info().is_none());
+    /// assert_eq!(uri.host(), "rocket.rs");
+    /// assert_eq!(uri.port(), Some(8000));
     /// ```
     pub fn parse_owned(string: String) -> Result<Authority<'static>, Error<'static>> {
         let authority = Authority::parse(&string).map_err(|e| e.into_owned())?;

--- a/core/http/src/uri/origin.rs
+++ b/core/http/src/uri/origin.rs
@@ -90,7 +90,8 @@ use crate::{RawStr, RawStrBuf};
 ///
 /// For convience, `Origin` implements `Serialize` and `Deserialize`.
 /// Because `Origin` has a lifetime parameter, serde requires a borrow
-/// attribute for the derive macro to work.
+/// attribute for the derive macro to work. If you want to own the Uri,
+/// rather than borrow from the deserializer, use `'static`.
 ///
 /// ```ignore
 /// #[derive(Deserialize)]

--- a/core/http/src/uri/origin.rs
+++ b/core/http/src/uri/origin.rs
@@ -504,7 +504,7 @@ mod serde {
     impl<'a> Visitor<'a> for OriginVistor {
         type Value = Origin<'a>;
         fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-            write!(formatter, "Expecting a valid URI string")
+            write!(formatter, "Expecting a valid Origin URI")
         }
 
         fn visit_str<E: Error>(self, v: &str) -> Result<Self::Value, E> {

--- a/core/http/src/uri/origin.rs
+++ b/core/http/src/uri/origin.rs
@@ -518,7 +518,7 @@ mod serde {
     impl<'a> Visitor<'a> for OriginVistor {
         type Value = Origin<'a>;
         fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-            write!(formatter, "Expecting a valid Origin URI")
+            write!(formatter, "origin Uri")
         }
 
         fn visit_str<E: Error>(self, v: &str) -> Result<Self::Value, E> {

--- a/core/http/src/uri/origin.rs
+++ b/core/http/src/uri/origin.rs
@@ -520,8 +520,8 @@ mod serde {
         }
     }
 
-    impl<'a> Deserialize<'a> for Origin<'a> {
-        fn deserialize<D: Deserializer<'a>>(deserializer: D) -> Result<Self, D::Error> {
+    impl<'a, 'de: 'a> Deserialize<'de> for Origin<'a> {
+        fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
             deserializer.deserialize_str(OriginVistor)
         }
     }

--- a/core/http/src/uri/origin.rs
+++ b/core/http/src/uri/origin.rs
@@ -85,6 +85,20 @@ use crate::{RawStr, RawStrBuf};
 /// #     assert_eq!(abnormal.into_normalized(), expected);
 /// # }
 /// ```
+///
+/// ## Serde
+///
+/// For convience, `Origin` implements `Serialize` and `Deserialize`.
+/// Because `Origin` has a lifetime parameter, serde requires a borrow
+/// attribute for the derive macro to work.
+///
+/// ```ignore
+/// #[derive(Deserialize)]
+/// struct Uris<'a> {
+///     #[serde(borrow)]
+///     origin: Origin<'a>,
+/// }
+/// ```
 #[derive(Debug, Clone)]
 pub struct Origin<'a> {
     pub(crate) source: Option<Cow<'a, str>>,

--- a/core/http/src/uri/reference.rs
+++ b/core/http/src/uri/reference.rs
@@ -165,6 +165,8 @@ impl<'a> Reference<'a> {
     /// Parses the string `string` into a `Reference`. Never allocates on
     /// success. May allocate on error.
     ///
+    /// TODO: Avoid allocation
+    ///
     /// This method should be used instead of [`Reference::parse()`] when the
     /// source URI is already a `String`. Returns an `Error` if `string` is not
     /// a valid URI reference.

--- a/core/http/src/uri/reference.rs
+++ b/core/http/src/uri/reference.rs
@@ -565,8 +565,8 @@ mod serde {
         }
     }
 
-    impl<'a> Deserialize<'a> for Reference<'a> {
-        fn deserialize<D: Deserializer<'a>>(deserializer: D) -> Result<Self, D::Error> {
+    impl<'a, 'de: 'a> Deserialize<'de> for Reference<'a> {
+        fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
             deserializer.deserialize_str(ReferenceVistor)
         }
     }

--- a/core/http/src/uri/reference.rs
+++ b/core/http/src/uri/reference.rs
@@ -50,7 +50,8 @@ use crate::parse::{Extent, IndexedStr};
 ///
 /// For convience, `Reference` implements `Serialize` and `Deserialize`.
 /// Because `Reference` has a lifetime parameter, serde requires a borrow
-/// attribute for the derive macro to work.
+/// attribute for the derive macro to work. If you want to own the Uri,
+/// rather than borrow from the deserializer, use `'static`.
 ///
 /// ```ignore
 /// #[derive(Deserialize)]

--- a/core/http/src/uri/reference.rs
+++ b/core/http/src/uri/reference.rs
@@ -45,6 +45,20 @@ use crate::parse::{Extent, IndexedStr};
 /// Note that `uri!()` macro _always_ prefers the more specific URI variant to
 /// `Reference` when possible, as is demonstrated above for `absolute` and
 /// `origin`.
+///
+/// ## Serde
+///
+/// For convience, `Reference` implements `Serialize` and `Deserialize`.
+/// Because `Reference` has a lifetime parameter, serde requires a borrow
+/// attribute for the derive macro to work.
+///
+/// ```ignore
+/// #[derive(Deserialize)]
+/// struct Uris<'a> {
+///     #[serde(borrow)]
+///     reference: Reference<'a>,
+/// }
+/// ```
 #[derive(Debug, Clone)]
 pub struct Reference<'a> {
     source: Option<Cow<'a, str>>,

--- a/core/http/src/uri/reference.rs
+++ b/core/http/src/uri/reference.rs
@@ -530,3 +530,44 @@ impl std::fmt::Display for Reference<'_> {
         Ok(())
     }
 }
+
+#[cfg(feature = "serde")]
+mod serde {
+    use std::fmt;
+
+    use super::Reference;
+    use _serde::{ser::{Serialize, Serializer}, de::{Deserialize, Deserializer, Error, Visitor}};
+
+    impl<'a> Serialize for Reference<'a> {
+        fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            serializer.serialize_str(&self.to_string())
+        }
+    }
+
+    struct ReferenceVistor;
+
+    impl<'a> Visitor<'a> for ReferenceVistor {
+        type Value = Reference<'a>;
+        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(formatter, "Expecting a valid Reference URI")
+        }
+
+        fn visit_str<E: Error>(self, v: &str) -> Result<Self::Value, E> {
+            Reference::parse_owned(v.to_string()).map_err(Error::custom)
+        }
+
+        fn visit_string<E: Error>(self, v: String) -> Result<Self::Value, E> {
+            Reference::parse_owned(v).map_err(Error::custom)
+        }
+
+        fn visit_borrowed_str<E: Error>(self, v: &'a str) -> Result<Self::Value, E> {
+            Reference::parse(v).map_err(Error::custom)
+        }
+    }
+
+    impl<'a> Deserialize<'a> for Reference<'a> {
+        fn deserialize<D: Deserializer<'a>>(deserializer: D) -> Result<Self, D::Error> {
+            deserializer.deserialize_str(ReferenceVistor)
+        }
+    }
+}

--- a/core/http/src/uri/reference.rs
+++ b/core/http/src/uri/reference.rs
@@ -563,7 +563,7 @@ mod serde {
     impl<'a> Visitor<'a> for ReferenceVistor {
         type Value = Reference<'a>;
         fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-            write!(formatter, "Expecting a valid Reference URI")
+            write!(formatter, "reference Uri")
         }
 
         fn visit_str<E: Error>(self, v: &str) -> Result<Self::Value, E> {

--- a/core/http/src/uri/uri.rs
+++ b/core/http/src/uri/uri.rs
@@ -35,12 +35,9 @@ use crate::uri::error::{Error, TryFromUriError};
 /// [RFC 7230]: https://tools.ietf.org/html/rfc7230
 ///
 /// ## Serde
-///
-/// For convience, `Uri` implements `Serialize`, although it does not implement
-/// `Deserialize`. If you need to deserialize a Uri, use one of the variants,
-/// since they provide much stricter parsing requirements. See [`Uri::parse`]
-/// for why deserialization is not implemented for `Uri` directly. If you need
-/// a generic Uri, [`Reference`] is likely a better fit.
+/// Parsing a string into a `Uri` is ambgious, so `Uri` does not implement `Serialize`
+/// or `Deserialize`, although all of the variants do. See [`Uri::parse_any`] for more
+/// information
 #[derive(Debug, PartialEq, Clone)]
 pub enum Uri<'a> {
     /// An asterisk: exactly `*`.
@@ -351,15 +348,3 @@ impl_uri_from!(Authority<'a>);
 impl_uri_from!(Absolute<'a>);
 impl_uri_from!(Reference<'a>);
 impl_uri_from!(Asterisk);
-
-#[cfg(feature = "serde")]
-mod serde {
-    use super::Uri;
-    use _serde::ser::{Serialize, Serializer};
-
-    impl<'a> Serialize for Uri<'a> {
-        fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-            serializer.serialize_str(&self.to_string())
-        }
-    }
-}

--- a/core/http/src/uri/uri.rs
+++ b/core/http/src/uri/uri.rs
@@ -343,3 +343,15 @@ impl_uri_from!(Authority<'a>);
 impl_uri_from!(Absolute<'a>);
 impl_uri_from!(Reference<'a>);
 impl_uri_from!(Asterisk);
+
+#[cfg(feature = "serde")]
+mod serde {
+    use super::Uri;
+    use _serde::ser::{Serialize, Serializer};
+
+    impl<'a> Serialize for Uri<'a> {
+        fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            serializer.serialize_str(&self.to_string())
+        }
+    }
+}

--- a/core/http/src/uri/uri.rs
+++ b/core/http/src/uri/uri.rs
@@ -33,6 +33,13 @@ use crate::uri::error::{Error, TryFromUriError};
 /// methods of the internal structure.
 ///
 /// [RFC 7230]: https://tools.ietf.org/html/rfc7230
+///
+/// ## Serde
+///
+/// For convience, `Uri` implements `Serialize`, although it does not implement
+/// `Deserialize`. If you need to deserialize a Uri, use one of the variants,
+/// since they provide much stricter parsing requirements. See [`Uri::parse`]
+/// for why deserialization is not implemented for `Uri` directly.
 #[derive(Debug, PartialEq, Clone)]
 pub enum Uri<'a> {
     /// An asterisk: exactly `*`.

--- a/core/http/src/uri/uri.rs
+++ b/core/http/src/uri/uri.rs
@@ -39,7 +39,8 @@ use crate::uri::error::{Error, TryFromUriError};
 /// For convience, `Uri` implements `Serialize`, although it does not implement
 /// `Deserialize`. If you need to deserialize a Uri, use one of the variants,
 /// since they provide much stricter parsing requirements. See [`Uri::parse`]
-/// for why deserialization is not implemented for `Uri` directly.
+/// for why deserialization is not implemented for `Uri` directly. If you need
+/// a generic Uri, [`Reference`] is likely a better fit.
 #[derive(Debug, PartialEq, Clone)]
 pub enum Uri<'a> {
     /// An asterisk: exactly `*`.

--- a/core/lib/tests/http_uri_serde.rs
+++ b/core/lib/tests/http_uri_serde.rs
@@ -1,0 +1,50 @@
+//use figment::{Figment, Profile};
+use rocket::Config;
+use rocket_http::uri::{Absolute, Asterisk, Authority, Origin, Reference};
+use serde::{Serialize, Deserialize};
+//use pretty_assertions::assert_eq;
+
+#[derive(PartialEq, Debug, Serialize, Deserialize)]
+struct UriContainer<'a> {
+    asterisk: Asterisk,
+    #[serde(borrow)]
+    origin: Origin<'a>,
+    #[serde(borrow)]
+    authority: Authority<'a>,
+    #[serde(borrow)]
+    absolute: Absolute<'a>,
+    #[serde(borrow)]
+    reference: Reference<'a>,
+}
+
+#[test]
+fn uri_deserialize() {
+    figment::Jail::expect_with(|jail| {
+        jail.create_file("Rocket.toml", r#"
+            [default]
+            asterisk = "*"
+            origin = "/foo/bar?baz"
+            authority = "user:pass@rocket.rs:80"
+            absolute = "https://rocket.rs/foo/bar"
+            reference = "https://rocket.rs:8000/index.html"
+        "#)?;
+
+        let uris: UriContainer<'_> = Config::figment().extract()?;
+        assert_eq!(uris, UriContainer {
+            asterisk: Asterisk,
+            origin: Origin::new("/foo/bar", Some("baz")),
+            authority: Authority::const_new(Some("user:pass"), "rocket.rs", Some(80)),
+            absolute: Absolute::const_new(
+                "https",
+                Some(Authority::const_new(None, "rocket.rs", None)),
+                "/foo/bar",
+                None),
+            reference: Reference::const_new(
+                Some("https"),
+                Some(Authority::const_new(None, "rocket.rs", Some(8000))),
+                "/index.html",
+                None, None),
+        });
+        Ok(())
+    });
+}

--- a/core/lib/tests/http_uri_serde.rs
+++ b/core/lib/tests/http_uri_serde.rs
@@ -17,6 +17,19 @@ struct UriContainer<'a> {
     reference: Reference<'a>,
 }
 
+#[derive(PartialEq, Debug, Serialize, Deserialize)]
+struct UriContainerOwned {
+    asterisk: Asterisk,
+    #[serde(borrow)]
+    origin: Origin<'static>,
+    #[serde(borrow)]
+    authority: Authority<'static>,
+    #[serde(borrow)]
+    absolute: Absolute<'static>,
+    #[serde(borrow)]
+    reference: Reference<'static>,
+}
+
 #[test]
 fn uri_serde() {
     figment::Jail::expect_with(|jail| {
@@ -32,18 +45,35 @@ fn uri_serde() {
         let uris: UriContainer<'_> = Config::figment().extract()?;
         assert_eq!(uris, UriContainer {
             asterisk: Asterisk,
-            origin: Origin::new("/foo/bar", Some("baz")),
-            authority: Authority::const_new(Some("user:pass"), "rocket.rs", Some(80)),
-            absolute: Absolute::const_new(
-                "https",
-                Some(Authority::const_new(None, "rocket.rs", None)),
-                "/foo/bar",
-                None),
-            reference: Reference::const_new(
-                Some("https"),
-                Some(Authority::const_new(None, "rocket.rs", Some(8000))),
-                "/index.html",
-                None, None),
+            origin: uri!("/foo/bar?baz"),
+            authority: uri!("user:pass@rocket.rs:80"),
+            absolute: uri!("https://rocket.rs/foo/bar"),
+            reference: uri!("https://rocket.rs:8000/index.html").into(),
+        });
+
+        Ok(())
+    });
+}
+
+#[test]
+fn uri_serde_owned() {
+    figment::Jail::expect_with(|jail| {
+        jail.create_file("Rocket.toml", r#"
+            [default]
+            asterisk = "*"
+            origin = "/foo/bar?baz"
+            authority = "user:pass@rocket.rs:80"
+            absolute = "https://rocket.rs/foo/bar"
+            reference = "https://rocket.rs:8000/index.html"
+        "#)?;
+
+        let uris: UriContainerOwned = Config::figment().extract()?;
+        assert_eq!(uris, UriContainerOwned {
+            asterisk: Asterisk,
+            origin: uri!("/foo/bar?baz"),
+            authority: uri!("user:pass@rocket.rs:80"),
+            absolute: uri!("https://rocket.rs/foo/bar"),
+            reference: uri!("https://rocket.rs:8000/index.html").into(),
         });
 
         Ok(())

--- a/core/lib/tests/http_uri_serde.rs
+++ b/core/lib/tests/http_uri_serde.rs
@@ -52,7 +52,7 @@ fn uri_serde() {
 
 #[test]
 fn uri_serde_round_trip() {
-    let tmp = Figment::from(Serialized::default("uris", UriContainer {
+    let tmp = Figment::from(Serialized::defaults(UriContainer {
         asterisk: Asterisk,
         origin: uri!("/foo/bar?baz"),
         authority: uri!("user:pass@rocket.rs:80"),
@@ -60,7 +60,7 @@ fn uri_serde_round_trip() {
         reference: uri!("https://rocket.rs:8000/index.html").into(),
     }));
 
-    let uris: UriContainer<'_> = tmp.extract_inner("uris").expect("Parsing failed");
+    let uris: UriContainer<'_> = tmp.extract().expect("Parsing failed");
     assert_eq!(uris, UriContainer {
         asterisk: Asterisk,
         origin: uri!("/foo/bar?baz"),

--- a/core/lib/tests/http_uri_serde.rs
+++ b/core/lib/tests/http_uri_serde.rs
@@ -52,7 +52,7 @@ fn uri_serde() {
 
 #[test]
 fn uri_serde_round_trip() {
-    let tmp = Figment::from(Serialized::default("default", UriContainer {
+    let tmp = Figment::from(Serialized::default("uris", UriContainer {
         asterisk: Asterisk,
         origin: uri!("/foo/bar?baz"),
         authority: uri!("user:pass@rocket.rs:80"),
@@ -60,7 +60,7 @@ fn uri_serde_round_trip() {
         reference: uri!("https://rocket.rs:8000/index.html").into(),
     }));
 
-    let uris: UriContainer<'_> = tmp.extract().expect("Parsing failed");
+    let uris: UriContainer<'_> = tmp.extract_inner("uris").expect("Parsing failed");
     assert_eq!(uris, UriContainer {
         asterisk: Asterisk,
         origin: uri!("/foo/bar?baz"),

--- a/core/lib/tests/http_uri_serde.rs
+++ b/core/lib/tests/http_uri_serde.rs
@@ -1,8 +1,7 @@
-//use figment::{Figment, Profile};
 use rocket::Config;
 use rocket_http::uri::{Absolute, Asterisk, Authority, Origin, Reference};
 use serde::{Serialize, Deserialize};
-//use pretty_assertions::assert_eq;
+use pretty_assertions::assert_eq;
 
 #[derive(PartialEq, Debug, Serialize, Deserialize)]
 struct UriContainer<'a> {


### PR DESCRIPTION
This is a continuation of #1621, since I started over on a separate branch. This should be nearly complete, I don't expect any major changes to happen.

A few notes:

- I've implemented Serialize and Deserialize for all 5 Uri variants, and added documentation noting the implementation. I felt it was important to include some information about `#[serde(borrow)]`, since it took me a while to figure that out for the test.
- I believe the `serde` flag for `http` in `core` is already enabled, let me know if I'm wrong about that.
- I added the integration test in `core`, since Figment isn't a depedency in `http`.

I agree that implementing `Deserialize` on `Uri` itself isn't particularly useful. I did however implement `Serialize` for `Uri`, since there are less issues there. I'm not sure if this will actually be used, but I didn't think it would cause any issues. I did add documentation to `Uri` noting the implementation, and recommending `Reference` for the generic usecase.

I also added `parse_owned` implementations to the types that didn't have an implementation. I don't think there should be any issues with my implementation, but I'm not particularly familiar with the parser itself, so let me know.