### PR TITLE
make Router public

### DIFF
--- a/core/lib/src/lib.rs
+++ b/core/lib/src/lib.rs
@@ -159,6 +159,7 @@ mod phase;
 #[doc(inline)] pub use crate::config::Config;
 #[doc(inline)] pub use crate::catcher::Catcher;
 #[doc(inline)] pub use crate::route::Route;
+#[doc(inline)] pub use crate::router::Router;
 #[doc(hidden)] pub use either::Either;
 #[doc(inline)] pub use phase::{Phase, Build, Ignite, Orbit};
 #[doc(inline)] pub use error::Error;

--- a/core/lib/src/router/mod.rs
+++ b/core/lib/src/router/mod.rs
@@ -3,5 +3,6 @@
 mod router;
 mod collider;
 
+pub use router::Router;
 pub(crate) use router::*;
 pub(crate) use collider::*;

--- a/core/lib/src/router/router.rs
+++ b/core/lib/src/router/router.rs
@@ -7,7 +7,7 @@ use crate::{Route, Catcher};
 use crate::router::Collide;
 
 #[derive(Debug, Default)]
-pub(crate) struct Router {
+pub struct Router {
     routes: HashMap<Method, Vec<Route>>,
     catchers: HashMap<Option<u16>, Vec<Catcher>>,
 }


### PR DESCRIPTION
Please make `Router` public. Related to #1872, I want to be to test that a `Router` routes correctly to a specific named route.