### PR TITLE
Update irc network references to Libera.Chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -689,7 +689,7 @@ In addition to new features and major improvements, Rocket saw the following imp
 ## Infrastructure
 
   * CI was moved from Travis to Azure Pipelines; Windows support is tested.
-  * Rocket's chat moved to [Matrix] and [Freenode].
+  * Rocket's chat moved to [Matrix] and Freenode.
 
 [`Debug`]: https://api.rocket.rs/v0.4/rocket/response/struct.Debug.html
 [`NoContent`]: https://api.rocket.rs/v0.4/rocket/response/status/struct.NoContent.html
@@ -697,7 +697,6 @@ In addition to new features and major improvements, Rocket saw the following imp
 [`Forbidden`]: https://api.rocket.rs/v0.4/rocket/response/status/struct.Forbidden.html
 [`Conflict`]: https://api.rocket.rs/v0.4/rocket/response/status/struct.Conflict.html
 [Matrix]: https://chat.mozilla.org/#/room/#rocket:mozilla.org
-[Freenode]: https://kiwiirc.com/client/chat.freenode.net/#rocket
 
 # Version 0.4.2 (Jun 28, 2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -689,7 +689,7 @@ In addition to new features and major improvements, Rocket saw the following imp
 ## Infrastructure
 
   * CI was moved from Travis to Azure Pipelines; Windows support is tested.
-  * Rocket's chat moved to [Matrix] and Freenode.
+  * Rocket's chat moved to [Matrix] and [Freenode].
 
 [`Debug`]: https://api.rocket.rs/v0.4/rocket/response/struct.Debug.html
 [`NoContent`]: https://api.rocket.rs/v0.4/rocket/response/status/struct.NoContent.html
@@ -697,6 +697,7 @@ In addition to new features and major improvements, Rocket saw the following imp
 [`Forbidden`]: https://api.rocket.rs/v0.4/rocket/response/status/struct.Forbidden.html
 [`Conflict`]: https://api.rocket.rs/v0.4/rocket/response/status/struct.Conflict.html
 [Matrix]: https://chat.mozilla.org/#/room/#rocket:mozilla.org
+[Freenode]: https://kiwiirc.com/client/chat.freenode.net/#rocket
 
 # Version 0.4.2 (Jun 28, 2019)
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Rocket is extensively documented:
 [API Documentation]: https://api.rocket.rs/rocket/
 
 The official community support channels are [`#rocket:mozilla.org`] on Matrix
