### PR TITLE
Fix IPv6 based URI when rocket as launched

### DIFF
--- a/core/lib/src/rocket.rs
+++ b/core/lib/src/rocket.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 use std::ops::{Deref, DerefMut};
 use std::convert::TryInto;
+use std::net::SocketAddr;
 
 use yansi::Paint;
 use either::Either;
@@ -619,11 +620,8 @@ impl Rocket<Ignite> {
             rkt.fairings.handle_liftoff(&rkt).await;
 
             let proto = rkt.config.tls_enabled().then(|| "https").unwrap_or("http");
-            let addr = if rkt.config.address.is_ipv4() {
-                format!("{}://{}:{}", proto, rkt.config.address, rkt.config.port)
-            } else {
-                format!("{}://[{}]:{}", proto, rkt.config.address, rkt.config.port)
-            };
+            let socket_addr = SocketAddr::new(rkt.config.address, rkt.config.port);
+            let addr = format!("{}://{}", proto, socket_addr);
             launch_info!("{}{} {}",
                 Paint::emoji("🚀 "),
                 Paint::default("Rocket has launched from").bold(),

--- a/core/lib/src/rocket.rs
+++ b/core/lib/src/rocket.rs
@@ -619,7 +619,11 @@ impl Rocket<Ignite> {
             rkt.fairings.handle_liftoff(&rkt).await;
 
             let proto = rkt.config.tls_enabled().then(|| "https").unwrap_or("http");
-            let addr = format!("{}://{}:{}", proto, rkt.config.address, rkt.config.port);
+            let addr = if rkt.config.address.is_ipv4() {
+                format!("{}://{}:{}", proto, rkt.config.address, rkt.config.port)
+            } else {
+                format!("{}://[{}]:{}", proto, rkt.config.address, rkt.config.port)
+            };
             launch_info!("{}{} {}",
                 Paint::emoji("🚀 "),
                 Paint::default("Rocket has launched from").bold(),


### PR DESCRIPTION
Currently, when Rocket is configured to listen on an IPv6 address, the URI displayed during the launch is invalid:

```
🚀 Rocket has launched from http://::1:8000
```

[RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986) section 3.2.2 requires that a host identified by an IPv6 enclosed the IP within square brackets:


```
🚀 Rocket has launched from http://[::1]:8000
```

Since the RFC states "version 6 [...] or later", the test has been made using `.is_ipv4()`. This way, an eventual newer protocol would be correctly handled.
