### PR TITLE
Add missing documentation about `#[database]`-generated `run()`

### DIFF
--- a/contrib/sync_db_pools/codegen/src/lib.rs
+++ b/contrib/sync_db_pools/codegen/src/lib.rs
@@ -30,7 +30,7 @@ use proc_macro::TokenStream;
 /// retrieves a connection from the database pool or fails with a
 /// `Status::ServiceUnavailable` if connecting to the database times out.
 ///
-/// The macro also generates two inherent methods on the decorated type:
+/// The macro also generates three inherent methods on the decorated type:
 ///
 ///   * `fn fairing() -> impl Fairing`
 ///

--- a/contrib/sync_db_pools/codegen/src/lib.rs
+++ b/contrib/sync_db_pools/codegen/src/lib.rs
@@ -41,6 +41,11 @@ use proc_macro::TokenStream;
 ///
 ///     Retrieves a connection wrapper from the configured pool. Returns `Some`
 ///     as long as `Self::fairing()` has been attached.
+//!
+//!   * `async fn run<R: Send + Static>(&self, impl FnOnce(&mut Db) -> R) -> R`
+//!
+//!     Asynchronously runs the specified function returning its result of type `R`
+//!     using the instance of the connection where `Db` is the underlying `Poolable` type.
 ///
 /// [`FromRequest`]: rocket::request::FromRequest
 #[proc_macro_attribute]

--- a/contrib/sync_db_pools/codegen/src/lib.rs
+++ b/contrib/sync_db_pools/codegen/src/lib.rs
@@ -42,7 +42,7 @@ use proc_macro::TokenStream;
 ///     Retrieves a connection wrapper from the configured pool. Returns `Some`
 ///     as long as `Self::fairing()` has been attached.
 ///
-///   * `async fn run<R: Send + Static>(&self, impl FnOnce(&mut Db) -> R) -> R`
+///   * `async fn run<R: Send + 'static>(&self, impl FnOnce(&mut Db) -> R + Send + 'static) -> R`
 ///
 ///     Asynchronously runs the specified function returning its result of type `R`
 ///     using the instance of the connection where `Db` is the underlying `Poolable` type.

--- a/contrib/sync_db_pools/codegen/src/lib.rs
+++ b/contrib/sync_db_pools/codegen/src/lib.rs
@@ -41,11 +41,11 @@ use proc_macro::TokenStream;
 ///
 ///     Retrieves a connection wrapper from the configured pool. Returns `Some`
 ///     as long as `Self::fairing()` has been attached.
-//!
-//!   * `async fn run<R: Send + Static>(&self, impl FnOnce(&mut Db) -> R) -> R`
-//!
-//!     Asynchronously runs the specified function returning its result of type `R`
-//!     using the instance of the connection where `Db` is the underlying `Poolable` type.
+///
+///   * `async fn run<R: Send + Static>(&self, impl FnOnce(&mut Db) -> R) -> R`
+///
+///     Asynchronously runs the specified function returning its result of type `R`
+///     using the instance of the connection where `Db` is the underlying `Poolable` type.
 ///
 /// [`FromRequest`]: rocket::request::FromRequest
 #[proc_macro_attribute]

--- a/contrib/sync_db_pools/lib/src/lib.rs
+++ b/contrib/sync_db_pools/lib/src/lib.rs
@@ -187,7 +187,7 @@
 //! retrieves a connection from the database pool or fails with a
 //! `Status::ServiceUnavailable` if connecting to the database times out.
 //!
-//! The macro also generates two inherent methods on the decorated type:
+//! The macro also generates three inherent methods on the decorated type:
 //!
 //!   * `fn fairing() -> impl Fairing`
 //!

--- a/contrib/sync_db_pools/lib/src/lib.rs
+++ b/contrib/sync_db_pools/lib/src/lib.rs
@@ -199,7 +199,7 @@
 //!     Retrieves a connection wrapper from the configured pool. Returns `Some`
 //!     as long as `Self::fairing()` has been attached.
 //!
-//!   * `async fn run<R: Send + Static>(&self, impl FnOnce(&mut Db) -> R) -> R`
+//!   * `async fn run<R: Send + 'static>(&self, impl FnOnce(&mut Db) -> R + Send + 'static) -> R`
 //!
 //!     Asynchronously runs the specified function returning its result of type `R`
 //!     using the instance of the connection where `Db` is the underlying `Poolable` type.

--- a/contrib/sync_db_pools/lib/src/lib.rs
+++ b/contrib/sync_db_pools/lib/src/lib.rs
@@ -199,6 +199,11 @@
 //!     Retrieves a connection wrapper from the configured pool. Returns `Some`
 //!     as long as `Self::fairing()` has been attached.
 //!
+//!   * `async fn run<R: Send + Static>(&self, impl FnOnce(&mut Db) -> R) -> R`
+//!
+//!     Asynchronously runs the specified function returning its result of type `R`
+//!     using the instance of the connection where `Db` is the underlying `Poolable` type.
+//!
 //! The attribute can only be applied to unit-like structs with one type. The
 //! internal type of the structure must implement [`Poolable`].
 //!


### PR DESCRIPTION
This resolves #1704.