-and the bridged [`#rocket`] IRC channel on Freenode at `irc.libera.chat`. We
+and the bridged [`#rocket`] IRC channel on Libera.Chat at `irc.libera.chat`. We
 recommend joining us on [Matrix via Element]. If your prefer IRC, you can join
 via the [Kiwi IRC client] or a client of your own.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Rocket Homepage](https://img.shields.io/badge/web-rocket.rs-red.svg?style=flat&label=https&colorB=d33847)](https://rocket.rs)
 [![Current Crates.io Version](https://img.shields.io/crates/v/rocket.svg)](https://crates.io/crates/rocket)
 [![Matrix: #rocket:mozilla.org](https://img.shields.io/badge/style-%23rocket:mozilla.org-blue.svg?style=flat&label=[m])](https://chat.mozilla.org/#/room/#rocket:mozilla.org)
-[![IRC: #rocket on irc.libera.chat](https://img.shields.io/badge/style-%23rocket-blue.svg?style=flat&label=freenode)](https://kiwiirc.com/client/irc.libera.chat/#rocket)
+[![IRC: #rocket on irc.libera.chat](https://img.shields.io/badge/style-%23rocket-blue.svg?style=flat&label=Libera.Chat)](https://kiwiirc.com/client/irc.libera.chat/#rocket)
 
 Rocket is an async web framework for Rust with a focus on usability, security,
 extensibility, and speed.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Rocket Homepage](https://img.shields.io/badge/web-rocket.rs-red.svg?style=flat&label=https&colorB=d33847)](https://rocket.rs)
 [![Current Crates.io Version](https://img.shields.io/crates/v/rocket.svg)](https://crates.io/crates/rocket)
 [![Matrix: #rocket:mozilla.org](https://img.shields.io/badge/style-%23rocket:mozilla.org-blue.svg?style=flat&label=[m])](https://chat.mozilla.org/#/room/#rocket:mozilla.org)
-[![IRC: #rocket on chat.freenode.net](https://img.shields.io/badge/style-%23rocket-blue.svg?style=flat&label=freenode)](https://kiwiirc.com/client/chat.freenode.net/#rocket)
+[![IRC: #rocket on irc.libera.chat](https://img.shields.io/badge/style-%23rocket-blue.svg?style=flat&label=freenode)](https://kiwiirc.com/client/irc.libera.chat/#rocket)
 
 Rocket is an async web framework for Rust with a focus on usability, security,
 extensibility, and speed.
@@ -45,14 +45,14 @@ Rocket is extensively documented:
 [API Documentation]: https://api.rocket.rs/rocket/
 
 The official community support channels are [`#rocket:mozilla.org`] on Matrix
-and the bridged [`#rocket`] IRC channel on Freenode at `chat.freenode.net`. We
+and the bridged [`#rocket`] IRC channel on Freenode at `irc.libera.chat`. We
 recommend joining us on [Matrix via Element]. If your prefer IRC, you can join
 via the [Kiwi IRC client] or a client of your own.
 
 [`#rocket:mozilla.org`]: https://chat.mozilla.org/#/room/#rocket:mozilla.org
-[`#rocket`]: https://kiwiirc.com/client/chat.freenode.net/#rocket
+[`#rocket`]: https://kiwiirc.com/client/irc.libera.chat/#rocket
 [Matrix via Element]: https://chat.mozilla.org/#/room/#rocket:mozilla.org
-[Kiwi IRC Client]: https://kiwiirc.com/client/chat.freenode.net/#rocket
+[Kiwi IRC Client]: https://kiwiirc.com/client/irc.libera.chat/#rocket
 
 ## Examples
 

--- a/site/guide/11-conclusion.md
+++ b/site/guide/11-conclusion.md
@@ -9,7 +9,7 @@ we're happy to take the best ideas. If you have something in mind, please
 
 If you find yourself having trouble developing Rocket applications, you can get
 help via chat at [`#rocket:mozilla.org`] on Matrix or the bridged [`#rocket`]
-IRC channel on Freenode at `irc.libera.chat`. We recommend joining us on
+IRC channel on Libera.Chat at `irc.libera.chat`. We recommend joining us on
 [Matrix via Element]. If you prefer IRC, you can join via the [Kiwi IRC client]
 or a client of your own.
 

--- a/site/guide/11-conclusion.md
+++ b/site/guide/11-conclusion.md
@@ -9,14 +9,14 @@ we're happy to take the best ideas. If you have something in mind, please
 
 If you find yourself having trouble developing Rocket applications, you can get
 help via chat at [`#rocket:mozilla.org`] on Matrix or the bridged [`#rocket`]
-IRC channel on Freenode at `chat.freenode.net`. We recommend joining us on
+IRC channel on Freenode at `irc.libera.chat`. We recommend joining us on
 [Matrix via Element]. If you prefer IRC, you can join via the [Kiwi IRC client]
 or a client of your own.
 
 [`#rocket:mozilla.org`]: https://chat.mozilla.org/#/room/#rocket:mozilla.org
-[`#rocket`]: https://kiwiirc.com/client/chat.freenode.net/#rocket
+[`#rocket`]: https://kiwiirc.com/client/irc.libera.chat/#rocket
 [Matrix via Element]: https://chat.mozilla.org/#/room/#rocket:mozilla.org
-[Kiwi IRC Client]: https://kiwiirc.com/client/chat.freenode.net/#rocket
+[Kiwi IRC Client]: https://kiwiirc.com/client/irc.libera.chat/#rocket
 
 ## What's next?
 

--- a/site/guide/index.md
+++ b/site/guide/index.md
@@ -34,11 +34,11 @@ aspect of Rocket. The sections are:
 ## Getting Help
 
 The official community support channels are [`#rocket:mozilla.org`] on Matrix
-and the bridged [`#rocket`] IRC channel on Freenode at `chat.freenode.net`. We
+and the bridged [`#rocket`] IRC channel on Freenode at `irc.libera.chat`. We
 recommend joining us on [Matrix via Element]. If you prefer IRC, you can join
 via the [Kiwi IRC client] or a client of your own.
 
 [`#rocket:mozilla.org`]: https://chat.mozilla.org/#/room/#rocket:mozilla.org
-[`#rocket`]: https://kiwiirc.com/client/chat.freenode.net/#rocket
+[`#rocket`]: https://kiwiirc.com/client/irc.libera.chat/#rocket
 [Matrix via Element]: https://chat.mozilla.org/#/room/#rocket:mozilla.org
-[Kiwi IRC Client]: https://kiwiirc.com/client/chat.freenode.net/#rocket
+[Kiwi IRC Client]: https://kiwiirc.com/client/irc.libera.chat/#rocket

--- a/site/guide/index.md
+++ b/site/guide/index.md
@@ -34,7 +34,7 @@ aspect of Rocket. The sections are:
 ## Getting Help
 
 The official community support channels are [`#rocket:mozilla.org`] on Matrix
-and the bridged [`#rocket`] IRC channel on Freenode at `irc.libera.chat`. We
+and the bridged [`#rocket`] IRC channel on Libera.Chat at `irc.libera.chat`. We
 recommend joining us on [Matrix via Element]. If you prefer IRC, you can join
 via the [Kiwi IRC client] or a client of your own.
 


### PR DESCRIPTION
Hi again.  I am very excited about Rocket 0.5!  I may file more issues/MRs as I work through updating my Rocket applications.  But in the meantime:

I was reading the docs and noticed references to the old irc network Freenode.  I checked with my irc client and `#rocket` on `irc.libera.chat` seems active and has the promised Matrix bridge.  So I think it's probably just that the website hasn't been updated yet.