### PR TITLE
Static files ,IfMatch/IfModifiedSince/ComputeRange/ComputeIfRange

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ scripts/redirect.html
 
 # Uploads in pastebin example.
 examples/pastebin/upload/*
+
+.idea

--- a/core/http/Cargo.toml
+++ b/core/http/Cargo.toml
@@ -43,6 +43,8 @@ memchr = "2"
 stable-pattern = "0.1"
 cookie = { version = "0.15", features = ["percent-encode"] }
 state = "0.5.1"
+chrono = "0.4.0"
+lazy_static="1.4"
 
 [dependencies.x509-parser]
 version = "0.9.2"

--- a/core/http/src/header/mod.rs
+++ b/core/http/src/header/mod.rs
@@ -4,10 +4,12 @@ mod media_type;
 mod content_type;
 mod accept;
 mod header;
+mod typed_header;
 
 pub use self::content_type::ContentType;
 pub use self::accept::{Accept, QMediaType};
 pub use self::media_type::MediaType;
 pub use self::header::{Header, HeaderMap};
+pub use self::typed_header::*;
 
 pub(crate) use self::media_type::Source;

--- a/core/http/src/header/typed_header/content_range_header_value.rs
+++ b/core/http/src/header/typed_header/content_range_header_value.rs
@@ -1,20 +1,29 @@
-use super::{header_utilities, header_names, RangeItemHeaderValue, Header};
+use super::{header_utilities, header_names, Header};
 
-
+/// Represents a `Content-Range` response HTTP header.
 pub struct ContentRangeHeaderValue {
+    /// The start of the range.
     pub from: Option<u64>,
+
+    /// The end of the range.
     pub to: Option<u64>,
+
+    /// The total size of the document.
     pub length: Option<u64>,
+
+    /// The unit in which ranges are specified.
     pub unit: String,
 }
 
 impl ContentRangeHeaderValue {
+    ///  Gets a value that determines if `length` has been specified.
     pub fn has_length(&self) -> bool {
         self.length.is_some()
     }
 
+    /// Gets a value that determines if `from` and `to` have been specified.
     pub fn has_range(&self) -> bool {
-        self.from.is_some()
+        self.from.is_some() && self.to.is_some()
     }
 }
 
@@ -77,11 +86,11 @@ impl ToString for ContentRangeHeaderValue {
     }
 }
 
-impl<'h> Into<Header<'h>> for ContentRangeHeaderValue {
-    fn into(self) -> Header<'h> {
+impl From<ContentRangeHeaderValue> for Header<'_> {
+    fn from(v: ContentRangeHeaderValue) -> Self {
         Header {
             name: header_names::CONTENT_RANGE.into(),
-            value: self.to_string().into()
+            value: v.to_string().into()
         }
     }
 }

--- a/core/http/src/header/typed_header/content_range_header_value.rs
+++ b/core/http/src/header/typed_header/content_range_header_value.rs
@@ -1,6 +1,7 @@
 use super::{header_utilities, header_names, Header};
 
 /// Represents a `Content-Range` response HTTP header.
+#[derive(Clone)]
 pub struct ContentRangeHeaderValue {
     /// The start of the range.
     pub from: Option<u64>,

--- a/core/http/src/header/typed_header/content_range_header_value.rs
+++ b/core/http/src/header/typed_header/content_range_header_value.rs
@@ -51,15 +51,6 @@ impl From<(u64, u64)> for ContentRangeHeaderValue {
     }
 }
 
-impl From<&RangeItemHeaderValue> for ContentRangeHeaderValue {
-    fn from(range: &RangeItemHeaderValue) -> Self {
-        let start = range.from.unwrap();
-        let end = range.to.unwrap();
-        let len = end - start + 1;
-        (start, end, len).into()
-    }
-}
-
 impl ToString for ContentRangeHeaderValue {
     fn to_string(&self) -> String {
         let mut s = String::new();

--- a/core/http/src/header/typed_header/content_range_header_value.rs
+++ b/core/http/src/header/typed_header/content_range_header_value.rs
@@ -70,9 +70,7 @@ impl ToString for ContentRangeHeaderValue {
         if self.has_range(){
             s.push_str(self.from.unwrap().to_string().as_str());
             s.push('-');
-            if let Some(to) = self.to {
-                s.push_str(to.to_string().as_str());
-            }
+            s.push_str(self.to.unwrap().to_string().as_str());
         } else {
             s.push('*');
         }

--- a/core/http/src/header/typed_header/content_range_header_value.rs
+++ b/core/http/src/header/typed_header/content_range_header_value.rs
@@ -1,0 +1,96 @@
+use super::{header_utilities, header_names, RangeItemHeaderValue, Header};
+
+
+pub struct ContentRangeHeaderValue {
+    pub from: Option<u64>,
+    pub to: Option<u64>,
+    pub length: Option<u64>,
+    pub unit: String,
+}
+
+impl ContentRangeHeaderValue {
+    pub fn has_length(&self) -> bool {
+        self.length.is_some()
+    }
+
+    pub fn has_range(&self) -> bool {
+        self.from.is_some()
+    }
+}
+
+impl From<u64> for ContentRangeHeaderValue {
+    fn from(len: u64) -> Self {
+        Self {
+            from: None,
+            to: None,
+            length: Some(len),
+            unit: header_utilities::BYTES_UNIT.to_string()
+        }
+    }
+}
+
+impl From<(u64, u64, u64)> for ContentRangeHeaderValue {
+    fn from((from, to, len): (u64, u64, u64)) -> Self {
+        Self {
+            from: Some(from),
+            to: Some(to),
+            length: Some(len),
+            unit: header_utilities::BYTES_UNIT.to_string()
+        }
+    }
+}
+/// Scenario: "Content-Range: bytes 12-34/*"
+impl From<(u64, u64)> for ContentRangeHeaderValue {
+    fn from((from, to): (u64, u64)) -> Self {
+        Self {
+            from: Some(from),
+            to: Some(to),
+            length: None,
+            unit: header_utilities::BYTES_UNIT.to_string()
+        }
+    }
+}
+
+impl From<&RangeItemHeaderValue> for ContentRangeHeaderValue {
+    fn from(range: &RangeItemHeaderValue) -> Self {
+        let start = range.from.unwrap();
+        let end = range.to.unwrap();
+        let len = end - start + 1;
+        (start, end, len).into()
+    }
+}
+
+impl ToString for ContentRangeHeaderValue {
+    fn to_string(&self) -> String {
+        let mut s = String::new();
+        s.push_str(self.unit.as_str());
+        s.push(' ');
+
+        if self.has_range(){
+            s.push_str(self.from.unwrap().to_string().as_str());
+            s.push('-');
+            if let Some(to) = self.to {
+                s.push_str(to.to_string().as_str());
+            }
+        } else {
+            s.push('*');
+        }
+
+        s.push('/');
+        if self.has_length() {
+            s.push_str(self.length.unwrap().to_string().as_str());
+        } else {
+            s.push('*');
+        }
+        s
+    }
+}
+
+impl<'h> Into<Header<'h>> for ContentRangeHeaderValue {
+    fn into(self) -> Header<'h> {
+        Header {
+            name: header_names::CONTENT_RANGE.into(),
+            value: self.to_string().into()
+        }
+    }
+}

--- a/core/http/src/header/typed_header/date_time_offset.rs
+++ b/core/http/src/header/typed_header/date_time_offset.rs
@@ -1,18 +1,22 @@
 use std::convert::TryFrom;
 
 use chrono::{DateTime, FixedOffset, Utc};
-use std::time::SystemTime;
+use std::time::{SystemTime, Duration};
 use std::cmp::Ordering;
 use std::fmt::{Debug, Formatter};
 
-#[derive(Eq, Ord)]
+/// Represents `DateTimeOffset` in HTTP header.
+#[derive(Eq)]
 pub struct DateTimeOffset(DateTime<FixedOffset>);
 
 impl DateTimeOffset {
+
+    /// Returns the DateTimeOffset corresponding to "now".
     pub fn now() -> Self {
         SystemTime::now().into()
     }
 
+    /// Returns the number of non-leap-milliseconds since January 1, 1970 UTC
     pub fn timestamp_millis(&self) -> i64 {
         self.0.timestamp_millis()
     }
@@ -53,7 +57,7 @@ impl TryFrom<&[char]> for DateTimeOffset {
     fn try_from(chars: &[char]) -> Result<Self, Self::Error> {
         let s: String = chars.iter().collect();
         DateTime::parse_from_rfc2822(s.as_str())
-            .map(|t| Self::from(t))
+            .map(Self::from)
     }
 }
 
@@ -76,6 +80,12 @@ impl From<SystemTime> for DateTimeOffset {
     }
 }
 
+impl From<u64> for DateTimeOffset {
+    fn from(v: u64) -> Self {
+        (SystemTime::UNIX_EPOCH + Duration::from_millis(v)).into()
+    }
+}
+
 impl std::cmp::PartialEq for DateTimeOffset {
     fn eq(&self, other: &Self) -> bool {
         self.0.eq(&other.0)
@@ -85,5 +95,17 @@ impl std::cmp::PartialEq for DateTimeOffset {
 impl std::cmp::PartialOrd for DateTimeOffset {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         self.0.partial_cmp(&other.0)
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test1() {
+        let p = DateTimeOffset::from(1628392450871);
+        assert_eq!("Sun, 08 Aug 2021 03:14:10 GMT", p.to_string());
     }
 }

--- a/core/http/src/header/typed_header/date_time_offset.rs
+++ b/core/http/src/header/typed_header/date_time_offset.rs
@@ -1,0 +1,89 @@
+use std::convert::TryFrom;
+
+use chrono::{DateTime, FixedOffset, Utc};
+use std::time::SystemTime;
+use std::cmp::Ordering;
+use std::fmt::{Debug, Formatter};
+
+#[derive(Eq, Ord)]
+pub struct DateTimeOffset(DateTime<FixedOffset>);
+
+impl DateTimeOffset {
+    pub fn now() -> Self {
+        SystemTime::now().into()
+    }
+
+    pub fn timestamp_millis(&self) -> i64 {
+        self.0.timestamp_millis()
+    }
+}
+
+impl Debug for DateTimeOffset {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self.0)
+    }
+}
+
+impl ToString for DateTimeOffset {
+    fn to_string(&self) -> String {
+        let s: String = self.0.to_rfc2822();
+        let mut s = s.trim_end_matches("+0000").to_string();
+        s.push_str("GMT");
+        s
+    }
+}
+
+impl TryFrom<Vec<&str>> for DateTimeOffset {
+    type Error = ();
+
+    fn try_from(value: Vec<&str>) -> Result<Self, Self::Error> {
+        if value.is_empty() {
+            return Err(())
+        }
+
+        let value: Vec<char> = value[0].chars().collect();
+
+        Self::try_from(&value[..]).map_err(|_| ())
+    }
+}
+
+impl TryFrom<&[char]> for DateTimeOffset {
+    type Error = chrono::ParseError;
+
+    fn try_from(chars: &[char]) -> Result<Self, Self::Error> {
+        let s: String = chars.iter().collect();
+        DateTime::parse_from_rfc2822(s.as_str())
+            .map(|t| Self::from(t))
+    }
+}
+
+impl From<DateTime<FixedOffset>> for DateTimeOffset {
+    fn from(time: DateTime<FixedOffset>) -> Self {
+        Self(time)
+    }
+}
+
+impl From<DateTime<Utc>> for DateTimeOffset {
+    fn from(time: DateTime<Utc>) -> Self {
+        Self(time.into())
+    }
+}
+
+impl From<SystemTime> for DateTimeOffset {
+    fn from(time: SystemTime) -> Self {
+        let u: DateTime<Utc> = DateTime::from(time);
+        u.into()
+    }
+}
+
+impl std::cmp::PartialEq for DateTimeOffset {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.eq(&other.0)
+    }
+}
+
+impl std::cmp::PartialOrd for DateTimeOffset {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.0.partial_cmp(&other.0)
+    }
+}

--- a/core/http/src/header/typed_header/date_time_offset.rs
+++ b/core/http/src/header/typed_header/date_time_offset.rs
@@ -6,7 +6,7 @@ use std::cmp::Ordering;
 use std::fmt::{Debug, Formatter};
 
 /// Represents `DateTimeOffset` in HTTP header.
-#[derive(Eq)]
+#[derive(Eq, Clone)]
 pub struct DateTimeOffset(DateTime<FixedOffset>);
 
 impl DateTimeOffset {

--- a/core/http/src/header/typed_header/entity_tag_header_value.rs
+++ b/core/http/src/header/typed_header/entity_tag_header_value.rs
@@ -1,0 +1,134 @@
+
+use super::{
+    http_rule_parser
+};
+use super::http_rule_parser::HttpParseResult;
+use std::convert::TryFrom;
+
+
+/// Represents an entity-tag (*etag*) header value.
+#[derive(Debug, Eq, PartialEq)]
+pub struct EntityTagHeaderValue {
+    tag: Vec<char>,
+    is_weak: bool
+}
+
+impl EntityTagHeaderValue {
+
+    /// Used by the parser to create a new instance of this type.
+    fn new() -> Self {
+        Self { tag: Vec::new(), is_weak: false }
+    }
+    pub fn any() -> Self {
+        Self{ tag: vec!['*'], is_weak: false }
+    }
+    pub fn compare(&self, other: &Self, use_strong_comparison: bool) -> bool {
+        if use_strong_comparison {
+            !self.is_weak && !other.is_weak && self.tag == other.tag
+        } else {
+            self.tag == other.tag
+        }
+    }
+
+    //noinspection ALL
+    pub(super) fn get_entity_tag_length(input: &[char], start_index: usize, parsed_value: &mut Self) -> usize {
+        if input.is_empty() || start_index >= input.len() {
+            return 0;
+        }
+        // Caller must remove leading whitespaces. If not, we'll return 0.
+        let mut is_weak = false;
+        let mut current = start_index;
+        let first_char = input[start_index];
+        if first_char == '*' {
+            // We have '*' value, indicating "any" ETag.
+            *parsed_value = Self::any();
+            current += 1;
+        } else {
+            // The RFC defines 'W/' as prefix, but we'll be flexible and also accept lower-case 'w'.
+            if first_char == 'W' || first_char == 'w' {
+                current += 1;
+                // We need at least 3 more chars: the '/' character followed by two quotes.
+                if current + 2 >= input.len() || input[current] != '/' {
+                    return 0;
+                }
+                is_weak = true;
+                current += 1;
+                current = current + http_rule_parser::get_whitespace_length(input, current);
+            }
+            // let tag_start_index = current;
+            let mut tag_len = 0;
+            if http_rule_parser::get_quoted_string_length(input, current, &mut tag_len)
+                != HttpParseResult::Parsed {
+                return 0;
+            }
+
+            *parsed_value = Self::new();
+            if tag_len == input.len() {
+                parsed_value.tag = input.to_vec();
+                parsed_value.is_weak = false;
+            } else {
+                parsed_value.tag = input[start_index .. start_index + tag_len + 2].to_vec();
+                parsed_value.is_weak = is_weak;
+            }
+
+            current += tag_len;
+        }
+        current += http_rule_parser::get_whitespace_length(input, current);
+
+        current - start_index
+    }
+}
+
+impl From<String> for EntityTagHeaderValue {
+    fn from(mut s: String) -> Self {
+        if !s.starts_with('"') {
+            s.insert(0, '"');
+        }
+        if !s.ends_with('"') {
+            s.push('"');
+        }
+        Self{
+            tag: s.chars().collect(),
+            is_weak: false
+        }
+    }
+}
+
+impl TryFrom<Vec<&str>> for EntityTagHeaderValue {
+    type Error = ();
+
+    fn try_from(value: Vec<&str>) -> Result<Self, Self::Error> {
+        if value.is_empty() {
+            return Err(());
+        }
+
+        let input: Vec<char> = value[0].chars().collect();
+
+        let mut v = Self::new();
+
+        if Self::get_entity_tag_length(&input, 0, &mut v) == 0 {
+            return Err(());
+        }
+        Ok(v)
+    }
+}
+
+
+impl ToString for EntityTagHeaderValue {
+    fn to_string(&self) -> String {
+        self.tag.iter().collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    pub fn test_from_str() {
+        let s = String::from("123456789");
+        let etag = EntityTagHeaderValue::from(s);
+
+        assert_eq!(r#""123456789""#, etag.to_string().as_str())
+    }
+}

--- a/core/http/src/header/typed_header/entity_tag_header_value.rs
+++ b/core/http/src/header/typed_header/entity_tag_header_value.rs
@@ -7,7 +7,7 @@ use super::http_rule_parser::{self, HttpParseResult};
 
 
 /// Represents an entity-tag (*etag*) header value.
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Clone , Eq, PartialEq)]
 pub struct EntityTagHeaderValue {
     tag: Vec<char>,
     is_weak: bool

--- a/core/http/src/header/typed_header/header_names.rs
+++ b/core/http/src/header/typed_header/header_names.rs
@@ -3,15 +3,15 @@
 //!
 #![allow(missing_docs)]
 
-pub const RANGE: &'static str = "Range";
-pub const IF_RANGE: &'static str = "If-Range";
-pub const IF_MODIFIED_SINCE: &'static str = "If-Modified-Since";
-pub const IF_UNMODIFIED_SINCE: &'static str = "If-Unmodified-Since";
-pub const IF_MATCH: &'static str = "If-Match";
-pub const IF_NONE_MATCH: &'static str = "If-None-Match";
-pub const CONTENT_RANGE: &'static str = "Content-Range";
-pub const LAST_MODIFIED: &'static str = "Last-Modified";
-pub const ETAG: &'static str = "ETag";
-pub const ACCEPT_RANGES: &'static str = "Accept-Ranges";
-pub const CONTENT_LENGTH: &'static str = "Content-Length";
-pub const CONNECTION: &'static str = "Connection";
+pub const RANGE: & str = "Range";
+pub const IF_RANGE: & str = "If-Range";
+pub const IF_MODIFIED_SINCE: & str = "If-Modified-Since";
+pub const IF_UNMODIFIED_SINCE: & str = "If-Unmodified-Since";
+pub const IF_MATCH: & str = "If-Match";
+pub const IF_NONE_MATCH: & str = "If-None-Match";
+pub const CONTENT_RANGE: & str = "Content-Range";
+pub const LAST_MODIFIED: & str = "Last-Modified";
+pub const ETAG: & str = "ETag";
+pub const ACCEPT_RANGES: & str = "Accept-Ranges";
+pub const CONTENT_LENGTH: & str = "Content-Length";
+pub const CONNECTION: & str = "Connection";

--- a/core/http/src/header/typed_header/header_names.rs
+++ b/core/http/src/header/typed_header/header_names.rs
@@ -1,0 +1,17 @@
+//!
+//! Defines constants for well-known HTTP headers.
+//!
+#![allow(missing_docs)]
+
+pub const RANGE: &'static str = "Range";
+pub const IF_RANGE: &'static str = "If-Range";
+pub const IF_MODIFIED_SINCE: &'static str = "If-Modified-Since";
+pub const IF_UNMODIFIED_SINCE: &'static str = "If-Unmodified-Since";
+pub const IF_MATCH: &'static str = "If-Match";
+pub const IF_NONE_MATCH: &'static str = "If-None-Match";
+pub const CONTENT_RANGE: &'static str = "Content-Range";
+pub const LAST_MODIFIED: &'static str = "Last-Modified";
+pub const ETAG: &'static str = "ETag";
+pub const ACCEPT_RANGES: &'static str = "Accept-Ranges";
+pub const CONTENT_LENGTH: &'static str = "Content-Length";
+pub const CONNECTION: &'static str = "Connection";

--- a/core/http/src/header/typed_header/header_utilities.rs
+++ b/core/http/src/header/typed_header/header_utilities.rs
@@ -1,0 +1,56 @@
+use super::http_rule_parser;
+
+
+pub const BYTES_UNIT: &'static str = "bytes";
+
+pub fn try_parse_non_negative_int64(value: &[char], result: &mut u64) -> bool {
+    *result = 0;
+    if value.is_empty() || value[0] == ' '{
+        return false;
+    }
+
+    let mut digit;
+    for ch in value {
+        digit = *ch as u64 - 0x30;
+        if digit > 9 {
+            *result = 0;
+            return false;
+        }
+
+        if let Some(r) = result.checked_mul(10)
+            .map(|n| n.checked_add(digit))
+            .unwrap_or(None) {
+            *result = r
+        } else {
+            *result = 0;
+            return false;
+        }
+    }
+    true
+}
+
+pub fn get_next_non_empty_or_whitespace_index(input: &[char], start_index: usize, skip_empty_values: bool, separator_found: &mut bool) -> usize {
+
+    *separator_found = false;
+
+    let mut current = start_index + http_rule_parser::get_whitespace_length(input, start_index);
+    if current == input.len() || input[current] != ',' {
+        return current;
+    }
+
+    // If we have a separator, skip the separator and all following whitespaces. If we support
+    // empty values, continue until the current character is neither a separator nor a whitespace.
+    *separator_found = true;
+
+    current += 1;  // skip delimiter.
+    current += http_rule_parser::get_whitespace_length(input, current);
+
+    if skip_empty_values {
+        while current < input.len() && input[current] == ',' {
+            current += 1;  // skip delimiter.
+            current += http_rule_parser::get_whitespace_length(input, current);
+
+        }
+    }
+    return current;
+}

--- a/core/http/src/header/typed_header/header_utilities.rs
+++ b/core/http/src/header/typed_header/header_utilities.rs
@@ -1,7 +1,7 @@
 use super::http_rule_parser;
 
 
-pub const BYTES_UNIT: &'static str = "bytes";
+pub const BYTES_UNIT: & str = "bytes";
 
 pub fn try_parse_non_negative_int64(value: &[char], result: &mut u64) -> bool {
     *result = 0;
@@ -52,5 +52,5 @@ pub fn get_next_non_empty_or_whitespace_index(input: &[char], start_index: usize
 
         }
     }
-    return current;
+    current
 }

--- a/core/http/src/header/typed_header/http_rule_parser.rs
+++ b/core/http/src/header/typed_header/http_rule_parser.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 
 use lazy_static::*;
 
@@ -13,8 +14,8 @@ pub(super) const MAX_INT32DIGITS: usize = 10;
 lazy_static! {
             static ref TOKEN_CHARS: [bool; 128] = {
                 let mut token_chars = [false; 128];
-                for i in 33..127 {
-                    token_chars[i] = true;
+                for token_char in &mut token_chars[33..127] {
+                    *token_char = true;
                 }
                 token_chars['(' as usize] = false;
                 token_chars[')' as usize] = false;
@@ -78,7 +79,7 @@ pub fn get_number_length(input: &[char], start_index: usize, allow_decimal: bool
 
     while current < input.len() {
         c = input[current];
-        if c >= '0' && c <= '9' {
+        if ('0'..='9').contains(&c) {
             current += 1;
         } else if !have_dot && c == '.' {
             // Note that value "1." is valid.
@@ -156,7 +157,7 @@ fn get_expression_length(
             // We ignore invalid quoted-pairs. Invalid quoted-pairs may mean that it looked like a quoted pair,
             // but we actually have a quoted-string: e.g. "\ü" ('\' followed by a char >127 - quoted-pair only
             // allows ASCII chars after '\'; qdtext allows both '\' and >127 chars).
-            current = current + quoted_pair_length;
+            current += quoted_pair_length;
             continue;
         }
 

--- a/core/http/src/header/typed_header/http_rule_parser.rs
+++ b/core/http/src/header/typed_header/http_rule_parser.rs
@@ -73,7 +73,7 @@ pub fn get_number_length(input: &[char], start_index: usize, allow_decimal: bool
     // values.
     // The RFC only allows decimal dots not ',' characters as decimal separators. Therefore value "1,23" is
     // considered invalid and must be represented as "1.23".
-    if input[current] == '.' {
+    if current < input.len() || input[current] == '.' {
         return 0;
     }
 
@@ -142,7 +142,7 @@ fn get_expression_length(
     length: &mut usize
 ) -> HttpParseResult {
     *length = 0;
-    if input[start_index] != open_char {
+    if start_index < input.len() || input[start_index] != open_char {
         return HttpParseResult::NotParsed;
     }
     let mut current = start_index + 1; // Start parsing with the character next to the first open-char
@@ -214,7 +214,7 @@ fn get_expression_length(
 /// CHAR = <any US-ASCII character (octets 0 - 127)>
 pub fn get_quoted_pair_length(input: &[char], start_index: usize, length: &mut usize) -> HttpParseResult {
     *length = 0;
-    if input[start_index] != '\\' {
+    if start_index < input.len() || input[start_index] != '\\' {
         return HttpParseResult::NotParsed;
     }
 

--- a/core/http/src/header/typed_header/http_rule_parser.rs
+++ b/core/http/src/header/typed_header/http_rule_parser.rs
@@ -1,0 +1,251 @@
+
+use lazy_static::*;
+
+const CR: char = '\r';
+const LF: char = '\n';
+const SP: char = ' ';
+const TAB: char = '\t';
+const MAX_NESTED_COUNT: usize = 5;
+
+pub(super) const MAX_INT64DIGITS: usize = 19;
+pub(super) const MAX_INT32DIGITS: usize = 10;
+
+lazy_static! {
+            static ref TOKEN_CHARS: [bool; 128] = {
+                let mut token_chars = [false; 128];
+                for i in 33..127 {
+                    token_chars[i] = true;
+                }
+                token_chars['(' as usize] = false;
+                token_chars[')' as usize] = false;
+                token_chars['<' as usize] = false;
+                token_chars['>' as usize] = false;
+                token_chars['@' as usize] = false;
+                token_chars[',' as usize] = false;
+                token_chars[';' as usize] = false;
+                token_chars[':' as usize] = false;
+                token_chars['\\' as usize] = false;
+                token_chars['"' as usize] = false;
+                token_chars['/' as usize] = false;
+                token_chars['[' as usize] = false;
+                token_chars[']' as usize] = false;
+                token_chars['?' as usize] = false;
+                token_chars['=' as usize] = false;
+                token_chars['{' as usize] = false;
+                token_chars['}' as usize] = false;
+                    token_chars
+            };
+        }
+
+fn is_token_char(character: char) -> bool {
+    if character as usize > 127 {
+        return false;
+    }
+    TOKEN_CHARS[character as usize]
+}
+
+pub fn get_token_length(input: &[char], start_index: usize) -> usize {
+    if start_index >= input.len() {
+        return 0;
+    }
+    let mut current = start_index;
+    while current < input.len() {
+        if !is_token_char(input[current]) {
+            return current - start_index;
+        }
+        current += 1;
+    }
+
+    input.len() - start_index
+}
+
+pub fn get_number_length(input: &[char], start_index: usize, allow_decimal: bool) -> usize {
+
+    let mut current = start_index;
+    let mut c;
+    // If decimal values are not allowed, we pretend to have read the '.' character already. I.e. if a dot is
+    // found in the string, parsing will be aborted.
+    let mut have_dot = !allow_decimal;
+
+    // The RFC doesn't allow decimal values starting with dot. I.e. value ".123" is invalid. It must be in the
+    // form "0.123". Also, there are no negative values defined in the RFC. So we'll just parse non-negative
+    // values.
+    // The RFC only allows decimal dots not ',' characters as decimal separators. Therefore value "1,23" is
+    // considered invalid and must be represented as "1.23".
+    if input[current] == '.' {
+        return 0;
+    }
+
+    while current < input.len() {
+        c = input[current];
+        if c >= '0' && c <= '9' {
+            current += 1;
+        } else if !have_dot && c == '.' {
+            // Note that value "1." is valid.
+            have_dot = true;
+            current += 1;
+        } else {
+            break;
+        }
+
+    }
+    current - start_index
+}
+
+pub fn get_whitespace_length(input: &[char], start_index: usize) -> usize {
+    if start_index >= input.len() {
+        return 0;
+    }
+
+    let mut current = start_index;
+
+    let mut c;
+
+    while current < input.len() {
+        c = input[current];
+        if c == SP || c == TAB {
+            current +=1;
+            continue;
+        }
+        if c == CR {
+            // If we have a #13 char, it must be followed by #10 and then at least one SP or HT.
+            if current + 2 < input.len() && input[current + 1] == LF {
+                let space_or_tab = input[current + 2];
+                if space_or_tab == SP || space_or_tab == TAB {
+                    current += 3;
+                    continue;
+                }
+            }
+        }
+        return current - start_index;
+    }
+
+    current - start_index
+}
+
+pub fn get_quoted_string_length(input: &[char], start_index: usize, length: &mut usize) -> HttpParseResult {
+    let mut nested_count = 0;
+    get_expression_length(
+        input, start_index,
+        '"', '"',
+        false,&mut nested_count, length)
+}
+
+fn get_expression_length(
+    input: &[char],
+    start_index: usize,
+    open_char: char,
+    close_char: char,
+    supports_nesting: bool,
+    nested_count: &mut usize,
+    length: &mut usize
+) -> HttpParseResult {
+    *length = 0;
+    if input[start_index] != open_char {
+        return HttpParseResult::NotParsed;
+    }
+    let mut current = start_index + 1; // Start parsing with the character next to the first open-char
+
+    while current < input.len() {
+
+        // Only check whether we have a quoted char, if we have at least 3 characters left to read (i.e.
+        // quoted char + closing char). Otherwise the closing char may be considered part of the quoted char.
+        let mut quoted_pair_length  = 0;
+        if current + 2 < input.len() && get_quoted_pair_length(input, current, &mut quoted_pair_length) == HttpParseResult::Parsed {
+
+            // We ignore invalid quoted-pairs. Invalid quoted-pairs may mean that it looked like a quoted pair,
+            // but we actually have a quoted-string: e.g. "\ü" ('\' followed by a char >127 - quoted-pair only
+            // allows ASCII chars after '\'; qdtext allows both '\' and >127 chars).
+            current = current + quoted_pair_length;
+            continue;
+        }
+
+        // If we support nested expressions and we find an open-char, then parse the nested expressions.
+        if supports_nesting && input[current] == open_char {
+            *nested_count += 1;
+            let result = {
+                // Check if we exceeded the number of nested calls.
+                if *nested_count > MAX_NESTED_COUNT {
+                    return HttpParseResult::InvalidFormat;
+                }
+
+                let mut nested_length = 0;
+                let nested_result = get_expression_length(
+                    input, current,
+                    open_char, close_char,
+                    supports_nesting, nested_count, &mut nested_length);
+
+                match nested_result {
+                    HttpParseResult::Parsed => {
+                        current += nested_length;
+                        HttpParseResult::Parsed
+                    }
+                    HttpParseResult::NotParsed => {
+                        // 'NotParsed' is unexpected: We started nested expression parsing,
+                        // because we found the open-char. So either it's a valid nested
+                        // expression or it has invalid format.
+                        HttpParseResult::NotParsed
+                    }
+                    HttpParseResult::InvalidFormat => {
+                        // If the nested expression is invalid, we can't continue, so we fail with invalid format.
+                        return HttpParseResult::InvalidFormat
+                    }
+                }
+            };
+            *nested_count -= 1;
+            if result == HttpParseResult::InvalidFormat {
+                return HttpParseResult::InvalidFormat;
+            }
+        }
+
+        if input[current] == close_char {
+            *length = current - start_index + 1;
+            return HttpParseResult::Parsed;
+        }
+        current += 1;
+    }
+
+
+    HttpParseResult::InvalidFormat
+}
+
+/// quoted-pair = "\" CHAR
+/// CHAR = <any US-ASCII character (octets 0 - 127)>
+pub fn get_quoted_pair_length(input: &[char], start_index: usize, length: &mut usize) -> HttpParseResult {
+    *length = 0;
+    if input[start_index] != '\\' {
+        return HttpParseResult::NotParsed;
+    }
+
+    // Quoted-char has 2 characters. Check whether there are 2 chars left ('\' + char)
+    // If so, check whether the character is in the range 0-127. If not, it's an invalid value.
+    if start_index + 2 > input.len() || input[start_index + 1] as u8 > 127 {
+        return HttpParseResult::InvalidFormat;
+    }
+
+    *length = 2;
+    // We don't care what the char next to '\' is.
+    HttpParseResult::Parsed
+}
+
+
+#[derive(PartialEq)]
+pub enum HttpParseResult
+{
+    Parsed,
+    NotParsed,
+    InvalidFormat,
+}
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/core/http/src/header/typed_header/http_rule_parser.rs
+++ b/core/http/src/header/typed_header/http_rule_parser.rs
@@ -73,7 +73,7 @@ pub fn get_number_length(input: &[char], start_index: usize, allow_decimal: bool
     // values.
     // The RFC only allows decimal dots not ',' characters as decimal separators. Therefore value "1,23" is
     // considered invalid and must be represented as "1.23".
-    if current < input.len() || input[current] == '.' {
+    if current >= input.len() || input[current] == '.' {
         return 0;
     }
 
@@ -142,7 +142,7 @@ fn get_expression_length(
     length: &mut usize
 ) -> HttpParseResult {
     *length = 0;
-    if start_index < input.len() || input[start_index] != open_char {
+    if start_index >= input.len() || input[start_index] != open_char {
         return HttpParseResult::NotParsed;
     }
     let mut current = start_index + 1; // Start parsing with the character next to the first open-char
@@ -214,7 +214,7 @@ fn get_expression_length(
 /// CHAR = <any US-ASCII character (octets 0 - 127)>
 pub fn get_quoted_pair_length(input: &[char], start_index: usize, length: &mut usize) -> HttpParseResult {
     *length = 0;
-    if start_index < input.len() || input[start_index] != '\\' {
+    if start_index >= input.len() || input[start_index] != '\\' {
         return HttpParseResult::NotParsed;
     }
 

--- a/core/http/src/header/typed_header/mod.rs
+++ b/core/http/src/header/typed_header/mod.rs
@@ -77,11 +77,9 @@ impl<'h> TypedHeaders for HeaderMap<'h> {
 
     fn get_typed_header_value<'a, T>(&'a self, name: &str) -> Option<T> where T: TryFrom<Vec<&'a str>> {
         let header_values: Vec<&str> = self.get(name).collect();
-        let p = T::try_from(header_values)
-            .map(|x| Some(x))
-            .unwrap_or(None);
-
-        p
+        T::try_from(header_values)
+            .map(Some)
+            .unwrap_or(None)
     }
 
     fn get_typed_header_value_list<'a, T>(&'a self, name: &str) -> Vec<T> where T: TryFrom<Vec<&'a str>> {

--- a/core/http/src/header/typed_header/mod.rs
+++ b/core/http/src/header/typed_header/mod.rs
@@ -1,0 +1,97 @@
+use std::convert::TryFrom;
+use super::{HeaderMap, Header};
+
+
+pub mod header_names;
+mod header_utilities;
+mod http_rule_parser;
+
+
+mod range_header_value;
+mod range_item_header_value;
+mod range_condition_header_value;
+mod entity_tag_header_value;
+mod date_time_offset;
+mod content_range_header_value;
+
+
+pub use range_header_value::RangeHeaderValue;
+pub use range_item_header_value::RangeItemHeaderValue;
+pub use range_condition_header_value::RangeConditionHeaderValue;
+pub use entity_tag_header_value::EntityTagHeaderValue;
+pub use content_range_header_value::ContentRangeHeaderValue;
+pub use date_time_offset::DateTimeOffset;
+
+/// Strongly typed HTTP request headers.
+pub struct RequestHeaders<'r, 'h> (&'r HeaderMap<'h>);
+
+impl<'r, 'h> RequestHeaders<'r, 'h> {
+
+    /// Get typed HeaderValue
+    pub fn range(&self) -> Option<RangeHeaderValue> {
+        self.0.get_typed_header_value(header_names::RANGE)
+    }
+
+    /// Get typed HeaderValue
+    pub fn if_range(&self) -> Option<RangeConditionHeaderValue> {
+        self.0.get_typed_header_value(header_names::IF_RANGE)
+    }
+
+    /// Get typed HeaderValue
+    pub fn if_modified_since(&self) -> Option<DateTimeOffset> {
+        self.0.get_typed_header_value(header_names::IF_MODIFIED_SINCE)
+    }
+
+    /// Get typed HeaderValue
+    pub fn if_unmodified_since(&self) -> Option<DateTimeOffset> {
+        self.0.get_typed_header_value(header_names::IF_UNMODIFIED_SINCE)
+    }
+
+    /// Get typed HeaderValue
+    pub fn if_match(&self) -> Vec<EntityTagHeaderValue> {
+        self.0.get_typed_header_value_list(header_names::IF_MATCH)
+    }
+
+    /// Get typed HeaderValue
+    pub fn if_none_match(&self) -> Vec<EntityTagHeaderValue> {
+        self.0.get_typed_header_value_list(header_names::IF_NONE_MATCH)
+    }
+}
+
+/// Strongly typed HTTP request headers.
+pub trait TypedHeaders {
+    /// Gets strongly typed HTTP request headers.
+    fn get_typed_headers(&self) -> RequestHeaders<'_, '_>;
+
+    /// Gets strongly typed HTTP request header value.
+    fn get_typed_header_value<'a, T>(&'a self, name: &str) -> Option<T> where T: TryFrom<Vec<&'a str>>;
+
+    /// Gets strongly typed HTTP request header values.
+    fn get_typed_header_value_list<'a, T>(&'a self, name: &str) -> Vec<T> where T: TryFrom<Vec<&'a str>>;
+}
+
+impl<'h> TypedHeaders for HeaderMap<'h> {
+    fn get_typed_headers(&self) -> RequestHeaders<'_, '_> {
+        RequestHeaders (self)
+    }
+
+    fn get_typed_header_value<'a, T>(&'a self, name: &str) -> Option<T> where T: TryFrom<Vec<&'a str>> {
+        let header_values: Vec<&str> = self.get(name).collect();
+        let p = T::try_from(header_values)
+            .map(|x| Some(x))
+            .unwrap_or(None);
+
+        p
+    }
+
+    fn get_typed_header_value_list<'a, T>(&'a self, name: &str) -> Vec<T> where T: TryFrom<Vec<&'a str>> {
+        let header_values: Vec<&str> = self.get(name).collect();
+        let mut v = Vec::new();
+        for header_value in header_values {
+            if let Ok(t) = T::try_from(vec![header_value]) {
+                v.push(t)
+            }
+        }
+        v
+    }
+}

--- a/core/http/src/header/typed_header/range_condition_header_value.rs
+++ b/core/http/src/header/typed_header/range_condition_header_value.rs
@@ -1,0 +1,127 @@
+use std::convert::TryFrom;
+use super::{
+    EntityTagHeaderValue, DateTimeOffset
+};
+use std::result::Result::Ok;
+
+pub enum RangeConditionHeaderValue {
+    LastModified(DateTimeOffset),
+    EntityTag(EntityTagHeaderValue)
+}
+
+impl RangeConditionHeaderValue {
+    pub fn last_modified(&self) -> Option<&DateTimeOffset> {
+        match self {
+            RangeConditionHeaderValue::LastModified(date) => Some(date),
+            RangeConditionHeaderValue::EntityTag(_) => None
+        }
+    }
+    pub fn entity_tag(&self) -> Option<&EntityTagHeaderValue> {
+        match self {
+            RangeConditionHeaderValue::LastModified(_) => None,
+            RangeConditionHeaderValue::EntityTag(etag) => Some(etag)
+        }
+    }
+}
+
+impl TryFrom<Vec<&str>> for RangeConditionHeaderValue {
+    type Error = ();
+
+    fn try_from(value: Vec<&str>) -> Result<Self, Self::Error> {
+        if value.len() == 0 {
+            return Err(());
+        }
+        let start_index = 0;
+
+        // Parse the unit string: <unit> in '<unit>=<from1>-<to1>, <from2>-<to2>'
+        let input = value[0].chars().collect::<Vec<char>>();
+
+        if input.is_empty() || start_index + 1 >= input.len() {
+            return Err(());
+        }
+
+        let mut current = start_index;
+
+        // Caller must remove leading whitespaces.
+        let mut entity_tag = EntityTagHeaderValue::any();
+
+        let first_char = input[current];
+        let second_char = input[current + 1];
+        if (first_char == '"') || (((first_char == 'w') || (first_char == 'W')) && (second_char == '/')) {
+            // trailing whitespaces are removed by GetEntityTagLength()
+            let entity_tag_length = EntityTagHeaderValue::get_entity_tag_length(
+                &input, current,
+                &mut entity_tag);
+
+            if entity_tag_length == 0 {
+                return Err(());
+            }
+
+            current += entity_tag_length;
+
+            // RangeConditionHeaderValue only allows 1 value. There must be no delimiter/other chars after an
+            // entity tag.
+            if current != input.len() {
+
+                return Err(());
+            }
+            Ok(Self::EntityTag(entity_tag) )
+        } else {
+            if let Ok(date) = DateTimeOffset::try_from(&input[current..]){
+                // If we got a valid date, then the parser consumed the whole string (incl. trailing whitespaces).
+                // current = input.len();
+                Ok(Self::LastModified(date) )
+            } else {
+                return Err(());
+            }
+        }
+    }
+}
+
+impl ToString for RangeConditionHeaderValue {
+    fn to_string(&self) -> String {
+        match self {
+            RangeConditionHeaderValue::LastModified(date) => date.to_string(),
+            RangeConditionHeaderValue::EntityTag(etag) => etag.to_string()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::*;
+    use std::time::SystemTime;
+    use chrono::{DateTime, FixedOffset, TimeZone};
+
+    #[test]
+    fn test_last_modified(){
+        let mut headers = HeaderMap::new();
+        headers.add_raw(header_names::IF_RANGE, "Wed, 18 Feb 2015 23:16:09 GMT");
+
+        let value = headers.get_typed_headers().if_range().unwrap();
+
+        assert_eq!(
+            &DateTimeOffset::from(FixedOffset::east(0).ymd(2015, 2, 18).and_hms(23, 16, 9)),
+                   value.last_modified().unwrap());
+
+        assert_eq!("Wed, 18 Feb 2015 23:16:09 GMT", value.to_string())
+    }
+
+    #[test]
+    fn test_etag(){
+        let mut headers = HeaderMap::new();
+        headers.add_raw(header_names::IF_RANGE, r#""675af34563dc-tr34""#);
+
+        let value = headers.get_typed_headers().if_range().unwrap();
+        assert_eq!(r#""675af34563dc-tr34""#, value.to_string());
+    }
+
+    #[test]
+    fn test_etag1(){
+        let mut headers = HeaderMap::new();
+        headers.add_raw(header_names::IF_RANGE, r#"W/"675af34563dc-tr34""#);
+
+        let value = headers.get_typed_headers().if_range().unwrap();
+        assert_eq!(r#"W/"675af34563dc-tr34""#, value.to_string())
+    }
+}

--- a/core/http/src/header/typed_header/range_condition_header_value.rs
+++ b/core/http/src/header/typed_header/range_condition_header_value.rs
@@ -5,6 +5,7 @@ use super::{
 use std::result::Result::Ok;
 
 /// Represents an `If-Range` header value which can either be a date/time or an entity-tag value.
+#[derive(Clone)]
 pub enum RangeConditionHeaderValue {
 
     /// A date value used to initialize the new instance.

--- a/core/http/src/header/typed_header/range_header_value.rs
+++ b/core/http/src/header/typed_header/range_header_value.rs
@@ -1,0 +1,146 @@
+use std::convert::TryFrom;
+use super::{
+    http_rule_parser,
+    RangeItemHeaderValue
+};
+
+/// Represents a *Range* header value.
+///
+/// The `RangeHeaderValue` provides support for the Range header as defined in
+/// [RFC 2616](https://tools.ietf.org/html/rfc2616)
+pub struct RangeHeaderValue {
+    /// The unit from the header.
+    pub unit: Vec<char>,
+
+    /// The ranges specified in the header.
+    pub ranges: Vec<RangeItemHeaderValue>
+}
+
+impl RangeHeaderValue {
+    pub fn new(from: Option<u64>, to: Option<u64>) -> Self {
+        let mut v = Self::default();
+        v.ranges.push(RangeItemHeaderValue::new(from, to));
+        v
+    }
+}
+
+impl Default for RangeHeaderValue {
+    fn default() -> Self {
+        Self { unit: "bytes".chars().collect(), ranges: Vec::new() }
+    }
+}
+
+
+impl TryFrom<Vec<&str>> for RangeHeaderValue {
+    type Error = ();
+
+    fn try_from(value: Vec<&str>) -> Result<Self, Self::Error> {
+        if value.len() == 0 {
+            return Err(());
+        }
+        let start_index = 0;
+
+        // Parse the unit string: <unit> in '<unit>=<from1>-<to1>, <from2>-<to2>'
+        let input = value[0].chars().collect::<Vec<char>>();
+        let unit_len = http_rule_parser::get_token_length(&input, start_index);
+        if unit_len == 0 {
+            return Err(());
+        }
+        let mut result = Self::default();
+        result.unit = input[start_index..start_index + unit_len].to_owned();
+        let mut current = start_index + unit_len;
+        current += http_rule_parser::get_whitespace_length(&input, current);
+        if current == input.len() || input[current] != '=' {
+            return Err(())
+        }
+        current += 1; // skip '=' separator
+        current += http_rule_parser::get_whitespace_length(&input, current);
+        let ranges_len = RangeItemHeaderValue::get_range_item_list_length(&input, current, &mut result.ranges);
+
+        if ranges_len == 0 {
+            return Err(());
+        }
+        current += ranges_len;
+
+        assert_eq!(current, input.len());
+
+        Ok(result)
+    }
+}
+
+
+impl ToString for RangeHeaderValue {
+    fn to_string(&self) -> String {
+        let mut s = String::new();
+        self.unit.iter().for_each(|u|s.push(*u));
+        s.push('=');
+
+        for (i, range) in self.ranges.iter().enumerate() {
+            if i > 0 {
+                s.push(',');
+                s.push(' ');
+            }
+            if let Some(ref f) = range.from {
+                s.push_str(f.to_string().as_str());
+            }
+            s.push('-');
+            if let Some(ref t) = range.to {
+                s.push_str(t.to_string().as_str());
+            }
+        }
+
+        s
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::*;
+    use super::super::HeaderMap;
+
+    #[test]
+    fn test_get_range_header_value_u_s() {
+        let mut headers = HeaderMap::new();
+        headers.add_raw(header_names::RANGE, "bytes=0-");
+        let value = headers.get_typed_headers().range().unwrap();
+
+        assert_eq!(0, value.ranges[0].from.unwrap());
+        assert_eq!(None, value.ranges[0].to);
+        assert_eq!("bytes=0-", value.to_string());
+    }
+
+    #[test]
+    fn test_get_range_header_value_u_s1() {
+        let mut headers = HeaderMap::new();
+        headers.add_raw(header_names::RANGE, "bytes = 0 -");
+        let value = headers.get_typed_headers().range().unwrap();
+
+        assert_eq!(0, value.ranges[0].from.unwrap());
+        assert_eq!(None, value.ranges[0].to);
+        assert_eq!("bytes=0-", value.to_string());
+    }
+
+    #[test]
+    fn test_get_range_header_value_u_s_e() {
+        let mut headers = HeaderMap::new();
+        headers.add_raw(header_names::RANGE, "bytes=7-9");
+        let value = headers.get_typed_headers().range().unwrap();
+
+        assert_eq!(7, value.ranges[0].from.unwrap());
+        assert_eq!(9, value.ranges[0].to.unwrap());
+        assert_eq!("bytes=7-9", value.to_string());
+    }
+
+    #[test]
+    fn test_get_range_header_value_u_s_e_2() {
+        let mut headers = HeaderMap::new();
+        headers.add_raw(header_names::RANGE, "bytes=7-9,11-13");
+        let value = headers.get_typed_headers().range().unwrap();
+
+        assert_eq!(7, value.ranges[0].from.unwrap());
+        assert_eq!(9, value.ranges[0].to.unwrap());
+        assert_eq!(11, value.ranges[1].from.unwrap());
+        assert_eq!(13, value.ranges[1].to.unwrap());
+        assert_eq!("bytes=7-9, 11-13", value.to_string());
+    }
+}

--- a/core/http/src/header/typed_header/range_header_value.rs
+++ b/core/http/src/header/typed_header/range_header_value.rs
@@ -8,6 +8,7 @@ use super::{
 ///
 /// The `RangeHeaderValue` provides support for the Range header as defined in
 /// [RFC 2616](https://tools.ietf.org/html/rfc2616)
+#[derive(Clone)]
 pub struct RangeHeaderValue {
     /// The unit from the header.
     pub unit: Vec<char>,

--- a/core/http/src/header/typed_header/range_header_value.rs
+++ b/core/http/src/header/typed_header/range_header_value.rs
@@ -17,6 +17,8 @@ pub struct RangeHeaderValue {
 }
 
 impl RangeHeaderValue {
+
+    /// Initializes a new struct of `RangeHeaderValue`.
     pub fn new(from: Option<u64>, to: Option<u64>) -> Self {
         let mut v = Self::default();
         v.ranges.push(RangeItemHeaderValue::new(from, to));
@@ -35,7 +37,7 @@ impl TryFrom<Vec<&str>> for RangeHeaderValue {
     type Error = ();
 
     fn try_from(value: Vec<&str>) -> Result<Self, Self::Error> {
-        if value.len() == 0 {
+        if value.is_empty() {
             return Err(());
         }
         let start_index = 0;
@@ -46,8 +48,10 @@ impl TryFrom<Vec<&str>> for RangeHeaderValue {
         if unit_len == 0 {
             return Err(());
         }
-        let mut result = Self::default();
-        result.unit = input[start_index..start_index + unit_len].to_owned();
+        let mut result = Self{
+            unit: input[start_index..start_index + unit_len].to_owned(),
+            ..Self::default()
+        };
         let mut current = start_index + unit_len;
         current += http_rule_parser::get_whitespace_length(&input, current);
         if current == input.len() || input[current] != '=' {

--- a/core/http/src/header/typed_header/range_item_header_value.rs
+++ b/core/http/src/header/typed_header/range_item_header_value.rs
@@ -4,14 +4,20 @@ use super::{http_rule_parser, header_utilities};
 /// Represents a byte range in a Range header value.
 #[derive(Default, Clone, Debug)]
 pub struct RangeItemHeaderValue {
+    /// The position at which to start sending data.
     pub from: Option<u64>,
+
+    /// The position at which to stop sending data.
     pub to: Option<u64>
 }
 
 impl RangeItemHeaderValue {
+    /// Initializes a new instance of the `RangeItemHeaderValue`.
     pub fn new(from: Option<u64>, to: Option<u64>) -> Self {
         Self{ from, to }
     }
+
+    /// Normalize the `RangeItemHeaderValue`
     pub fn normalize(&self, len: u64) -> Option<Self> {
         let mut start = self.from;
         let mut end = self.to;
@@ -37,10 +43,11 @@ impl RangeItemHeaderValue {
         }
         Some(Self::new(start, end))
     }
+
     //noinspection RsSelfConvention
     pub(super) fn get_range_item_length(input: &[char], start_index: usize, parsed_value: &mut Self) -> usize {
         // This parser parses number ranges: e.g. '1-2', '1-', '-2'.
-        if input.len() == 0 || input[0] ==' ' || start_index >= input.len() {
+        if input.is_empty() || input[0] ==' ' || start_index >= input.len() {
             return 0;
         }
         // Caller must remove leading whitespaces. If not, we'll return 0.
@@ -102,7 +109,7 @@ impl RangeItemHeaderValue {
     //noinspection RsSelfConvention
     pub(super) fn get_range_item_list_length(input: &[char], start_index: usize, ranges: &mut Vec<Self>) -> usize {
 
-        if input.len() == 0 || start_index >=input.len() {
+        if input.is_empty() || start_index >=input.len() {
             return 0;
         }
         // Empty segments are allowed, so skip all delimiter-only segments (e.g. ", ,").

--- a/core/http/src/header/typed_header/range_item_header_value.rs
+++ b/core/http/src/header/typed_header/range_item_header_value.rs
@@ -1,0 +1,137 @@
+
+use super::{http_rule_parser, header_utilities};
+
+/// Represents a byte range in a Range header value.
+#[derive(Default, Clone, Debug)]
+pub struct RangeItemHeaderValue {
+    pub from: Option<u64>,
+    pub to: Option<u64>
+}
+
+impl RangeItemHeaderValue {
+    pub fn new(from: Option<u64>, to: Option<u64>) -> Self {
+        Self{ from, to }
+    }
+    pub fn normalize(&self, len: u64) -> Option<Self> {
+        let mut start = self.from;
+        let mut end = self.to;
+        // X-[Y]
+        if let Some(s) = start {
+            if s >= len {
+                // Not satisfiable, skip/discard.
+                return None;
+            }
+            if end.is_none() || end.unwrap() >= len {
+                end = Some(len - 1);
+            }
+        } else {
+            if let Some(e) = end {
+                if e == 0 {
+                    // Not satisfiable, skip/discard.
+                    return None;
+                }
+            }
+            let bytes = std::cmp::min(end.unwrap(), len);
+            start = Some(len - bytes);
+            end = Some(start.unwrap() + bytes - 1);
+        }
+        Some(Self::new(start, end))
+    }
+    //noinspection RsSelfConvention
+    pub(super) fn get_range_item_length(input: &[char], start_index: usize, parsed_value: &mut Self) -> usize {
+        // This parser parses number ranges: e.g. '1-2', '1-', '-2'.
+        if input.len() == 0 || input[0] ==' ' || start_index >= input.len() {
+            return 0;
+        }
+        // Caller must remove leading whitespaces. If not, we'll return 0.
+        let mut current = start_index;
+        // Try parse the first value of a value pair.
+        let from_start_index = current;
+        let from_len = http_rule_parser::get_number_length(input, current, false);
+        if from_len > http_rule_parser::MAX_INT64DIGITS {
+            return 0;
+        }
+        current += from_len;
+        current += http_rule_parser::get_whitespace_length(input, current);
+
+        if current == input.len() || input[current] != '-' {
+            // We need a '-' character otherwise this can't be a valid range.
+            return 0;
+        }
+
+        current += 1; // skip the '-' character
+        current += http_rule_parser::get_whitespace_length(input, current);
+
+        let to_start_index = current;
+        let mut to_len = 0;
+
+        if current < input.len() {
+            to_len = http_rule_parser::get_number_length(input, current, false);
+            if to_len > http_rule_parser::MAX_INT64DIGITS {
+                return 0;
+            }
+            current += to_len;
+            current += http_rule_parser::get_whitespace_length(input, current);
+        }
+        if from_len == 0 && to_len == 0 {
+            return 0;  // At least one value must be provided in order to be a valid range.
+        }
+
+        // Try convert first value to int64
+        let mut from= 0;
+        if from_len > 0 && !header_utilities::try_parse_non_negative_int64(&input[from_start_index..from_start_index + from_len], &mut from) {
+            return 0;
+        }
+        let mut to= 0;
+
+        // Try convert first value to int64
+        if to_len > 0 && !header_utilities::try_parse_non_negative_int64(&input[to_start_index..to_start_index + to_len], &mut to) {
+            return 0;
+        }
+
+        // 'from' must not be greater than 'to'
+        if from_len > 0 && to_len > 0 && from > to {
+            return 0;
+        }
+        *parsed_value = Self::new(
+            if from_len == 0 { None } else {Some(from) },
+            if to_len == 0 { None } else { Some(to) }
+        );
+        current - start_index
+    }
+    //noinspection RsSelfConvention
+    pub(super) fn get_range_item_list_length(input: &[char], start_index: usize, ranges: &mut Vec<Self>) -> usize {
+
+        if input.len() == 0 || start_index >=input.len() {
+            return 0;
+        }
+        // Empty segments are allowed, so skip all delimiter-only segments (e.g. ", ,").
+        let mut separator_found = false;
+        let mut current = header_utilities::get_next_non_empty_or_whitespace_index(input, start_index, true, &mut separator_found);
+        // It's OK if we didn't find leading separator characters. Ignore 'separatorFound'.
+
+        if current == input.len() {
+            return 0;
+        }
+        let mut range = Self::default();
+
+        loop {
+            let range_len  = Self::get_range_item_length(input, current, &mut range);
+            if range_len == 0 {
+                return 0;
+            }
+            ranges.push(range.clone());
+            current += range_len;
+            current = header_utilities::get_next_non_empty_or_whitespace_index(input, current, true, &mut separator_found);
+
+            // If the string is not consumed, we must have a delimiter, otherwise the string is not a valid
+            // range list.
+            if current < input.len() && !separator_found {
+                return 0;
+            }
+            if current == input.len() {
+                return current - start_index;
+            }
+        }
+    }
+}

--- a/core/lib/Cargo.toml
+++ b/core/lib/Cargo.toml
@@ -58,6 +58,7 @@ async-stream = "0.3.2"
 multer = { version = "2", features = ["tokio-io"] }
 tokio-stream = { version = "0.1.6", features = ["signal", "time"] }
 state = "0.5.1"
+enum-flags = "^0.1.6"
 
 [dependencies.rocket_codegen]
 version = "0.5.0-rc.1"

--- a/core/lib/Cargo.toml
+++ b/core/lib/Cargo.toml
@@ -58,7 +58,7 @@ async-stream = "0.3.2"
 multer = { version = "2", features = ["tokio-io"] }
 tokio-stream = { version = "0.1.6", features = ["signal", "time"] }
 state = "0.5.1"
-enum-flags = "^0.1.6"
+enum-flags = "^0.1.7"
 
 [dependencies.rocket_codegen]
 version = "0.5.0-rc.1"

--- a/core/lib/src/fs/mod.rs
+++ b/core/lib/src/fs/mod.rs
@@ -2,11 +2,13 @@
 
 mod server;
 mod named_file;
+mod static_file;
 mod temp_file;
 mod file_name;
 
 pub use server::*;
 pub use named_file::*;
+pub use static_file::*;
 pub use temp_file::*;
 pub use file_name::*;
 pub use server::relative;

--- a/core/lib/src/fs/static_file.rs
+++ b/core/lib/src/fs/static_file.rs
@@ -1,0 +1,494 @@
+
+use std::io;
+use std::path::{Path, PathBuf};
+use std::ops::{Deref, DerefMut};
+
+use enum_flags::EnumFlags;
+use crate::{
+    http::{ContentType, Status, Method, TypedHeaders},
+    response::{Responder, Builder},
+    {Request, response, Response},
+    tokio::fs::File,
+    tokio::io::{ AsyncSeek}
+};
+
+use std::io::{SeekFrom};
+
+
+use crate::http::{
+    header_names,
+    RangeItemHeaderValue,
+    RangeHeaderValue,
+    RangeConditionHeaderValue,
+    DateTimeOffset,
+    EntityTagHeaderValue,
+    ContentRangeHeaderValue};
+
+
+/// A [`Responder`] that sends a file with a Content-Type based on its name.
+///
+/// # Example
+///
+/// A simple static file server mimicking [`FileServer`]:
+///
+/// ```rust
+/// # use rocket::get;
+/// use std::path::{PathBuf, Path};
+///
+/// use rocket::fs::{StaticFile, relative};
+///
+/// #[get("/file/<path..>")]
+/// pub async fn second(path: PathBuf) -> Option<StaticFile> {
+///     let mut path = Path::new(relative!("static")).join(path);
+///     if path.is_dir() {
+///         path.push("index.html");
+///     }
+///
+///     StaticFile::open(path).await.ok()
+/// }
+/// ```
+///
+/// Always prefer to use [`FileServer`] which has more functionality and a
+/// pithier API.
+///
+/// [`FileServer`]: crate::fs::FileServer
+#[derive(Debug)]
+pub struct StaticFile {
+    path: PathBuf,
+    file: File,
+    content_type: Option<ContentType>,
+    len: u64,
+    last_modified: DateTimeOffset,
+    etag: EntityTagHeaderValue,
+    if_match_state: PreconditionState,
+    if_none_match_state: PreconditionState,
+    if_modified_since_state: PreconditionState,
+    if_unmodified_since_state: PreconditionState,
+    range: Option<RangeItemHeaderValue>,
+    request_type: RequestType
+}
+
+impl StaticFile {
+    /// Attempts to open a file in read-only mode.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if path does not already exist. Other
+    /// errors may also be returned according to
+    /// [`OpenOptions::open()`](std::fs::OpenOptions::open()).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use rocket::get;
+    /// use rocket::fs::NamedFile;
+    ///
+    /// #[get("/")]
+    /// async fn index() -> Option<NamedFile> {
+    ///     NamedFile::open("index.html").await.ok()
+    /// }
+    /// ```
+    pub async fn open<P: AsRef<Path>>(path: P) -> io::Result<StaticFile> {
+        // FIXME: Grab the file size here and prohibit `seek`ing later (or else
+        // the file's effective size may change), to save on the cost of doing
+        // all of those `seek`s to determine the file size. But, what happens if
+        // the file gets changed between now and then?
+        let path = path.as_ref();
+        let file = File::open(path).await?;
+        let metadata = file.metadata().await?;
+        let len = metadata.len();
+        let modified: DateTimeOffset = metadata.modified().unwrap().into();
+        let etag_hash = modified.timestamp_millis() ^ len as i64;
+        let etag_hash = format!("{:x}", etag_hash);
+        let content_type = path.extension()
+            .map(|ext| ContentType::from_extension(&ext.to_string_lossy()))
+            .unwrap_or_default();
+
+        Ok(StaticFile {
+            path: path.to_path_buf(),
+            file,
+            content_type,
+            len,
+            etag: etag_hash.into(),
+            last_modified: modified,
+            if_match_state: PreconditionState::Unspecified,
+            if_none_match_state: PreconditionState::Unspecified,
+            if_modified_since_state: PreconditionState::Unspecified,
+            if_unmodified_since_state: PreconditionState::Unspecified,
+            range: None,
+            request_type: RequestType::Unspecified
+        })
+    }
+
+    /// Retrieve the underlying `File`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use rocket::fs::NamedFile;
+    ///
+    /// # async fn f() -> std::io::Result<()> {
+    /// let named_file = NamedFile::open("index.html").await?;
+    /// let file = named_file.file();
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline(always)]
+    pub fn file(&self) -> &File {
+        &self.file
+    }
+
+    /// Retrieve a mutable borrow to the underlying `File`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use rocket::fs::NamedFile;
+    ///
+    /// # async fn f() -> std::io::Result<()> {
+    /// let mut named_file = NamedFile::open("index.html").await?;
+    /// let file = named_file.file_mut();
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline(always)]
+    pub fn file_mut(&mut self) -> &mut File {
+        &mut self.file
+    }
+
+    /// Take the underlying `File`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use rocket::fs::NamedFile;
+    ///
+    /// # async fn f() -> std::io::Result<()> {
+    /// let named_file = NamedFile::open("index.html").await?;
+    /// let file = named_file.take_file();
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline(always)]
+    pub fn take_file(self) -> File {
+        self.file
+    }
+
+    /// Retrieve the path of this file.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use rocket::fs::NamedFile;
+    ///
+    /// # async fn demo_path() -> std::io::Result<()> {
+    /// let file = NamedFile::open("foo.txt").await?;
+    /// assert_eq!(file.path().as_os_str(), "foo.txt");
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline(always)]
+    pub fn path(&self) -> &Path {
+        self.path.as_path()
+    }
+
+    fn is_range_request(&self) -> bool {
+        self.request_type.contains(RequestType::IsRange)
+    }
+
+    fn comprehend_request_headers(&mut self, req: &Request<'_>) {
+        // ComputeIfMatch
+        self.compute_if_match(req);
+
+        // compute_if_modified_since
+        self.compute_if_modified_since(req);
+
+        // ComputeRange
+
+        self.compute_range(req);
+
+        // ComputeIfRange
+        self.compute_if_range(req);
+    }
+
+    fn get_precondition_state(&self) -> PreconditionState {
+        let mut max = PreconditionState::Unspecified;
+        for i in [
+            self.if_match_state, self.if_none_match_state,
+            self.if_modified_since_state, self.if_unmodified_since_state] {
+            if i > max {
+                max = i;
+            }
+        }
+        max
+    }
+
+    fn compute_if_match(&mut self, req: &Request<'_>) {
+        let request_headers = req.headers().get_typed_headers();
+
+        // 14.24 If-Match
+        let if_match = request_headers.if_match();
+        if !if_match.is_empty() {
+            self.if_match_state = PreconditionState::PreconditionFailed;
+            for etag in if_match {
+                if etag == EntityTagHeaderValue::any() && etag.compare(&self.etag, true) {
+                    self.if_match_state = PreconditionState::ShouldProcess;
+                    break;
+                }
+            }
+        }
+
+        // 14.26 If-None-Match
+        let if_none_match = request_headers.if_none_match();
+        if !if_none_match.is_empty() {
+            self.if_none_match_state = PreconditionState::ShouldProcess;
+
+            for etag in if_none_match {
+                if etag == EntityTagHeaderValue::any() || etag.compare(&self.etag, true) {
+                    self.if_none_match_state = PreconditionState::NotModified;
+                    break;
+                }
+            }
+        }
+    }
+
+    fn compute_if_modified_since(&mut self, req: &Request<'_>) {
+        let now = DateTimeOffset::now();
+
+        let request_headers = req.headers().get_typed_headers();
+
+        // 14.25 If-Modified-Since
+        if let Some(if_modified_since) = request_headers.if_modified_since() {
+            if if_modified_since <= now {
+                self.if_modified_since_state = if if_modified_since < self.last_modified {
+                    PreconditionState::ShouldProcess
+                } else {
+                    PreconditionState::NotModified
+                }
+            }
+        }
+
+        // 14.28 If-Unmodified-Since
+        if let Some(if_unmodified_since) = request_headers.if_unmodified_since() {
+            if if_unmodified_since <= now {
+                self.if_unmodified_since_state = if if_unmodified_since >= self.last_modified {
+                    PreconditionState::ShouldProcess
+                } else {
+                    PreconditionState::PreconditionFailed
+                }
+            }
+        }
+    }
+
+    fn compute_if_range(&mut self, req: &Request<'_>) {
+        if let Some(if_range_header) = req.headers().get_typed_headers().if_range() {
+            match if_range_header {
+                RangeConditionHeaderValue::LastModified(last_modified) => {
+                    if self.last_modified > last_modified {
+                        self.request_type = self.request_type - RequestType::IsRange;
+                    }
+                }
+                RangeConditionHeaderValue::EntityTag(etag) => {
+                    if !etag.compare(&self.etag, true) {
+                        self.request_type = self.request_type - RequestType::IsRange;
+                    }
+                }
+            }
+        }
+    }
+
+    fn compute_range(&mut self, req: &Request<'_>) {
+        if req.method() != Method::Get {
+            return;
+        }
+
+        let (is_range_request, range) = self.parse_range(req, self.len);
+
+        self.range = range;
+        if is_range_request {
+            self.request_type |= RequestType::IsRange
+        } else {
+            self.request_type -= RequestType::IsRange
+        }
+    }
+
+    fn parse_range(&mut self, req: &Request<'_>, len: u64) -> (bool, Option<RangeItemHeaderValue>) {
+        let raw_range_header = req.headers().get(header_names::RANGE).collect::<Vec<&str>>();
+
+        if raw_range_header.is_empty() || raw_range_header.join("") == "" {
+            // Range header's value is empty.
+            return (false, None);
+        }
+
+        if raw_range_header.len() > 1 || raw_range_header.get(0).unwrap().find(",").is_some() {
+            // Multiple ranges are not supported.
+
+            // The spec allows for multiple ranges but we choose not to support them because the client may request
+            // very strange ranges (e.g. each byte separately, overlapping ranges, etc.) that could negatively
+            // impact the server. Ignore the header and serve the response normally.
+            return (false, None);
+        }
+
+        let range_header: Option<RangeHeaderValue> = req.headers().get_typed_headers().range();
+        if range_header.is_none() {
+            // Range header's value is invalid.
+            // Invalid
+            return (false, None);
+        }
+        let range_header = range_header.unwrap();
+
+        // Already verified above
+        assert_eq!(1, range_header.ranges.len());
+        let ranges = &range_header.ranges;
+        if ranges.is_empty() {
+            return (true, None);
+        }
+
+        if len == 0 {
+            return (true, None);
+        }
+
+        let range = ranges.first()
+            .map(|r| r.normalize(len))
+            .unwrap_or_default();
+
+        (range.is_some(), range)
+    }
+
+    fn apply_response_headers(&mut self, builder: &mut Builder<'_>, status: Status) {
+        builder.status(status);
+        if status.code < 400 {
+
+            // these headers are returned for 200, 206, and 304
+            // they are not returned for 412 and 416
+
+            if let Some(ct) = &self.content_type {
+                builder.header(ct.clone());
+            }
+            builder.raw_header(header_names::LAST_MODIFIED, self.last_modified.to_string());
+            builder.raw_header(header_names::ETAG, self.etag.to_string());
+            builder.raw_header(header_names::ACCEPT_RANGES, "bytes");
+            builder.raw_header(header_names::CONNECTION, "keep-alive");
+        }
+
+        if status == Status::Ok {
+            // this header is only returned here for 200
+            // it already set to the returned range for 206
+            // it is not returned for 304, 412, and 416
+            builder.raw_header(header_names::CONTENT_LENGTH, self.len.to_string());
+        }
+    }
+
+    fn send<'r>(self, req: &'r Request<'_>) -> response::Result<'static> {
+        let mut response = self.file.respond_to(req)?;
+        if let Some(ct) = self.content_type {
+            response.set_header(ct);
+        }
+        Ok(response)
+    }
+
+    fn send_range<'r>(mut self, _req: &'r Request<'_>) -> response::Result<'static> {
+        // do range
+        if let Some(ref range) = self.range {
+            let mut builder = Response::build();
+            let content_range_header = ContentRangeHeaderValue::from(range);
+            let from = content_range_header.from.unwrap();
+            let length = content_range_header.length.unwrap();
+            builder.header(content_range_header);
+            builder.raw_header(header_names::CONTENT_LENGTH, length.to_string());
+
+            self.apply_response_headers(&mut builder, Status::PartialContent);
+
+            if from > 0 {
+                std::pin::Pin::new(&mut self.file)
+                    .start_seek(SeekFrom::Start(from))
+                    .unwrap();
+            }
+
+            builder.sized_body(length as usize, self.file);
+
+            Ok(builder.finalize())
+        } else {
+            // 14.16 Content-Range - A server sending a response with status code 416 (Requested range not satisfiable)
+            // SHOULD include a Content-Range field with a byte-range-resp-spec of "*". The instance-length specifies
+            // the current length of the selected resource.  e.g. */length
+            let mut builder = Response::build();
+            builder.header(ContentRangeHeaderValue::from(self.len));
+
+            self.apply_response_headers(&mut builder,Status::RangeNotSatisfiable);
+
+            Ok(builder.finalize())
+        }
+    }
+}
+
+/// Streams the named file to the client. Sets or overrides the Content-Type in
+/// the response according to the file's extension if the extension is
+/// recognized. See [`ContentType::from_extension()`] for more information. If
+/// you would like to stream a file with a different Content-Type than that
+/// implied by its extension, use a [`File`] directly.
+impl<'r> Responder<'r, 'static> for StaticFile {
+    fn respond_to(mut self, req: &'r Request<'_>) -> response::Result<'static> {
+        use PreconditionState::*;
+        self.comprehend_request_headers(req);
+        match self.get_precondition_state() {
+            Unspecified | ShouldProcess=> {
+                if req.method() == Method::Head {
+                    Ok(Response::build()
+                        .status(Status::Ok)
+                        .finalize())
+                } else{
+                    if self.is_range_request() {
+                        self.send_range(req)
+                    } else {
+                        self.send(req)
+                    }
+                }
+            }
+            NotModified => {
+                Ok(Response::build()
+                        .status(Status::NotModified)
+                        .finalize())
+            }
+            PreconditionFailed => {
+                Ok(Response::build()
+                    .status(Status::PreconditionFailed)
+                    .finalize())
+            }
+        }
+    }
+}
+
+impl Deref for StaticFile {
+    type Target = File;
+
+    fn deref(&self) -> &File {
+        &self.file
+    }
+}
+
+impl DerefMut for StaticFile {
+    fn deref_mut(&mut self) -> &mut File {
+        &mut self.file
+    }
+}
+
+
+#[repr(u8)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Ord, PartialOrd)]
+enum PreconditionState
+{
+    Unspecified,
+    NotModified,
+    ShouldProcess,
+    PreconditionFailed,
+}
+
+#[repr(u8)]
+#[derive(EnumFlags, Copy, Clone, Eq, PartialEq)]
+enum RequestType {
+    Unspecified = 0,
+    IsHead = 1,
+    IsGet = 2,
+    IsRange = 4,
+}

