### PR TITLE
Update todo example's index.html.tera

### DIFF
--- a/examples/todo/src/tests.rs
+++ b/examples/todo/src/tests.rs
@@ -152,6 +152,26 @@ fn test_bad_form_submissions() {
 
         let mut cookies = res.headers().get("Set-Cookie");
         assert!(cookies.any(|value| value.contains("error")));
+        
+        // Check that the index now contains the flash message that we were expecting.
+        let body = client
+            .get("/")
+            .dispatch()
+            .await
+            .into_string()
+            .await
+            .unwrap();
+        assert!(body.contains("Description cannot be empty."));
+
+        // Check that the flash message was cleared upon another visit to the index.
+        let body = client
+            .get("/")
+            .dispatch()
+            .await
+            .into_string()
+            .await
+            .unwrap();
+        assert!(!body.contains("Description cannot be empty."));
 
         // Submit a form without a description. Expect a 422 but no flash error.
         let res = client.post("/todo")

--- a/examples/todo/static/index.html.tera
+++ b/examples/todo/static/index.html.tera
@@ -23,10 +23,10 @@
         <div class="ten columns">
           <input type="text" placeholder="enter a task description..."
             name="description" id="description" value="" autofocus
-            class="u-full-width {% if msg %}field-{{msg.0}}{% endif %}" />
-          {% if msg %}
-            <small class="field-{{msg.0}}-msg">
-               {{ msg.1 }}
+            class="u-full-width {% if flash %}field-{{flash.0}}{% endif %}" />
+          {% if flash %}
+            <small class="field-{{flash.0}}-msg">
+               {{ flash.1 }}
             </small>
           {% endif %}
         </div>


### PR DESCRIPTION
The [example rework](https://github.com/SergioBenitez/Rocket/commit/50c9e88cf91cbcc6298cbd04282aebf6fba69b88#diff-8ef15e4657ed4039d24756f97d0af86db9576c69eb8d8ea7ef7e07700dc59cc7L26) changed `msg` to `flash`, but the template was never updated to match this new name.
Without this, flash messages never appear to the enduser.