### PR TITLE
Drop `tx` channel handle before task `await` to prevent deadlocking local Client

### DIFF
--- a/core/lib/src/local/asynchronous/response.rs
+++ b/core/lib/src/local/asynchronous/response.rs
@@ -179,6 +179,8 @@ impl LocalResponse<'_> {
             }
         }
 
+        drop(tx);
+        
         reader.await.ok()
     }
 


### PR DESCRIPTION
Fixes #1729.

This change ensures that the `rx` isn't deadlocked waiting for more writes that will never arrive after `tx` is finished sending data in the loop.