--- a/core/lib/src/fs/static_file.rs
+++ b/core/lib/src/fs/static_file.rs
@@ -391,9 +391,10 @@ impl StaticFile {
         // do range
         if let Some(ref range) = self.range {
             let mut builder = Response::build();
-            let content_range_header = ContentRangeHeaderValue::from(range);
-            let from = content_range_header.from.unwrap();
-            let length = content_range_header.length.unwrap();
+            let from = range.from.unwrap();
+            let to = range.to.unwrap();
+            let length = to - from + 1;
+            let content_range_header: ContentRangeHeaderValue = (from, to, self.len).into();
             builder.header(content_range_header);
             builder.raw_header(header_names::CONTENT_LENGTH, length.to_string());
 

--- a/core/lib/src/fs/static_file/mod.rs
+++ b/core/lib/src/fs/static_file/mod.rs
@@ -1,0 +1,220 @@
+#![allow(dead_code)]
+
+use std::io;
+use std::ops::{Deref, DerefMut};
+use std::path::{Path, PathBuf};
+
+
+use crate::{
+    http::{
+        ContentType,
+        DateTimeOffset,
+        EntityTagHeaderValue
+    },
+    request::Request,
+    response::{self, Responder},
+    tokio::{
+        fs::File,
+        io::AsyncSeek
+    }
+};
+
+mod static_file_context;
+
+pub use static_file_context::*;
+use std::io::SeekFrom;
+
+/// A [`Responder`] that sends file data with a Content-Type based on its
+/// file extension.
+///
+/// # Example
+///
+/// A simple static file server mimicking [`FileServer`]:
+///
+/// ```rust
+/// # use rocket::get;
+/// use std::path::{PathBuf, Path};
+///
+/// use rocket::fs::{StaticFile, relative};
+///
+/// #[get("/file/<path..>")]
+/// pub async fn second(path: PathBuf) -> Option<StaticFile> {
+///     let mut path = Path::new(relative!("static")).join(path);
+///     if path.is_dir() {
+///         path.push("index.html");
+///     }
+///
+///     StaticFile::open(path).await.ok()
+/// }
+/// ```
+///
+/// Always prefer to use [`FileServer`] which has more functionality and a
+/// pithier API.
+///
+/// [`FileServer`]: crate::fs::FileServer
+#[derive(Debug)]
+pub struct StaticFile{
+    path: PathBuf,
+    file: File,
+    content_type: Option<ContentType>,
+    len: u64,
+    last_modified: DateTimeOffset,
+    etag: EntityTagHeaderValue,
+}
+
+impl StaticFile {
+    /// Attempts to open a file in read-only mode.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if path does not already exist. Other
+    /// errors may also be returned according to
+    /// [`OpenOptions::open()`](std::fs::OpenOptions::open()).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use rocket::get;
+    /// use rocket::fs::StaticFile;
+    ///
+    /// #[get("/")]
+    /// async fn index() -> Option<StaticFile> {
+    ///     StaticFile::open("index.html").await.ok()
+    /// }
+    /// ```
+    pub async fn open<P: AsRef<Path>>(path: P) -> io::Result<StaticFile> {
+        // FIXME: Grab the file size here and prohibit `seek`ing later (or else
+        // the file's effective size may change), to save on the cost of doing
+        // all of those `seek`s to determine the file size. But, what happens if
+        // the file gets changed between now and then?
+        let path = path.as_ref();
+        let file = File::open(path).await?;
+        let metadata = file.metadata().await?;
+        let len = metadata.len();
+        let modified: DateTimeOffset = metadata.modified().unwrap().into();
+        let etag_hash = modified.timestamp_millis() ^ len as i64;
+        let etag_hash = format!("{:x}", etag_hash);
+        let content_type = path.extension()
+            .map(|ext| ContentType::from_extension(&ext.to_string_lossy()))
+            .unwrap_or_default();
+
+        Ok(StaticFile {
+            path: path.to_path_buf(),
+            file,
+            content_type,
+            len,
+            etag: etag_hash.into(),
+            last_modified: modified,
+        })
+    }
+
+    /// Retrieve the underlying `File`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use rocket::fs::StaticFile;
+    ///
+    /// # async fn f() -> std::io::Result<()> {
+    /// let named_file = StaticFile::open("index.html").await?;
+    /// let file = named_file.file();
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline(always)]
+    pub fn file(&self) -> &File {
+        &self.file
+    }
+
+    /// Retrieve a mutable borrow to the underlying `File`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use rocket::fs::StaticFile;
+    ///
+    /// # async fn f() -> std::io::Result<()> {
+    /// let mut named_file = StaticFile::open("index.html").await?;
+    /// let file = named_file.file_mut();
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline(always)]
+    pub fn file_mut(&mut self) -> &mut File {
+        &mut self.file
+    }
+
+    /// Take the underlying `File`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use rocket::fs::StaticFile;
+    ///
+    /// # async fn f() -> std::io::Result<()> {
+    /// let named_file = StaticFile::open("index.html").await?;
+    /// let file = named_file.take_file();
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline(always)]
+    pub fn take_file(self) -> File {
+        self.file
+    }
+
+    /// Retrieve the path of this file.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use rocket::fs::StaticFile;
+    ///
+    /// # async fn demo_path() -> std::io::Result<()> {
+    /// let file = StaticFile::open("foo.txt").await?;
+    /// assert_eq!(file.path().as_os_str(), "foo.txt");
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline(always)]
+    pub fn path(&self) -> &Path {
+        self.path.as_path()
+    }
+}
+
+/// Streams the named file to the client. Sets or overrides the Content-Type in
+/// the response according to the file's extension if the extension is
+/// recognized. See [`ContentType::from_extension()`] for more information. If
+/// you would like to stream a file with a different Content-Type than that
+/// implied by its extension, use a [`File`] directly.
+impl<'r> Responder<'r, 'static> for StaticFile {
+    fn respond_to(self, req: &'r Request<'_>) -> response::Result<'static> {
+        let mut static_ctx = StaticFileContext::from(
+            (self.len, self.content_type, self.etag, self.last_modified)
+        );
+        static_ctx.comprehend_request_headers(req);
+        let file = self.file;
+        static_ctx.proceed(req, |(builder, pos ,len)| {
+            let mut file = file;
+            if pos > 0 {
+                std::pin::Pin::new(&mut file)
+                    .start_seek(SeekFrom::Start(pos))
+                    .unwrap();
+            }
+            builder.sized_body(len as usize, file);
+        })
+    }
+}
+
+impl Deref for StaticFile {
+    type Target = File;
+
+    fn deref(&self) -> &File {
+        &self.file
+    }
+}
+
+impl DerefMut for StaticFile {
+    fn deref_mut(&mut self) -> &mut File {
+        &mut self.file
+    }
+}


