### PR TITLE
site: prevent an unused Result warning

### DIFF
--- a/site/guide/3-overview.md
+++ b/site/guide/3-overview.md
@@ -213,7 +213,8 @@ async fn main() {
     rocket::build()
         .mount("/hello", routes![world])
         .launch()
-        .await;
+        .await
+        .unwrap();
 }
 ```
 


### PR DESCRIPTION
`launch()` returns a `Result` type that is not handled in the example `async fn main()`, which leads to a warning when compiling:

```
warning: unused `Result` that must be used
  --> src/main.rs:19:5
   |
19 | /     rocket::build()
20 | |         .mount("/", routes![index, delay])
21 | |         .launch()
22 | |         .await;
   | |_______________^
   |
   = note: `#[warn(unused_must_use)]` on by default
   = note: this `Result` may be an `Err` variant, which should be handled
```

The simplest change is just to `unwrap()` it, but the guide might want to explicitly mention the fact of `launch()` return type signature.