### PR TITLE
Bump `mongodb` dependency to `2.0.0`

### DIFF
--- a/contrib/db_pools/lib/Cargo.toml
+++ b/contrib/db_pools/lib/Cargo.toml
@@ -53,6 +53,8 @@ optional = true
 
 [dependencies.mongodb]
 version = "2.0.0"
+default-features = false
+features = ["tokio-runtime"]
 optional = true
 
 [dependencies.sqlx]

--- a/contrib/db_pools/lib/Cargo.toml
+++ b/contrib/db_pools/lib/Cargo.toml
@@ -52,9 +52,7 @@ features = ["rt_tokio_1"]
 optional = true
 
 [dependencies.mongodb]
-version = "1"
-default-features = false
-features = ["tokio-runtime"]
+version = "2.0.0"
 optional = true
 
 [dependencies.sqlx]

--- a/contrib/db_pools/lib/src/lib.rs
+++ b/contrib/db_pools/lib/src/lib.rs
@@ -126,7 +126,7 @@
 //! [`sqlx::PoolConnection<Sqlite>`]: https://docs.rs/sqlx/0.5/sqlx/pool/struct.PoolConnection.html
 //! [`sqlx::PoolConnection<Mssql>`]: https://docs.rs/sqlx/0.5/sqlx/pool/struct.PoolConnection.html
 //!
-//! ## `mongodb` (v1)
+//! ## `mongodb` (v2)
 //!
 //! | Database | Feature   | [`Pool`] Type and [`Connection`] Deref |
 //! |----------|-----------|----------------------------------------|

--- a/contrib/db_pools/lib/src/pool.rs
+++ b/contrib/db_pools/lib/src/pool.rs
@@ -254,7 +254,6 @@ mod mongodb {
             opts.min_pool_size = config.min_connections;
             opts.max_pool_size = Some(config.max_connections as u32);
             opts.max_idle_time = config.idle_timeout.map(Duration::from_secs);
-            opts.wait_queue_timeout = Some(Duration::from_secs(config.connect_timeout));
             opts.connect_timeout = Some(Duration::from_secs(config.connect_timeout));
             Client::with_options(opts).map_err(Error::Init)
         }


### PR DESCRIPTION
Bumps the `mongodb` dependency to the newly-released `2.0.0` version. This notably includes support for tokio 1.0; a full changelog can be viewed [here](https://github.com/mongodb/mongo-rust-driver/releases/tag/v2.0.0).