### PR TITLE
Small fixes for the v0.5 of the guide after review

### DIFF
--- a/site/guide/4-requests.md
+++ b/site/guide/4-requests.md
@@ -1735,7 +1735,7 @@ fn hello(name: &str, color: Vec<Color>, person: Person<'_>, other: Option<usize>
 
 // A request with these query segments matches as above.
 # rocket_guide_tests::client(routes![hello]).get("/?\
-color=reg&\
+color=red&\
 color=green&\
 person.pet.name=Fi+Fo+Alex&\
 color=green&\

--- a/site/guide/4-requests.md
+++ b/site/guide/4-requests.md
@@ -211,7 +211,7 @@ there are no remaining routes to try. When there are no remaining routes, a
 customizable **404 error** is returned.
 
 Routes are attempted in increasing _rank_ order. Rocket chooses a default
-ranking from -6 to -1, detailed in the next section, but a route's rank can also
+ranking from -12 to -1, detailed in the next section, but a route's rank can also
 be manually set with the `rank` attribute. To illustrate, consider the following
 routes:
 

--- a/site/guide/4-requests.md
+++ b/site/guide/4-requests.md
@@ -781,6 +781,7 @@ fn new(task: Option<Form<Task<'_>>>) { /* .. */ }
 
 [`Form`]: @api/rocket/form/struct.Form.html
 [`FromForm`]: @api/rocket/form/trait.FromForm.html
+[`FromFormField`]: @api/rocket/form/trait.FromFormField.html
 
 ### Parsing Strategy
 

--- a/site/guide/5-responses.md
+++ b/site/guide/5-responses.md
@@ -649,8 +649,8 @@ generated.
 ```rust
 # #[macro_use] extern crate rocket;
 
-# #[get("/<id>/<name>?<age>")]
-# fn person(id: Option<usize>, name: &str, age: Option<u8>) { /* .. */ }
+#[get("/<id>/<name>?<age>")]
+fn person(id: Option<usize>, name: &str, age: Option<u8>) { /* .. */ }
 
 /// Note that `id` is `Option<usize>` in the route, but `id` in `uri!` _cannot_
 /// be an `Option`. `age`, on the other hand, _must_ be an `Option` (or `Result`


### PR DESCRIPTION
While brushing up my knowledge of the upcoming 0.5 features, I read through the entire guide and ran into a few small issues. Trying to help out with #1329 a bit, this PR fixes those issues.

### Notes:

* ~~Libera.Chat has their own, accessible web chat now, so I linked that. If you'd still prefer Kiwi, I can revert that.~~
* I found the missing "callback" to the original handler definition in the example of https://rocket.rs/v0.5-rc/guide/responses/#typed-uri-parts confusing, since the previous subsection talks about a different situation (https://rocket.rs/v0.5-rc/guide/responses/#deriving-uridisplay) and that is what I just read before so I didn't understand the remark. I unhid the definition here to make clear what handler we were talking about again.