### PR TITLE
Fix the link to the JSON example in the docs

### DIFF
--- a/site/guide/4-requests.md
+++ b/site/guide/4-requests.md
@@ -678,9 +678,7 @@ struct Task<'r> {
 fn new(task: Json<Task<'_>>) { /* .. */ }
 ```
 
-See the [JSON example] on GitHub for a complete example.
-
-[JSON example]: @example/json
+See the [JSON example](@example/serialization/src/json.rs) on GitHub for a complete example.
 
 ### Temporary Files
 


### PR DESCRIPTION
In the docs, the link to the JSON example is broken. My guess is you folded it into the serialization example. I changed the link to point to the JSON file in the example.

If you would like me to instead change the copy so that it specifies that file and link the user to the root of the serialization example, I am happy to make that modification.