### PR TITLE
Fix codegen issue for parameters with lifetimes

### DIFF
--- a/core/codegen/tests/async-routes.rs
+++ b/core/codegen/tests/async-routes.rs
@@ -12,6 +12,12 @@ async fn hello(_origin: &Origin<'_>) -> &'static str {
     "Hello, world!"
 }
 
+#[get("/repeated_query?<sort>")]
+async fn repeated_query(sort: Vec<&str>) -> &str {
+    noop().await;
+    sort[0]
+}
+
 #[catch(404)]
 async fn not_found(req: &Request<'_>) -> String {
     noop().await;


### PR DESCRIPTION
I added one function to tests, but there might actually be other instances of this bug with other examples I haven't found.

Resolves #1834 