### PR DESCRIPTION
Related issues:
- https://github.com/SergioBenitez/Rocket/issues/95
- https://github.com/SergioBenitez/Rocket/pull/1376
- https://github.com/SergioBenitez/Rocket/issues/989

1.  [rust-embed](https://github.com/pyros2097/rust-embed) - [examples](https://github.com/pyros2097/rust-embed/blob/master/examples/rocket.rs)

    ```rust
    
    use std::path::PathBuf;
    use std::ffi::OsStr;
    use std::io::Cursor;
    use rocket::{
        http::{
            ContentType,
            DateTimeOffset,
            EntityTagHeaderValue
        },
        Request,
        response::{
            self, Responder,
        },
        fs::StaticFileContext
    };
    
    
    #[derive(rust_embed::RustEmbed)]
    #[folder = "dist"]
    struct Asset;
    
    pub struct EmbeddedFile {
        file: rust_embed::EmbeddedFile,
        content_type: Option<ContentType>,
    }
    
    
    impl EmbeddedFile {
        pub fn get(file_name: PathBuf) -> Option<Self> {
            let file: Option<rust_embed::EmbeddedFile>  = file_name.to_str().and_then(Asset::get);
    
            let file = file?;
    
            let content_type: Option<ContentType> = file_name
                .extension()
                .and_then(OsStr::to_str)
                .and_then(ContentType::from_extension);
            Some(Self { file, content_type })
        }
    }
    
    impl<'r> Responder<'r, 'static> for EmbeddedFile {
        fn respond_to(self, req: &'r Request<'_>) -> response::Result<'static> {
            let Self{file, content_type} = self;
            let mut static_ctx = StaticFileContext::from((
                file.data.len() as u64, content_type,
                EntityTagHeaderValue::from(&file.metadata.sha256_hash()),
                file.metadata.last_modified().map(|t| t * 1000).map(DateTimeOffset::from).unwrap_or_else(DateTimeOffset::now)
            ));
            static_ctx.comprehend_request_headers(req);
            static_ctx.proceed(req, |(builder, pos ,len)| {
                let mut data = Cursor::new(file.data);
                if pos > 0 {
                    data.set_position(pos);
                }
                builder.sized_body(len as usize, data);
            })
        }
    }
    
    ```