### PR TITLE
allow setting the route name

### DIFF
--- a/core/codegen/src/attribute/route/mod.rs
+++ b/core/codegen/src/attribute/route/mod.rs
@@ -422,6 +422,7 @@ fn incomplete_route(
         data: method_attribute.data,
         format: method_attribute.format,
         rank: method_attribute.rank,
+        name: method_attribute.name,
     };
 
     codegen_route(Route::from(attribute, function)?)

--- a/core/codegen/src/attribute/route/mod.rs
+++ b/core/codegen/src/attribute/route/mod.rs
@@ -330,6 +330,13 @@ fn codegen_route(route: Route) -> Result<TokenStream> {
     let rank = Optional(route.attr.rank);
     let format = Optional(route.attr.format.as_ref());
 
+    let route_name = match &route.attr.name {
+        Some(name) => quote! { #name },
+        None => {
+            quote! { stringify!(#handler_fn_name) }
+        }
+    };
+
     Ok(quote! {
         #handler_fn
 
@@ -357,7 +364,7 @@ fn codegen_route(route: Route) -> Result<TokenStream> {
                 }
 
                 #_route::StaticInfo {
-                    name: stringify!(#handler_fn_name),
+                    name: #route_name,
                     method: #method,
                     uri: #uri,
                     handler: monomorphized_function,

--- a/core/codegen/src/attribute/route/parse.rs
+++ b/core/codegen/src/attribute/route/parse.rs
@@ -47,6 +47,7 @@ pub struct Attribute {
     pub data: Option<SpanWrapped<Dynamic>>,
     pub format: Option<MediaType>,
     pub rank: Option<isize>,
+    pub name: Option<String>,
 }
 
 /// The parsed `#[method(..)]` (e.g, `get`, `put`, etc.) attribute.
@@ -57,6 +58,7 @@ pub struct MethodAttribute {
     pub data: Option<SpanWrapped<Dynamic>>,
     pub format: Option<MediaType>,
     pub rank: Option<isize>,
+    pub name: Option<String>,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
The route name is currently derived from the handler function name. This allows setting the route name. Here, the route name is set to `Hello`.

``` rust
#[get("/", name = "Hello")]
fn hello() -> &'static str {
    "hello"
}
```

In my use case, I use the Swagger operationId as the route name.