### PR TITLE
msgpack Responder create named representations

### DIFF
--- a/core/lib/src/serde/msgpack.rs
+++ b/core/lib/src/serde/msgpack.rs
@@ -188,7 +188,7 @@ impl<'r, T: Deserialize<'r>> FromData<'r> for MsgPack<T> {
 /// serialization fails, an `Err` of `Status::InternalServerError` is returned.
 impl<'r, T: Serialize> Responder<'r, 'static> for MsgPack<T> {
     fn respond_to(self, req: &'r Request<'_>) -> response::Result<'static> {
-        let buf = rmp_serde::to_vec(&self.0)
+        let buf = to_vec(&self.0)
             .map_err(|e| {
                 error_!("MsgPack failed to serialize: {:?}", e);
                 Status::InternalServerError


### PR DESCRIPTION
I noticed that the MsgPack responder uses the compact form which leaves out the property names. This seems like an odd default as clients may be relying on that information to know how to interpret the response.

After looking through the code I found that there's already two functions for serializing using compact and non compact structures but neither were being used.
In this PR I have updated the Responder implementation for MsgPack so that it uses these existing function to serialize with names as opposed to the compact structure that was being used.

A future task might be to make this configurable?



**Input**
```rust
struct Test {
    v1: String,
    v2: f64,
}
```
**Original output** 
(converted to json with [msgpack-inspect](https://github.com/tagomoris/msgpack-inspect))
```JSON
[
  { "format": "fixarray",
    "header": "0x92",
    "length": 2,
    "children": [
          { "format": "fixstr",
            "header": "0xa5",
            "length": 5,
            "data": "0x68656c6c6f",
            "value": "hello"
          },
          { "format": "float64",
            "header": "0xcb",
            "data": "0x4045000000000000",
            "value": 42
          }
    ]
  }
]
```
The raw message pack encoded in base64 is as follows
```base64
kqVoZWxsb8tARQAAAAAAAA==
```

**New output** 
(converted to json with [msgpack-inspect](https://github.com/tagomoris/msgpack-inspect))
```JSON
[
  { "format": "fixmap",
    "header": "0x82",
    "length": 2,
    "children": [
        { "key":
              { "format": "fixstr",
                "header": "0xa2",
                "length": 2,
                "data": "0x7631",
                "value": "v1"
              },
          "value":
              { "format": "fixstr",
                "header": "0xa5",
                "length": 5,
                "data": "0x68656c6c6f",
                "value": "hello"
              }
        },
        { "key":
              { "format": "fixstr",
                "header": "0xa2",
                "length": 2,
                "data": "0x7632",
                "value": "v2"
              },
          "value":
              { "format": "float64",
                "header": "0xcb",
                "data": "0x4045000000000000",
                "value": 42
              }
        }
    ]
  }
]
```
The raw message pack encoded in base64 is as follows
```base64
gqJ2MaVoZWxsb6J2MstARQAAAAAAAA==
```