### PR TITLE
Add support for MacAddress params

### DIFF
--- a/core/lib/Cargo.toml
+++ b/core/lib/Cargo.toml
@@ -31,6 +31,7 @@ uuid = ["uuid_", "rocket_http/uuid"]
 # Serialization dependencies.
 serde_json = { version = "1.0.26", optional = true }
 rmp-serde = { version = "0.15.0", optional = true }
+mac_address = { version = "1.1.1", optional = true }
 uuid_ = { package = "uuid", version = "0.8", optional = true, features = ["serde"] }
 
 # Non-optional, core dependencies from here on out.

--- a/core/lib/src/request/from_param.rs
+++ b/core/lib/src/request/from_param.rs
@@ -264,6 +264,9 @@ impl<'a, T: FromParam<'a>> FromParam<'a> for Option<T> {
     }
 }
 
+#[cfg(feature = "mac_address")]
+impl_with_fromstr! { mac_address::MacAddress }
+
 /// Trait to convert _many_ dynamic path segment strings to a concrete value.
 ///
 /// This is the `..` analog to [`FromParam`], and its functionality is identical

--- a/core/lib/src/request/from_param.rs
+++ b/core/lib/src/request/from_param.rs
@@ -75,6 +75,8 @@ use crate::http::uri::{Segments, error::PathError, fmt::Path};
 ///       * `NonZero*` types: **NonZeroI8, NonZeroI16, NonZeroI32, NonZeroI64,
 ///         NonZeroI128, NonZeroIsize, NonZeroU8, NonZeroU16, NonZeroU32,
 ///         NonZeroU64, NonZeroU128, NonZeroUsize**
+///       * `mac_address::MacAddress`: Support for this type requires the
+///         `mac_address` feature to be enabled.
 ///
 ///     A value is parsed successfully if the `from_str` method from the given
 ///     type returns successfully. Otherwise, the raw path segment is returned


### PR DESCRIPTION
Add support for using `MacAddress` from the `mac_address` crate as a dynamic path segment. This would introduce `mac_address` as an optional dependency.