### PR TITLE
Fix ROCKET_CLI_COLORS syntax

### DIFF
--- a/site/guide/2-getting-started.md
+++ b/site/guide/2-getting-started.md
@@ -103,5 +103,5 @@ Visit `http://localhost:8000` to see your first Rocket application in action!
 ! tip: Don't like colors or emoji?
 
   You can disable colors and emoji by setting the `ROCKET_CLI_COLORS`
-  environment variable to `0` or `off` when running a Rocket binary:
-  `ROCKET_CLI_COLORS=off cargo run`.
+  environment variable to `0` or `false` when running a Rocket binary:
+  `ROCKET_CLI_COLORS=false cargo run`.


### PR DESCRIPTION
The documented `ROCKET_CLI_COLORS=off` fails with the following error:

```
Error: Rocket configuration extraction from provider failed.
   >> invalid value string "off", expected true or false
   >> for key CLI_COLORS
   >> in `ROCKET_` environment variable(s)
```