### PR TITLE
(TLS) Advertise HTTP/2 support via ALPN.

### DIFF
--- a/core/http/src/tls.rs
+++ b/core/http/src/tls.rs
@@ -117,6 +117,7 @@ pub async fn bind_tls<C: io::BufRead + Send, K: io::BufRead + Send>(
     tls_config.set_persistence(cache);
     tls_config.ticketer = rustls::Ticketer::new();
     tls_config.set_single_cert(cert_chain, key).expect("invalid key");
+    tls_config.set_protocols(&[b"h2".to_vec(), b"http/1.1".to_vec()]);
 
     let acceptor = TlsAcceptor::from(Arc::new(tls_config));
     let state = TlsListenerState::Listening;


### PR DESCRIPTION
Currently HTTP/2 is supported, but not advertised. So, `curl` for instance needs `--http2-prior-knowledge` and browsers don't attempt it. This commit changes the TLS listener to indicate via ALPN that both `h2` and `http/1.1` are available.

At present both the `http1` and `http2` features of `hyper` are enabled. Note that this approach may work unexpectedly or badly if the `http2` feature is made optional in the future, as the client would try to use HTTP/2 as advertised but be subsequently refused.

<details>
<summary>curl request before/after</summary>

```diff

--- a	2021-06-06 12:49:33.766687353 -0600
+++ b	2021-06-06 12:49:36.696754023 -0600
@@ -17,28 +17,32 @@
 * TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
 * TLSv1.3 (OUT), TLS handshake, Finished (20):
 * SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384
-* ALPN, server did not agree to a protocol
+* ALPN, server accepted to use h2
 * Server certificate:
 *  subject: C=US; ST=CA; O=Rocket; CN=localhost
 *  start date: Sep  1 10:02:28 2017 GMT
 *  expire date: Aug 30 10:02:28 2027 GMT
 *  issuer: C=US; ST=CA; O=Rocket CA; CN=Rocket Root CA
 *  SSL certificate verify result: unable to get local issuer certificate (20), continuing anyway.
-> GET / HTTP/1.1
+* Using HTTP2, server supports multi-use
+* Connection state changed (HTTP/2 confirmed)
+* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
+* Using Stream ID: 1 (easy handle 0x562b0a120970)
+> GET / HTTP/2
 > Host: localhost:8000
-> User-Agent: curl/7.77.0
-> Accept: */*
+> user-agent: curl/7.77.0
+> accept: */*
 > 
 * TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
-* Mark bundle as not supporting multiuse
-< HTTP/1.1 200 OK
+* Connection state changed (MAX_CONCURRENT_STREAMS == 4294967295)!
+< HTTP/2 200 
 < content-type: text/plain; charset=utf-8
 < server: Rocket
+< permissions-policy: interest-cohort=()
 < x-content-type-options: nosniff
 < x-frame-options: SAMEORIGIN
-< permissions-policy: interest-cohort=()
 < content-length: 13
-< date: Sun, 06 Jun 2021 18:47:28 GMT
+< date: Sun, 06 Jun 2021 18:47:52 GMT
 < 
 * Connection #0 to host localhost left intact
 Hello, world!%
```

</details>