### PR TITLE
Fix typo in requests guide

### DIFF
--- a/site/guide/4-requests.md
+++ b/site/guide/4-requests.md
@@ -882,7 +882,7 @@ struct MyForm<'v> {
 # rocket_guide_tests::assert_form_parses_ok!(MyForm, "");
 ```
 
-The default can be overridden or unset using the `#[field(default = expr)` field
+The default can be overridden or unset using the `#[field(default = expr)]` field
 attribute. If `expr` is not literally `None`, the parameter sets the default
 value of the field to be `expr.into()`. If `expr` _is_ `None`, the parameter
 _unsets_ the default value of the field, if any.


### PR DESCRIPTION
This fixes a typo in Requests guide, missing closing bracket: `#[field(default = expr)` -> `#[field(default = expr)]`