### PR TITLE
Fix some clippy lints

### DIFF
--- a/contrib/sync_db_pools/codegen/src/database.rs
+++ b/contrib/sync_db_pools/codegen/src/database.rs
@@ -65,7 +65,7 @@ pub fn database_attr(attr: TokenStream, input: TokenStream) -> Result<TokenStrea
     let guard_type = &invocation.type_name;
     let vis = &invocation.visibility;
     let fairing_name = format!("'{}' Database Pool", name);
-    let span = conn_type.span().into();
+    let span = conn_type.span();
 
     // A few useful paths.
     let root = quote_spanned!(span => ::rocket_sync_db_pools);

--- a/contrib/sync_db_pools/lib/src/connection.rs
+++ b/contrib/sync_db_pools/lib/src/connection.rs
@@ -138,7 +138,7 @@ impl<K: 'static, C: Poolable> ConnectionPool<K, C> {
 
     #[inline]
     pub async fn get_pool<P: Phase>(rocket: &Rocket<P>) -> Option<Self> {
-        rocket.state::<Self>().map(|pool| pool.clone())
+        rocket.state::<Self>().cloned()
     }
 }
 

--- a/core/codegen/src/attribute/catch/mod.rs
+++ b/core/codegen/src/attribute/catch/mod.rs
@@ -30,14 +30,14 @@ pub fn _catch(
 
     // This ensures that "Responder not implemented" points to the return type.
     let return_type_span = catch.function.sig.output.ty()
-        .map(|ty| ty.span().into())
-        .unwrap_or(Span::call_site().into());
+        .map(|ty| ty.span())
+        .unwrap_or_else(Span::call_site);
 
     // Set the `req` and `status` spans to that of their respective function
     // arguments for a more correct `wrong type` error span. `rev` to be cute.
     let codegen_args = &[__req, __status];
     let inputs = catch.function.sig.inputs.iter().rev()
-        .zip(codegen_args.into_iter())
+        .zip(codegen_args.iter())
         .map(|(fn_arg, codegen_arg)| match fn_arg {
             syn::FnArg::Receiver(_) => codegen_arg.respanned(fn_arg.span()),
             syn::FnArg::Typed(a) => codegen_arg.respanned(a.ty.span())
@@ -45,7 +45,7 @@ pub fn _catch(
 
     // We append `.await` to the function call if this is `async`.
     let dot_await = catch.function.sig.asyncness
-        .map(|a| quote_spanned!(a.span().into() => .await));
+        .map(|a| quote_spanned!(a.span() => .await));
 
     let catcher_response = quote_spanned!(return_type_span => {
         let ___responder = #user_catcher_fn_name(#(#inputs),*) #dot_await;

--- a/core/codegen/src/attribute/entry/launch.rs
+++ b/core/codegen/src/attribute/entry/launch.rs
@@ -36,7 +36,7 @@ impl EntryAttr for Launch {
         };
 
         let block = &f.block;
-        let rocket = quote_spanned!(ty.span().into() => {
+        let rocket = quote_spanned!(ty.span() => {
             let ___rocket: #ty = #block;
             let ___rocket: ::rocket::Rocket<::rocket::Build> = ___rocket;
             ___rocket
@@ -47,7 +47,7 @@ impl EntryAttr for Launch {
         sig.output = syn::ReturnType::Default;
         sig.asyncness = None;
 
-        Ok(quote_spanned!(block.span().into() =>
+        Ok(quote_spanned!(block.span() =>
             #[allow(dead_code)] #f
 
             #vis #sig {

--- a/core/codegen/src/attribute/entry/main.rs
+++ b/core/codegen/src/attribute/entry/main.rs
@@ -21,7 +21,7 @@ impl EntryAttr for Main {
         }
 
         sig.asyncness = None;
-        Ok(quote_spanned!(block.span().into() => #(#attrs)* #vis #sig {
+        Ok(quote_spanned!(block.span() => #(#attrs)* #vis #sig {
             ::rocket::async_main(async move #block)
         }))
     }

--- a/core/codegen/src/attribute/entry/mod.rs
+++ b/core/codegen/src/attribute/entry/mod.rs
@@ -35,7 +35,7 @@ fn _async_entry<A: EntryAttr>(
             .span_note(function.sig.span(), "this function must take no arguments"));
     }
 
-    A::function(&mut function).map(|t| t.into())
+    A::function(&mut function)
 }
 
 macro_rules! async_entry {

--- a/core/codegen/src/attribute/entry/test.rs
+++ b/core/codegen/src/attribute/entry/test.rs
@@ -12,7 +12,7 @@ impl EntryAttr for Test {
     fn function(f: &mut syn::ItemFn) -> Result<TokenStream> {
         let (attrs, vis, block, sig) = (&f.attrs, &f.vis, &f.block, &mut f.sig);
         sig.asyncness = None;
-        Ok(quote_spanned!(block.span().into() => #(#attrs)* #[test] #vis #sig {
+        Ok(quote_spanned!(block.span() => #(#attrs)* #[test] #vis #sig {
             ::rocket::async_test(async move #block)
         }))
     }

--- a/core/codegen/src/attribute/route/mod.rs
+++ b/core/codegen/src/attribute/route/mod.rs
@@ -236,7 +236,7 @@ fn responder_outcome_expr(route: &Route) -> TokenStream {
         .map(|(ident, _)| ident.rocketized());
 
     let _await = route.handler.sig.asyncness
-        .map(|a| quote_spanned!(a.span().into() => .await));
+        .map(|a| quote_spanned!(a.span() => .await));
 
     define_spanned_export!(ret_span => __req, _route);
     quote_spanned! { ret_span =>
@@ -364,7 +364,7 @@ fn codegen_route(route: Route) -> Result<TokenStream> {
 
         /// Rocket code generated wrapping URI macro.
         #internal_uri_macro
-    }.into())
+    })
 }
 
 fn complete_route(args: TokenStream, input: TokenStream) -> Result<TokenStream> {
@@ -387,10 +387,10 @@ fn incomplete_route(
     let method_span = StringLit::new(format!("#[{}]", method), Span::call_site())
         .subspan(2..2 + method_str.len());
 
-    let method_ident = syn::Ident::new(&method_str, method_span.into());
+    let method_ident = syn::Ident::new(&method_str, method_span);
 
     let function: syn::ItemFn = syn::parse2(input)
-        .map_err(|e| Diagnostic::from(e))
+        .map_err(Diagnostic::from)
         .map_err(|d| d.help(format!("#[{}] can only be used on functions", method_str)))?;
 
     let full_attr = quote!(#method_ident(#args));

--- a/core/codegen/src/attribute/route/mod.rs
+++ b/core/codegen/src/attribute/route/mod.rs
@@ -228,7 +228,7 @@ fn internal_uri_macro_decl(route: &Route) -> TokenStream {
 fn responder_outcome_expr(route: &Route) -> TokenStream {
     let ret_span = match route.handler.sig.output {
         syn::ReturnType::Default => route.handler.sig.ident.span(),
-        syn::ReturnType::Type(_, ref ty) => ty.span().into()
+        syn::ReturnType::Type(_, ref ty) => ty.span()
     };
 
     let user_handler_fn_name = &route.handler.sig.ident;
@@ -369,7 +369,7 @@ fn codegen_route(route: Route) -> Result<TokenStream> {
 
 fn complete_route(args: TokenStream, input: TokenStream) -> Result<TokenStream> {
     let function: syn::ItemFn = syn::parse2(input)
-        .map_err(|e| Diagnostic::from(e))
+        .map_err(Diagnostic::from)
         .map_err(|diag| diag.help("`#[route]` can only be used on functions"))?;
 
     let attr_tokens = quote!(route(#args));

--- a/core/codegen/src/bang/test_guide.rs
+++ b/core/codegen/src/bang/test_guide.rs
@@ -6,7 +6,7 @@ use devise::ext::SpanDiagnosticExt;
 use proc_macro2::TokenStream;
 
 pub fn _macro(input: proc_macro::TokenStream) -> devise::Result<TokenStream> {
-    let root_glob = syn::parse::<LitStr>(input.into())?;
+    let root_glob = syn::parse::<LitStr>(input)?;
     let tests = entry_to_tests(&root_glob)
         .map_err(|e| root_glob.span().error(format!("failed to read: {}", e)))?;
 
@@ -24,7 +24,7 @@ fn entry_to_tests(root_glob: &LitStr) -> Result<Vec<TokenStream>, Box<dyn Error>
             .and_then(|f| f.to_str())
             .map(|name| name.trim_matches(|c| char::is_numeric(c) || c == '-')
                 .replace(|c| c == '-' || c == '.', "_"))
-            .ok_or_else(|| "invalid file name")?;
+            .ok_or("invalid file name")?;
 
         let ident = Ident::new(&name.to_lowercase(), root_glob.span());
         let full_path = Path::new(&manifest_dir).join(&path).display().to_string();

--- a/core/codegen/src/bang/uri.rs
+++ b/core/codegen/src/bang/uri.rs
@@ -28,7 +28,7 @@ pub fn prefix_last_segment(path: &mut syn::Path, prefix: &str) {
 }
 
 pub fn _uri_macro(input: TokenStream) -> Result<TokenStream> {
-    let input2: TokenStream = input.clone().into();
+    let input2: TokenStream = input.clone();
     match syn::parse2::<UriMacro>(input)? {
         UriMacro::Routed(ref mut mac) => {
             prefix_last_segment(&mut mac.route.path, URI_MACRO_PREFIX);
@@ -39,10 +39,10 @@ pub fn _uri_macro(input: TokenStream) -> Result<TokenStream> {
     }
 }
 
-fn extract_exprs<'a>(internal: &'a InternalUriParams) -> Result<(
-        impl Iterator<Item = &'a Expr>,                // path exprs
-        impl Iterator<Item = &'a ArgExpr>,             // query exprs
-        impl Iterator<Item = (&'a Ident, &'a Type)>,   // types for both path || query
+fn extract_exprs(internal: &InternalUriParams) -> Result<(
+        impl Iterator<Item = &Expr>,                // path exprs
+        impl Iterator<Item = &ArgExpr>,             // query exprs
+        impl Iterator<Item = (&Ident, &Type)>,   // types for both path || query
     )>
 {
     let route_name = &internal.uri_mac.route.path;
@@ -51,7 +51,7 @@ fn extract_exprs<'a>(internal: &'a InternalUriParams) -> Result<(
             let path_params = internal.dynamic_path_params();
             let path_param_count = path_params.clone().count();
             for expr in exprs.iter().take(path_param_count) {
-                if !expr.as_expr().is_some() {
+                if expr.as_expr().is_none() {
                     return Err(expr.span().error("path parameters cannot be ignored"));
                 }
             }

--- a/core/codegen/src/derive/responder.rs
+++ b/core/codegen/src/derive/responder.rs
@@ -49,7 +49,7 @@ pub fn derive_responder(input: proc_macro::TokenStream) -> TokenStream {
                 false => Ok(())
             })
             .fields_validate(|_, fields| match fields.is_empty() {
-                true => return Err(fields.span().error("need at least one field")),
+                true => Err(fields.span().error("need at least one field")),
                 false => Ok(())
             })
         )

--- a/core/codegen/src/derive/responder.rs
+++ b/core/codegen/src/derive/responder.rs
@@ -61,7 +61,7 @@ pub fn derive_responder(input: proc_macro::TokenStream) -> TokenStream {
             })
             .try_fields_map(|_, fields| {
                 fn set_header_tokens<T: ToTokens + Spanned>(item: T) -> TokenStream {
-                    quote_spanned!(item.span().into() => __res.set_header(#item);)
+                    quote_spanned!(item.span() => __res.set_header(#item);)
                 }
 
                 let attr = ItemAttr::one_from_attrs("response", fields.parent.attrs())?
@@ -69,7 +69,7 @@ pub fn derive_responder(input: proc_macro::TokenStream) -> TokenStream {
 
                 let responder = fields.iter().next().map(|f| {
                     let (accessor, ty) = (f.accessor(), f.ty.with_stripped_lifetimes());
-                    quote_spanned! { f.span().into() =>
+                    quote_spanned! { f.span() =>
                         let mut __res = <#ty as ::rocket::response::Responder>::respond_to(
                             #accessor, __req
                         )?;
@@ -88,7 +88,7 @@ pub fn derive_responder(input: proc_macro::TokenStream) -> TokenStream {
 
                 let content_type = attr.content_type.map(set_header_tokens);
                 let status = attr.status.map(|status| {
-                    quote_spanned!(status.span().into() => __res.set_status(#status);)
+                    quote_spanned!(status.span() => __res.set_status(#status);)
                 });
 
                 Ok(quote! {

--- a/core/codegen/src/derive/uri_display.rs
+++ b/core/codegen/src/derive/uri_display.rs
@@ -21,7 +21,7 @@ pub fn derive_uri_display_query(input: proc_macro::TokenStream) -> TokenStream {
         .validator(ValidatorBuild::new()
             .enum_validate(|_, data| {
                 if data.variants().count() == 0 {
-                    return Err(data.brace_token.span.error(NO_EMPTY_ENUMS));
+                    Err(data.brace_token.span.error(NO_EMPTY_ENUMS))
                 } else {
                     Ok(())
                 }
@@ -84,13 +84,13 @@ pub fn derive_uri_display_query(input: proc_macro::TokenStream) -> TokenStream {
 
     let from_self = from_uri_param::<fmt::Query>(input.clone(), quote!(Self));
     let from_ref = from_uri_param::<fmt::Query>(input.clone(), quote!(&'__r Self));
-    let from_mut = from_uri_param::<fmt::Query>(input.clone(), quote!(&'__r mut Self));
+    let from_mut = from_uri_param::<fmt::Query>(input, quote!(&'__r mut Self));
 
-    let mut ts = TokenStream::from(uri_display);
-    ts.extend(TokenStream::from(from_self));
-    ts.extend(TokenStream::from(from_ref));
-    ts.extend(TokenStream::from(from_mut));
-    ts.into()
+    let mut ts = uri_display;
+    ts.extend(from_self);
+    ts.extend(from_ref);
+    ts.extend(from_mut);
+    ts
 }
 
 #[allow(non_snake_case)]
@@ -128,13 +128,13 @@ pub fn derive_uri_display_path(input: proc_macro::TokenStream) -> TokenStream {
 
     let from_self = from_uri_param::<fmt::Path>(input.clone(), quote!(Self));
     let from_ref = from_uri_param::<fmt::Path>(input.clone(), quote!(&'__r Self));
-    let from_mut = from_uri_param::<fmt::Path>(input.clone(), quote!(&'__r mut Self));
+    let from_mut = from_uri_param::<fmt::Path>(input, quote!(&'__r mut Self));
 
-    let mut ts = TokenStream::from(uri_display);
-    ts.extend(TokenStream::from(from_self));
-    ts.extend(TokenStream::from(from_ref));
-    ts.extend(TokenStream::from(from_mut));
-    ts.into()
+    let mut ts = uri_display;
+    ts.extend(from_self);
+    ts.extend(from_ref);
+    ts.extend(from_mut);
+    ts
 }
 
 fn from_uri_param<P: fmt::Part>(input: proc_macro::TokenStream, ty: TokenStream) -> TokenStream {

--- a/core/codegen/src/derive/uri_display.rs
+++ b/core/codegen/src/derive/uri_display.rs
@@ -63,7 +63,7 @@ pub fn derive_uri_display_query(input: proc_macro::TokenStream) -> TokenStream {
                 })
             })
             .try_field_map(|_, field| {
-                let span = field.span().into();
+                let span = field.span();
                 let accessor = field.accessor();
                 let tokens = if field.ident.is_some() {
                     let name = field.first_field_name()?;

--- a/core/codegen/src/http_codegen.rs
+++ b/core/codegen/src/http_codegen.rs
@@ -37,7 +37,7 @@ pub struct Asterisk(pub http::uri::Asterisk, pub Span);
 impl FromMeta for Status {
     fn from_meta(meta: &MetaItem) -> Result<Self> {
         let num = usize::from_meta(meta)?;
-        if num < 100 || num >= 600 {
+        if !(100..600).contains(&num) {
             return Err(meta.value_span().error("status must be in range [100, 599]"));
         }
 
@@ -56,7 +56,7 @@ impl FromMeta for ContentType {
     fn from_meta(meta: &MetaItem) -> Result<Self> {
         http::ContentType::parse_flexible(&String::from_meta(meta)?)
             .map(ContentType)
-            .ok_or(meta.value_span().error("invalid or unknown content type"))
+            .ok_or_else(|| meta.value_span().error("invalid or unknown content type"))
     }
 }
 
@@ -71,7 +71,7 @@ impl ToTokens for ContentType {
 impl FromMeta for MediaType {
     fn from_meta(meta: &MetaItem) -> Result<Self> {
         let mt = http::MediaType::parse_flexible(&String::from_meta(meta)?)
-            .ok_or(meta.value_span().error("invalid or unknown media type"))?;
+            .ok_or_else(|| meta.value_span().error("invalid or unknown media type"))?;
 
         if !mt.is_known() {
             // FIXME(diag: warning)

--- a/core/codegen/src/syn_ext.rs
+++ b/core/codegen/src/syn_ext.rs
@@ -203,15 +203,12 @@ impl TypeExt for syn::Type {
                 match ty {
                     Path(t) if self.1.iter().any(|i| t.path.is_ident(*i)) => {
                         self.0 = false;
-                        return;
                     }
                     ImplTrait(_) | Infer(_) | Macro(_) => {
                         self.0 = false;
-                        return;
                     }
                     BareFn(_) | Never(_) => {
                         self.0 = true;
-                        return;
                     },
                     _ => syn::visit::visit_type(self, ty),
                 }

--- a/core/codegen/tests/ui-fail-nightly/responder-types.stderr
+++ b/core/codegen/tests/ui-fail-nightly/responder-types.stderr
@@ -14,7 +14,10 @@ error[E0277]: the trait bound `Header<'_>: From<u8>` is not satisfied
    |
    = help: the following implementations were found:
              <Header<'static> as From<&Cookie<'_>>>
-             <Header<'static> as From<Cookie<'_>>>
+             <Header<'static> as From<&ExpectCt>>
+             <Header<'static> as From<&Frame>>
+             <Header<'static> as From<&Hsts>>
+           and 8 others
    = note: required because of the requirements on the impl of `Into<Header<'_>>` for `u8`
 
 error[E0277]: the trait bound `u8: Responder<'_, '_>` is not satisfied
@@ -33,7 +36,10 @@ error[E0277]: the trait bound `Header<'_>: From<u8>` is not satisfied
    |
    = help: the following implementations were found:
              <Header<'static> as From<&Cookie<'_>>>
-             <Header<'static> as From<Cookie<'_>>>
+             <Header<'static> as From<&ExpectCt>>
+             <Header<'static> as From<&Frame>>
+             <Header<'static> as From<&Hsts>>
+           and 8 others
    = note: required because of the requirements on the impl of `Into<Header<'_>>` for `u8`
 
 error[E0277]: the trait bound `Header<'_>: From<std::string::String>` is not satisfied
@@ -44,7 +50,10 @@ error[E0277]: the trait bound `Header<'_>: From<std::string::String>` is not sat
    |
    = help: the following implementations were found:
              <Header<'static> as From<&Cookie<'_>>>
-             <Header<'static> as From<Cookie<'_>>>
+             <Header<'static> as From<&ExpectCt>>
+             <Header<'static> as From<&Frame>>
+             <Header<'static> as From<&Hsts>>
+           and 8 others
    = note: required because of the requirements on the impl of `Into<Header<'_>>` for `std::string::String`
 
 error[E0277]: the trait bound `usize: Responder<'_, '_>` is not satisfied

--- a/core/codegen/tests/ui-fail-stable/responder-types.stderr
+++ b/core/codegen/tests/ui-fail-stable/responder-types.stderr
@@ -17,7 +17,7 @@ error[E0277]: the trait bound `Header<'_>: From<u8>` is not satisfied
              <Header<'static> as From<&ExpectCt>>
              <Header<'static> as From<&Frame>>
              <Header<'static> as From<&Hsts>>
-           and 7 others
+           and 8 others
    = note: required because of the requirements on the impl of `Into<Header<'_>>` for `u8`
 
 error[E0277]: the trait bound `u8: Responder<'_, '_>` is not satisfied
@@ -39,7 +39,7 @@ error[E0277]: the trait bound `Header<'_>: From<u8>` is not satisfied
              <Header<'static> as From<&ExpectCt>>
              <Header<'static> as From<&Frame>>
              <Header<'static> as From<&Hsts>>
-           and 7 others
+           and 8 others
    = note: required because of the requirements on the impl of `Into<Header<'_>>` for `u8`
 
 error[E0277]: the trait bound `Header<'_>: From<std::string::String>` is not satisfied
@@ -53,7 +53,7 @@ error[E0277]: the trait bound `Header<'_>: From<std::string::String>` is not sat
              <Header<'static> as From<&ExpectCt>>
              <Header<'static> as From<&Frame>>
              <Header<'static> as From<&Hsts>>
-           and 7 others
+           and 8 others
    = note: required because of the requirements on the impl of `Into<Header<'_>>` for `std::string::String`
 
 error[E0277]: the trait bound `usize: Responder<'_, '_>` is not satisfied

--- a/core/codegen/tests/ui-fail-stable/responder-types.stderr
+++ b/core/codegen/tests/ui-fail-stable/responder-types.stderr
@@ -14,7 +14,10 @@ error[E0277]: the trait bound `Header<'_>: From<u8>` is not satisfied
    |
    = help: the following implementations were found:
              <Header<'static> as From<&Cookie<'_>>>
-             <Header<'static> as From<Cookie<'_>>>
+             <Header<'static> as From<&ExpectCt>>
+             <Header<'static> as From<&Frame>>
+             <Header<'static> as From<&Hsts>>
+           and 7 others
    = note: required because of the requirements on the impl of `Into<Header<'_>>` for `u8`
 
 error[E0277]: the trait bound `u8: Responder<'_, '_>` is not satisfied
@@ -33,7 +36,10 @@ error[E0277]: the trait bound `Header<'_>: From<u8>` is not satisfied
    |
    = help: the following implementations were found:
              <Header<'static> as From<&Cookie<'_>>>
-             <Header<'static> as From<Cookie<'_>>>
+             <Header<'static> as From<&ExpectCt>>
+             <Header<'static> as From<&Frame>>
+             <Header<'static> as From<&Hsts>>
+           and 7 others
    = note: required because of the requirements on the impl of `Into<Header<'_>>` for `u8`
 
 error[E0277]: the trait bound `Header<'_>: From<std::string::String>` is not satisfied
@@ -44,7 +50,10 @@ error[E0277]: the trait bound `Header<'_>: From<std::string::String>` is not sat
    |
    = help: the following implementations were found:
              <Header<'static> as From<&Cookie<'_>>>
-             <Header<'static> as From<Cookie<'_>>>
+             <Header<'static> as From<&ExpectCt>>
+             <Header<'static> as From<&Frame>>
+             <Header<'static> as From<&Hsts>>
+           and 7 others
    = note: required because of the requirements on the impl of `Into<Header<'_>>` for `std::string::String`
 
 error[E0277]: the trait bound `usize: Responder<'_, '_>` is not satisfied

--- a/core/codegen/tests/ui-fail-stable/responder.stderr
+++ b/core/codegen/tests/ui-fail-stable/responder.stderr
@@ -215,8 +215,8 @@ error[E0277]: the trait bound `T: Responder<'_, '_>` is not satisfied
    = note: required by `respond_to`
 help: consider further restricting this bound
    |
-57 | #[response(bound = "T: std::fmt::Display" + Responder<'_, '_>)]
-   |                                           ^^^^^^^^^^^^^^^^^^^
+57 | #[response(bound = "T: std::fmt::Display" + rocket::response::Responder<'_, '_>)]
+   |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `T: Responder<'_, '_>` is not satisfied
   --> $DIR/responder.rs:62:19
@@ -227,5 +227,5 @@ error[E0277]: the trait bound `T: Responder<'_, '_>` is not satisfied
    = note: required by `respond_to`
 help: consider further restricting this bound
    |
-61 | #[response(bound = "T: std::fmt::Display" + Responder<'_, '_>)]
-   |                                           ^^^^^^^^^^^^^^^^^^^
+61 | #[response(bound = "T: std::fmt::Display" + rocket::response::Responder<'_, '_>)]
+   |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/core/http/src/header/accept.rs
+++ b/core/http/src/header/accept.rs
@@ -335,15 +335,12 @@ impl QMediaType {
         // 2. Prefer media types with a greater weight, but if one doesn't
         // have a weight, prefer the one we already have.
         match (self.weight(), other.weight()) {
-            (Some(sw), Some(ow)) if (sw - ow).abs() < 0.0001 =>
+            (Some(sw), Some(ow)) if (sw - ow).abs() > 0.0001 =>
                 return sw > ow,
             (Some(_), None) => return false,
             (None, Some(_)) => return true,
             _ => {}
         };
-        if self.weight().is_none() && other.weight().is_none() {
-            return false;
-        }
         // Prefer more specific media types over less specific ones. IE:
         // text/html over application/*.
         if self.specificity() != other.specificity() {

--- a/core/http/src/header/accept.rs
+++ b/core/http/src/header/accept.rs
@@ -158,7 +158,7 @@ impl Accept {
                 // Prefer more specific media types over less specific ones. IE:
                 // text/html over application/*.
                 preferred = media_type;
-            } else if media_type == preferred {
+            } else if media_type != preferred {
                 // Finally, all other things being equal, prefer a media type
                 // with more parameters over one with fewer. IE: text/html; a=b
                 // over text/html.
@@ -210,7 +210,7 @@ impl Accept {
     /// assert_eq!(iter.next(), None);
     /// ```
     #[inline(always)]
-    pub fn iter<'a>(&'a self) -> impl Iterator<Item=&'a QMediaType> + 'a {
+    pub fn iter(&self) -> impl Iterator<Item=&'_ QMediaType> + '_ {
         match self.0 {
             AcceptParams::Static(ref val) => Either::Left(Some(val).into_iter()),
             AcceptParams::Dynamic(ref vec) => Either::Right(vec.iter())
@@ -239,7 +239,7 @@ impl Accept {
     /// assert_eq!(iter.next(), None);
     /// ```
     #[inline(always)]
-    pub fn media_types<'a>(&'a self) -> impl Iterator<Item=&'a MediaType> + 'a {
+    pub fn media_types(&self) -> impl Iterator<Item=&'_ MediaType> + '_ {
         self.iter().map(|weighted_mt| weighted_mt.media_type())
     }
 
@@ -285,10 +285,10 @@ impl FromStr for Accept {
 
 /// Creates a new `Header` with name `Accept` and the value set to the HTTP
 /// rendering of this `Accept` header.
-impl Into<Header<'static>> for Accept {
+impl From<Accept> for Header<'static> {
     #[inline(always)]
-    fn into(self) -> Header<'static> {
-        Header::new("Accept", self.to_string())
+    fn from(val: Accept) -> Self {
+        Header::new("Accept", val.to_string())
     }
 }
 

--- a/core/http/src/header/accept.rs
+++ b/core/http/src/header/accept.rs
@@ -147,8 +147,26 @@ impl Accept {
         let mut all = self.iter();
         let mut preferred = all.next().unwrap_or(&ANY);
         for media_type in all {
-            if media_type.better_than(preferred) {
+            /*if media_type.better_than(preferred) {
                 preferred = media_type;
+            }*/
+            if media_type.weight().is_none() && preferred.weight().is_some() {
+                // Media types without a `q` parameter are preferred.
+            } else if media_type.weight_or(0.0) > preferred.weight_or(1.0) {
+                // Prefer media types with a greater weight, but if one doesn't
+                // have a weight, prefer the one we already have.
+                preferred = media_type;
+            } else if media_type.specificity() > preferred.specificity() {
+                // Prefer more specific media types over less specific ones. IE:
+                // text/html over application/*.
+                preferred = media_type;
+            } else if media_type == preferred {
+                // Finally, all other things being equal, prefer a media type
+                // with more parameters over one with fewer. IE: text/html; a=b
+                // over text/html.
+                if media_type.params().count() > preferred.params().count() {
+                    preferred = media_type;
+                }
             }
         }
 
@@ -326,30 +344,6 @@ impl QMediaType {
     #[inline(always)]
     pub fn media_type(&self) -> &MediaType {
         &self.0
-    }
-
-    // this is not impl Ord because we depend on argument order
-    pub(crate) fn better_than(&self, other: &QMediaType) -> bool {
-        // Check `q` parameter:
-        // 1. Media types without a `q` parameter are preferred.
-        // 2. Prefer media types with a greater weight, but if one doesn't
-        // have a weight, prefer the one we already have.
-        match (self.weight(), other.weight()) {
-            (Some(sw), Some(ow)) if (sw - ow).abs() > 0.0001 =>
-                return sw > ow,
-            (Some(_), None) => return false,
-            (None, Some(_)) => return true,
-            _ => {}
-        };
-        // Prefer more specific media types over less specific ones. IE:
-        // text/html over application/*.
-        if self.specificity() != other.specificity() {
-            return self.specificity() > other.specificity();
-        }
-        // Finally, all other things being equal, prefer a media type
-        // with more parameters over one with fewer. IE: text/html; a=b
-        // over text/html.
-        self.params().count() > other.params().count()
     }
 }
 

--- a/core/http/src/header/accept.rs
+++ b/core/http/src/header/accept.rs
@@ -147,9 +147,6 @@ impl Accept {
         let mut all = self.iter();
         let mut preferred = all.next().unwrap_or(&ANY);
         for media_type in all {
-            /*if media_type.better_than(preferred) {
-                preferred = media_type;
-            }*/
             if media_type.weight().is_none() && preferred.weight().is_some() {
                 // Media types without a `q` parameter are preferred.
                 preferred = media_type;

--- a/core/http/src/header/accept.rs
+++ b/core/http/src/header/accept.rs
@@ -152,6 +152,7 @@ impl Accept {
             }*/
             if media_type.weight().is_none() && preferred.weight().is_some() {
                 // Media types without a `q` parameter are preferred.
+                preferred = media_type;
             } else if media_type.weight_or(0.0) > preferred.weight_or(1.0) {
                 // Prefer media types with a greater weight, but if one doesn't
                 // have a weight, prefer the one we already have.

--- a/core/http/src/header/content_type.rs
+++ b/core/http/src/header/content_type.rs
@@ -382,13 +382,13 @@ impl fmt::Display for ContentType {
 
 /// Creates a new `Header` with name `Content-Type` and the value set to the
 /// HTTP rendering of this Content-Type.
-impl Into<Header<'static>> for ContentType {
+impl From<ContentType> for Header<'static> {
     #[inline(always)]
-    fn into(self) -> Header<'static> {
-        if let Some(src) = self.known_source() {
+    fn from(ctype: ContentType) -> Self {
+        if let Some(src) = ctype.known_source() {
             Header::new("Content-Type", src)
         } else {
-            Header::new("Content-Type", self.to_string())
+            Header::new("Content-Type", ctype.to_string())
         }
     }
 }

--- a/core/http/src/header/media_type.rs
+++ b/core/http/src/header/media_type.rs
@@ -546,7 +546,7 @@ impl MediaType {
     /// assert_eq!(png.params().count(), 0);
     /// ```
     #[inline]
-    pub fn params<'a>(&'a self) -> impl Iterator<Item=(&'a UncasedStr, &'a str)> + 'a {
+    pub fn params(&self) -> impl Iterator<Item=(&'_ UncasedStr, &'_ str)> + '_ {
         let raw = match self.params {
             MediaParams::Static(ref slice) => Either::Left(slice.iter().cloned()),
             MediaParams::Dynamic(ref vec) => {

--- a/core/http/src/parse/indexed.rs
+++ b/core/http/src/parse/indexed.rs
@@ -49,7 +49,7 @@ impl<A, T: ?Sized + ToOwned> From<Extent<A>> for Indexed<'_, T> {
 impl<'a, T: ?Sized + ToOwned + 'a> From<Cow<'a, T>> for Indexed<'a, T> {
     #[inline(always)]
     fn from(value: Cow<'a, T>) -> Indexed<'a, T> {
-        Indexed::Concrete(value.into())
+        Indexed::Concrete(value)
     }
 }
 

--- a/core/http/src/parse/uri/error.rs
+++ b/core/http/src/parse/uri/error.rs
@@ -21,7 +21,7 @@ pub struct Error<'a> {
 #[doc(hidden)]
 impl<'a> From<ParseError<RawInput<'a>>> for Error<'a> {
     fn from(inner: ParseError<RawInput<'a>>) -> Self {
-        let expected = inner.error.map(|t| t.into(), |v| v.values.into());
+        let expected = inner.error.map(std::convert::identity, |v| v.values.into());
         Error { expected, index: inner.info.context.start }
     }
 }

--- a/core/http/src/parse/uri/parser.rs
+++ b/core/http/src/parse/uri/parser.rs
@@ -52,7 +52,7 @@ pub fn asterisk<'a>(input: &mut RawInput<'a>) -> Result<'a, Asterisk> {
 #[parser]
 pub fn origin<'a>(input: &mut RawInput<'a>) -> Result<'a, Origin<'a>> {
     let (_, path, query) = (peek(b'/')?, path()?, query()?);
-    unsafe { Origin::raw(input.start.into(), path.into(), query) }
+    unsafe { Origin::raw(input.start.into(), path, query) }
 }
 
 #[parser]

--- a/core/http/src/raw_str.rs
+++ b/core/http/src/raw_str.rs
@@ -114,7 +114,7 @@ impl RawStr {
     /// let cow_raw = RawStr::from_cow_str(cow_str);
     /// assert_eq!(cow_raw.as_str(), "hello!");
     /// ```
-    pub fn from_cow_str<'a>(cow: Cow<'a, str>) -> Cow<'a, RawStr> {
+    pub fn from_cow_str(cow: Cow<'_, str>) -> Cow<'_, RawStr> {
         match cow {
             Cow::Borrowed(b) => Cow::Borrowed(b.into()),
             Cow::Owned(b) => Cow::Owned(b.into()),
@@ -136,7 +136,7 @@ impl RawStr {
     /// let cow_str = RawStr::into_cow_str(cow_raw);
     /// assert_eq!(&*cow_str, "hello!");
     /// ```
-    pub fn into_cow_str<'a>(cow: Cow<'a, RawStr>) -> Cow<'a, str> {
+    pub fn into_cow_str(cow: Cow<'_, RawStr>) -> Cow<'_, str> {
         match cow {
             Cow::Borrowed(b) => Cow::Borrowed(b.as_str()),
             Cow::Owned(b) => Cow::Owned(b.into_string()),

--- a/core/http/src/uri/fmt/from_uri_param.rs
+++ b/core/http/src/uri/fmt/from_uri_param.rs
@@ -351,7 +351,7 @@ impl<A, T: FromUriParam<fmt::Query, A>> FromUriParam<fmt::Query, Option<A>> for 
 
     #[inline(always)]
     fn from_uri_param(param: Option<A>) -> Self::Target {
-        param.map(|a| T::from_uri_param(a))
+        param.map(T::from_uri_param)
     }
 }
 

--- a/core/http/src/uri/fmt/from_uri_param.rs
+++ b/core/http/src/uri/fmt/from_uri_param.rs
@@ -360,7 +360,7 @@ impl<A, E, T: FromUriParam<fmt::Query, A>> FromUriParam<fmt::Query, Option<A>> f
 
     #[inline(always)]
     fn from_uri_param(param: Option<A>) -> Self::Target {
-        param.map(|a| T::from_uri_param(a))
+        param.map(T::from_uri_param)
     }
 }
 
@@ -369,7 +369,7 @@ impl<A, E, T: FromUriParam<fmt::Query, A>> FromUriParam<fmt::Query, Result<A, E>
 
     #[inline(always)]
     fn from_uri_param(param: Result<A, E>) -> Self::Target {
-        param.map(|a| T::from_uri_param(a))
+        param.map(T::from_uri_param)
     }
 }
 
@@ -378,6 +378,6 @@ impl<A, E, T: FromUriParam<fmt::Query, A>> FromUriParam<fmt::Query, Result<A, E>
 
     #[inline(always)]
     fn from_uri_param(param: Result<A, E>) -> Self::Target {
-        param.map(|a| T::from_uri_param(a))
+        param.map(T::from_uri_param)
     }
 }

--- a/core/http/src/uri/path_query.rs
+++ b/core/http/src/uri/path_query.rs
@@ -59,7 +59,7 @@ fn decode_to_indexed_str<P: fmt::Part>(
         Cow::Borrowed(b) if indexed.is_indexed() => {
             let indexed = IndexedStr::checked_from(b, source.as_str());
             debug_assert!(indexed.is_some());
-            indexed.unwrap_or(IndexedStr::from(Cow::Borrowed("")))
+            indexed.unwrap_or_else(|| IndexedStr::from(Cow::Borrowed("")))
         }
         cow => IndexedStr::from(Cow::Owned(cow.into_owned())),
     }

--- a/core/http/src/uri/reference.rs
+++ b/core/http/src/uri/reference.rs
@@ -92,7 +92,7 @@ impl<'a> Reference<'a> {
         Reference {
             source: Some(as_utf8_unchecked(source)),
             scheme: scheme.map(|s| s.into()),
-            authority: authority.map(|s| s.into()),
+            authority,
             path: Data::raw(path),
             query: query.map(Data::raw),
             fragment: fragment.map(|f| f.into()),

--- a/core/http/src/uri/segments.rs
+++ b/core/http/src/uri/segments.rs
@@ -154,7 +154,7 @@ impl<'a> Segments<'a, Path> {
     /// assert!(b.path().segments().skip(1).prefix_of(a.path().segments()));
     /// ```
     #[inline]
-    pub fn prefix_of<'b>(self, other: Segments<'b, Path>) -> bool {
+    pub fn prefix_of(self, other: Segments<'_, Path>) -> bool {
         if self.len() > other.len() {
             return false;
         }

--- a/core/lib/build.rs
+++ b/core/lib/build.rs
@@ -14,8 +14,8 @@ fn main() {
             panic!("Aborting compilation due to incompatible compiler.")
         }
     } else {
-        println!("cargo:warning={}", "Rocket was unable to check rustc compiler compatibility.");
-        println!("cargo:warning={}", "Build may fail due to incompatible rustc version.");
+        println!("cargo:warning=Rocket was unable to check rustc compiler compatibility.");
+        println!("cargo:warning=Build may fail due to incompatible rustc version.");
     }
 
     if let Some(true) = version_check::is_feature_flaggable() {

--- a/core/lib/build.rs
+++ b/core/lib/build.rs
@@ -3,14 +3,14 @@
 use yansi::{Paint, Color::{Red, Yellow}};
 
 fn main() {
-    const MIN_VERSION: &'static str = "1.46.0";
+    const MIN_VERSION: &str = "1.46.0";
 
     if let Some(version) = version_check::Version::read() {
         if !version.at_least(MIN_VERSION) {
             let msg = "Rocket requires a more recent version of rustc.";
             eprintln!("{} {}", Red.paint("Error:").bold(), Paint::new(msg).bold());
-            eprintln!("Installed version: {}", Yellow.paint(format!("{}", version)));
-            eprintln!("Minimum required:  {}", Yellow.paint(format!("{}", MIN_VERSION)));
+            eprintln!("Installed version: {}", Yellow.paint(version));
+            eprintln!("Minimum required:  {}", Yellow.paint(MIN_VERSION));
             panic!("Aborting compilation due to incompatible compiler.")
         }
     } else {

--- a/core/lib/src/catcher/catcher.rs
+++ b/core/lib/src/catcher/catcher.rs
@@ -159,7 +159,7 @@ impl Catcher {
     {
         let code = code.into();
         if let Some(code) = code {
-            assert!(code >= 400 && code < 600);
+            assert!((400..600).contains(&code));
         }
 
         Catcher {

--- a/core/lib/src/config/tls.rs
+++ b/core/lib/src/config/tls.rs
@@ -70,8 +70,8 @@ impl TlsConfig {
     /// ```
     pub fn from_bytes(certs: &[u8], key: &[u8]) -> Self {
         TlsConfig {
-            certs: Either::Right(certs.to_vec().into()),
-            key: Either::Right(key.to_vec().into())
+            certs: Either::Right(certs.to_vec()),
+            key: Either::Right(key.to_vec())
         }
     }
 

--- a/core/lib/src/cookies.rs
+++ b/core/lib/src/cookies.rs
@@ -259,15 +259,15 @@ impl<'a> CookieJar<'a> {
     /// ```
     pub fn get_pending(&self, name: &str) -> Option<Cookie<'static>> {
         let ops = self.ops.lock();
-        for op in ops.iter().rev().filter(|op| op.cookie().name() == name) {
-            match op {
-                Op::Add(c, _) => return Some(c.clone()),
-                Op::Remove(_, _) => return None,
+        let last_op = ops.iter().rev().find(|op| op.cookie().name() == name);
+        match last_op {
+            Some(Op::Add(c, _)) => Some(c.clone()),
+            Some(Op::Remove(_, _)) => None,
+            None => {
+                drop(ops);
+                self.get(name).cloned()
             }
         }
-
-        drop(ops);
-        self.get(name).map(|c| c.clone())
     }
 
     /// Retrives the _original or pending_ `Cookie` inside this collection with

--- a/core/lib/src/cookies.rs
+++ b/core/lib/src/cookies.rs
@@ -267,7 +267,7 @@ impl<'a> CookieJar<'a> {
         }
 
         drop(ops);
-        self.get(name).map(|c| c.clone())
+        self.get(name).cloned()
     }
 
     /// Retrives the _original or pending_ `Cookie` inside this collection with

--- a/core/lib/src/cookies.rs
+++ b/core/lib/src/cookies.rs
@@ -448,7 +448,7 @@ impl<'a> CookieJar<'a> {
     /// TODO: This could be faster by just returning the cookies directly via
     /// an ordered hash-set of sorts.
     pub(crate) fn take_delta_jar(&self) -> cookie::CookieJar {
-        let ops = std::mem::replace(&mut *self.ops.lock(), Vec::new());
+        let ops = std::mem::take(&mut *self.ops.lock());
         let mut jar = cookie::CookieJar::new();
 
         for op in ops {

--- a/core/lib/src/cookies.rs
+++ b/core/lib/src/cookies.rs
@@ -259,15 +259,15 @@ impl<'a> CookieJar<'a> {
     /// ```
     pub fn get_pending(&self, name: &str) -> Option<Cookie<'static>> {
         let ops = self.ops.lock();
-        let last_op = ops.iter().rev().find(|op| op.cookie().name() == name);
-        match last_op {
-            Some(Op::Add(c, _)) => Some(c.clone()),
-            Some(Op::Remove(_, _)) => None,
-            None => {
-                drop(ops);
-                self.get(name).cloned()
+        for op in ops.iter().rev().filter(|op| op.cookie().name() == name) {
+            match op {
+                Op::Add(c, _) => return Some(c.clone()),
+                Op::Remove(_, _) => return None,
             }
         }
+
+        drop(ops);
+        self.get(name).map(|c| c.clone())
     }
 
     /// Retrives the _original or pending_ `Cookie` inside this collection with

--- a/core/lib/src/data/limits.rs
+++ b/core/lib/src/data/limits.rs
@@ -203,7 +203,7 @@ impl Limits {
         let name = name.into();
         match self.limits.binary_search_by(|(k, _)| k.cmp(&name)) {
             Ok(i) => self.limits[i].1 = limit,
-            Err(i) => self.limits.insert(i, (name.into(), limit))
+            Err(i) => self.limits.insert(i, (name, limit))
         }
 
         self

--- a/core/lib/src/fairing/fairings.rs
+++ b/core/lib/src/fairing/fairings.rs
@@ -84,7 +84,7 @@ impl Fairings {
                 .collect();
 
             // Reverse the dup indices so `remove` is stable given shifts.
-            dups.sort(); dups.dedup(); dups.reverse();
+            dups.sort_unstable(); dups.dedup(); dups.reverse();
             for i in dups {
                 remove(i, &mut self.ignite);
                 remove(i, &mut self.liftoff);

--- a/core/lib/src/form/error.rs
+++ b/core/lib/src/form/error.rs
@@ -719,7 +719,6 @@ impl<'v> Error<'v> {
             | Multipart(FieldSizeExceeded { .. })
             | Multipart(StreamSizeExceeded { .. }) => Status::PayloadTooLarge,
             Unknown => Status::InternalServerError,
-            // FIXME: is this intended behavior?
             Io(_) => Status::BadRequest,
             _ if self.entity == Entity::Form => Status::BadRequest,
             _ => Status::UnprocessableEntity

--- a/core/lib/src/form/error.rs
+++ b/core/lib/src/form/error.rs
@@ -719,7 +719,9 @@ impl<'v> Error<'v> {
             | Multipart(FieldSizeExceeded { .. })
             | Multipart(StreamSizeExceeded { .. }) => Status::PayloadTooLarge,
             Unknown => Status::InternalServerError,
-            Io(_) | _ if self.entity == Entity::Form => Status::BadRequest,
+            // FIXME: is this intended behavior?
+            Io(_) => Status::BadRequest,
+            _ if self.entity == Entity::Form => Status::BadRequest,
             _ => Status::UnprocessableEntity
         }
     }
@@ -812,9 +814,9 @@ impl fmt::Display for ErrorKind<'_> {
                 }
             }
             ErrorKind::InvalidChoice { choices } => {
-                match choices.as_ref() {
-                    &[] => write!(f, "invalid choice")?,
-                    &[ref choice] => write!(f, "expected {}", choice)?,
+                match *choices.as_ref() {
+                    [] => write!(f, "invalid choice")?,
+                    [ref choice] => write!(f, "expected {}", choice)?,
                     _ => {
                         write!(f, "expected one of ")?;
                         for (i, choice) in choices.iter().enumerate() {

--- a/core/lib/src/form/error.rs
+++ b/core/lib/src/form/error.rs
@@ -719,7 +719,6 @@ impl<'v> Error<'v> {
             | Multipart(FieldSizeExceeded { .. })
             | Multipart(StreamSizeExceeded { .. }) => Status::PayloadTooLarge,
             Unknown => Status::InternalServerError,
-            Io(_) => Status::BadRequest,
             _ if self.entity == Entity::Form => Status::BadRequest,
             _ => Status::UnprocessableEntity
         }

--- a/core/lib/src/form/from_form.rs
+++ b/core/lib/src/form/from_form.rs
@@ -794,8 +794,8 @@ impl<'v, K, V> FromForm<'v> for BTreeMap<K, V>
 impl<'v, T: FromForm<'v>> FromForm<'v> for Option<T> {
     type Context = <T as FromForm<'v>>::Context;
 
-    fn init(opts: Options) -> Self::Context {
-        T::init(Options { strict: true, ..opts })
+    fn init(_opts: Options) -> Self::Context {
+        T::init(Options { strict: true })
     }
 
     fn push_value(ctxt: &mut Self::Context, field: ValueField<'v>) {

--- a/core/lib/src/form/lenient.rs
+++ b/core/lib/src/form/lenient.rs
@@ -78,8 +78,8 @@ impl<'v, T: FromForm<'v>> FromForm<'v> for Lenient<T> {
     type Context = T::Context;
 
     #[inline(always)]
-    fn init(opts: Options) -> Self::Context {
-        T::init(Options { strict: false, ..opts })
+    fn init(_opts: Options) -> Self::Context {
+        T::init(Options { strict: false })
     }
 
     #[inline(always)]

--- a/core/lib/src/form/name/view.rs
+++ b/core/lib/src/form/name/view.rs
@@ -154,7 +154,7 @@ impl<'v> NameView<'v> {
     /// assert_eq!(view.key(), None);
     /// ```
     pub fn shift(&mut self) {
-        const START_DELIMS: &'static [char] = &['.', '['];
+        const START_DELIMS: &[char] = &['.', '['];
 
         let string = &self.name[self.end..];
         let bytes = string.as_bytes();

--- a/core/lib/src/form/parser.rs
+++ b/core/lib/src/form/parser.rs
@@ -213,7 +213,7 @@ impl Buffer {
         }
     }
 
-    pub fn push_one<'a, S: Into<String>>(&'a self, string: S) -> &'a str {
+    pub fn push_one<S: Into<String>>(&self, string: S) -> &str {
         // SAFETY:
         //   * Aliasing: We retrieve a mutable reference to the last slot (via
         //     `push()`) and then return said reference as immutable; these

--- a/core/lib/src/form/strict.rs
+++ b/core/lib/src/form/strict.rs
@@ -93,8 +93,8 @@ impl<'v, T: FromForm<'v>> FromForm<'v> for Strict<T> {
     type Context = T::Context;
 
     #[inline(always)]
-    fn init(opts: Options) -> Self::Context {
-        T::init(Options { strict: true, ..opts })
+    fn init(_opts: Options) -> Self::Context {
+        T::init(Options { strict: true })
     }
 
     #[inline(always)]

--- a/core/lib/src/form/validate.rs
+++ b/core/lib/src/form/validate.rs
@@ -329,7 +329,7 @@ impl<L, T: Len<L> + ?Sized> Len<L> for &T {
 }
 
 impl<L, T: Len<L>> Len<L> for Option<T> {
-    fn len(&self) -> L { self.as_ref().map(|v| v.len()).unwrap_or(T::zero_len()) }
+    fn len(&self) -> L { self.as_ref().map(|v| v.len()).unwrap_or_else(T::zero_len) }
     fn len_into_u64(len: L) -> u64 { T::len_into_u64(len) }
     fn zero_len() -> L { T::zero_len() }
 }

--- a/core/lib/src/fs/file_name.rs
+++ b/core/lib/src/fs/file_name.rs
@@ -154,7 +154,7 @@ impl FileName {
         let file_name = std::path::Path::new(&self.0)
             .file_name()
             .and_then(|n| n.to_str())
-            .and_then(|n| n.split(bad_char).filter(|s| !s.is_empty()).next())?;
+            .and_then(|n| n.split(bad_char).find(|s| !s.is_empty()))?;
 
         // At this point, `file_name` can't contain `bad_chars` because of
         // `.split()`, but it can be empty or reserved.

--- a/core/lib/src/fs/server.rs
+++ b/core/lib/src/fs/server.rs
@@ -173,10 +173,10 @@ impl FileServer {
     }
 }
 
-impl Into<Vec<Route>> for FileServer {
-    fn into(self) -> Vec<Route> {
-        let source = figment::Source::File(self.root.clone());
-        let mut route = Route::ranked(self.rank, Method::Get, "/<path..>", self);
+impl From<FileServer> for Vec<Route> {
+    fn from(server: FileServer) -> Self {
+        let source = figment::Source::File(server.root.clone());
+        let mut route = Route::ranked(server.rank, Method::Get, "/<path..>", server);
         route.name = Some(format!("FileServer: {}/", source).into());
         vec![route]
     }

--- a/core/lib/src/local/asynchronous/client.rs
+++ b/core/lib/src/local/asynchronous/client.rs
@@ -60,7 +60,7 @@ impl Client {
     ) -> Result<Client, Error> {
         let rocket = rocket.local_launch().await?;
         let cookies = RwLock::new(cookie::CookieJar::new());
-        Ok(Client { rocket, tracked, cookies })
+        Ok(Client { rocket, cookies, tracked })
     }
 
     // WARNING: This is unstable! Do not use this method outside of Rocket!

--- a/core/lib/src/local/client.rs
+++ b/core/lib/src/local/client.rs
@@ -114,7 +114,7 @@ macro_rules! pub_client_impl {
 
     /// Deprecated alias to [`Client::tracked()`].
     #[deprecated(
-        since = "0.5",
+        since = "0.5.0",
         note = "choose between `Client::untracked()` and `Client::tracked()`"
     )]
     pub $($prefix)? fn new<P: Phase>(rocket: Rocket<P>) -> Result<Self, Error> {

--- a/core/lib/src/request/request.rs
+++ b/core/lib/src/request/request.rs
@@ -47,7 +47,7 @@ impl Request<'_> {
             method: Atomic::new(self.method()),
             uri: self.uri.clone(),
             headers: self.headers.clone(),
-            remote: self.remote.clone(),
+            remote: self.remote,
             state: self.state.clone(),
         }
     }
@@ -837,12 +837,12 @@ impl<'r> Request<'r> {
     ) -> Result<Request<'r>, Error<'r>> {
         // Ensure that the method is known. TODO: Allow made-up methods?
         let method = Method::from_hyp(&hyper.method)
-            .ok_or_else(|| Error::BadMethod(&hyper.method))?;
+            .ok_or(Error::BadMethod(&hyper.method))?;
 
         // In debug, make sure we agree with Hyper. Otherwise, cross our fingers
         // and trust that it only gives us valid URIs like it's supposed to.
         // TODO: Keep around not just the path/query, but the rest, if there?
-        let uri = hyper.uri.path_and_query().ok_or_else(|| Error::InvalidUri(&hyper.uri))?;
+        let uri = hyper.uri.path_and_query().ok_or(Error::InvalidUri(&hyper.uri))?;
         debug_assert!(Origin::parse(uri.as_str()).is_ok());
         let uri = Origin::new(uri.path(), uri.query().map(Cow::Borrowed));
 

--- a/core/lib/src/response/body.rs
+++ b/core/lib/src/response/body.rs
@@ -132,7 +132,7 @@ impl<'r> Body<'r> {
     }
 
     pub(crate) fn strip(&mut self) {
-        let body = std::mem::replace(self, Body::default());
+        let body = std::mem::take(self);
         *self = match body.inner {
             Inner::Seekable(b) | Inner::Phantom(b) => Body {
                 size: body.size,
@@ -322,7 +322,7 @@ impl<'r> Body<'r> {
     /// ```
     #[inline(always)]
     pub fn take(&mut self) -> Self {
-        std::mem::replace(self, Body::default())
+        std::mem::take(self)
     }
 
     /// Reads all of `self` into a vector of bytes, consuming the contents.

--- a/core/lib/src/response/stream/raw_sse.rs
+++ b/core/lib/src/response/stream/raw_sse.rs
@@ -177,7 +177,7 @@ fn skip<T: AsRef<[u8]> + Unpin>(buf: &mut Take<Cursor<T>>) {
                 buf.get_mut().set_position(pos + 1);
             }
         }
-        _ => return,
+        _ => {}
     }
 }
 

--- a/core/lib/src/response/stream/sse.rs
+++ b/core/lib/src/response/stream/sse.rs
@@ -323,7 +323,7 @@ impl Event {
             Some(RawLinedEvent::raw("")),
         ];
 
-        stream::iter(array::IntoIter::new(events)).filter_map(|v| ready(v))
+        stream::iter(array::IntoIter::new(events)).filter_map(ready)
     }
 }
 

--- a/core/lib/src/rocket.rs
+++ b/core/lib/src/rocket.rs
@@ -488,7 +488,7 @@ impl Rocket<Build> {
 
             if config.secret_key.is_zero() {
                 config.secret_key = crate::config::SecretKey::generate()
-                    .unwrap_or(crate::config::SecretKey::zero());
+                    .unwrap_or_else(crate::config::SecretKey::zero);
             }
         };
 

--- a/core/lib/src/route/uri.rs
+++ b/core/lib/src/route/uri.rs
@@ -123,7 +123,7 @@ impl<'a> RouteUri<'a> {
         let source = origin.to_string().into();
         let metadata = Metadata::from(&base, &origin);
 
-        Ok(RouteUri { source, unmounted_origin, base, origin, metadata })
+        Ok(RouteUri { source, base, unmounted_origin, origin, metadata })
     }
 
     /// Create a new `RouteUri`.
@@ -287,8 +287,8 @@ impl Metadata {
         let trailing_path = path_segs.last().map_or(false, |p| p.trailing);
 
         Metadata {
-            static_query_fields, path_color, query_color, trailing_path,
-            path_segs, query_segs, base_segs,
+            base_segs, path_segs, query_segs, static_query_fields,
+            path_color, query_color, trailing_path,
         }
     }
 }

--- a/core/lib/src/server.rs
+++ b/core/lib/src/server.rs
@@ -93,7 +93,7 @@ async fn hyper_service_fn(
 
         // Dispatch the request to get a response, then write that response out.
         let token = rocket.preprocess_request(&mut req, &mut data).await;
-        let r = rocket.dispatch(token, &mut req, data).await;
+        let r = rocket.dispatch(token, &req, data).await;
         rocket.send_response(r, tx).await;
     });
 
@@ -276,7 +276,7 @@ impl Rocket<Orbit> {
 
             let name = route.name.as_deref();
             let outcome = handle(name, || route.handler.handle(request, data)).await
-                .unwrap_or_else(|| Outcome::Failure(Status::InternalServerError));
+                .unwrap_or(Outcome::Failure(Status::InternalServerError));
 
             // Check if the request processing completed (Some) or if the
             // request needs to be forwarded. If it does, continue the loop

--- a/core/lib/src/shield/policy.rs
+++ b/core/lib/src/shield/policy.rs
@@ -156,9 +156,9 @@ impl Default for Referrer {
     }
 }
 
-impl Into<Header<'static>> for &Referrer {
-    fn into(self) -> Header<'static> {
-        let policy_string = match self {
+impl From<&Referrer> for Header<'static> {
+    fn from(referrer: &Referrer) -> Self {
+        let policy_string = match referrer {
             Referrer::NoReferrer => "no-referrer",
             Referrer::NoReferrerWhenDowngrade => "no-referrer-when-downgrade",
             Referrer::Origin => "origin",
@@ -217,9 +217,9 @@ impl Default for ExpectCt {
     }
 }
 
-impl Into<Header<'static>> for &ExpectCt {
-    fn into(self) -> Header<'static> {
-        let policy_string =  match self {
+impl From<&ExpectCt> for Header<'static> {
+    fn from(expect: &ExpectCt) -> Self {
+        let policy_string =  match expect {
             ExpectCt::Enforce(age) => format!("max-age={}, enforce", age.whole_seconds()),
             ExpectCt::Report(age, uri) => {
                 format!(r#"max-age={}, report-uri="{}""#, age.whole_seconds(), uri)
@@ -251,8 +251,8 @@ impl Default for NoSniff {
     }
 }
 
-impl Into<Header<'static>> for &NoSniff {
-    fn into(self) -> Header<'static> {
+impl From<&NoSniff> for Header<'static> {
+    fn from(_: &NoSniff) -> Self {
         Header::new(NoSniff::NAME, "nosniff")
     }
 }
@@ -301,9 +301,9 @@ impl Default for Hsts {
     }
 }
 
-impl Into<Header<'static>> for &Hsts {
-    fn into(self) -> Header<'static> {
-        if self == &Hsts::default() {
+impl From<&Hsts> for Header<'static> {
+    fn from(hsts: &Hsts) -> Self {
+        if hsts == &Hsts::default() {
             static DEFAULT: Header<'static> = Header {
                 name: Uncased::from_borrowed(Hsts::NAME),
                 value: Cow::Borrowed("max-age=31536000")
@@ -312,7 +312,7 @@ impl Into<Header<'static>> for &Hsts {
             return DEFAULT.clone();
         }
 
-        let policy_string = match self {
+        let policy_string = match hsts {
             Hsts::Enable(age) => format!("max-age={}", age.whole_seconds()),
             Hsts::IncludeSubDomains(age) => {
                 format!("max-age={}; includeSubDomains", age.whole_seconds())
@@ -353,9 +353,9 @@ impl Default for Frame {
     }
 }
 
-impl Into<Header<'static>> for &Frame {
-    fn into(self) -> Header<'static> {
-        let policy_string: &'static str = match self {
+impl From<&Frame> for Header<'static> {
+    fn from(frame: &Frame) -> Self {
+        let policy_string: &'static str = match frame {
             Frame::Deny => "DENY",
             Frame::SameOrigin => "SAMEORIGIN",
         };
@@ -389,9 +389,9 @@ impl Default for XssFilter {
     }
 }
 
-impl Into<Header<'static>> for &XssFilter {
-    fn into(self) -> Header<'static> {
-        let policy_string: &'static str = match self {
+impl From<&XssFilter> for Header<'static> {
+    fn from(filter: &XssFilter) -> Self {
+        let policy_string: &'static str = match filter {
             XssFilter::Disable => "0",
             XssFilter::Enable => "1",
             XssFilter::EnableBlock => "1; mode=block",
@@ -423,9 +423,9 @@ impl Default for Prefetch {
     }
 }
 
-impl Into<Header<'static>> for &Prefetch {
-    fn into(self) -> Header<'static> {
-        let policy_string = match self {
+impl From<&Prefetch> for Header<'static> {
+    fn from(prefetch: &Prefetch) -> Self {
+        let policy_string = match prefetch {
             Prefetch::On => "on",
             Prefetch::Off => "off",
         };
@@ -645,9 +645,9 @@ impl Permission {
     }
 }
 
-impl Into<Header<'static>> for &Permission {
-    fn into(self) -> Header<'static> {
-        if self == &Permission::default() {
+impl From<&Permission> for Header<'static> {
+    fn from(perm: &Permission) -> Self {
+        if perm == &Permission::default() {
             static DEFAULT: Header<'static> = Header {
                 name: Uncased::from_borrowed(Permission::NAME),
                 value: Cow::Borrowed("interest-cohort=()")
@@ -656,7 +656,7 @@ impl Into<Header<'static>> for &Permission {
             return DEFAULT.clone();
         }
 
-        let value = self.0.iter()
+        let value = perm.0.iter()
             .map(|(feature, allow)| {
                 let list = allow.as_ref()
                     .into_iter()


### PR DESCRIPTION
This pull request mostly just makes Clippy a bit happier (hopefully not hurting code readability), but it also contains two changes:
1. Several `Into` implementations are now `From` implementations. Makes UI errors a bit longer, so I'll roll back this change if needed.
2. Please, review `Accept::preferred`. I think the old implementation had a bug, and I'm not sure if the new one is correct.