### PR TITLE
Change logging level of launch messages to info.

### DIFF
--- a/core/lib/src/log.rs
+++ b/core/lib/src/log.rs
@@ -32,8 +32,8 @@ define_log_macro!(warn, warn_);
 define_log_macro!(info, info_);
 define_log_macro!(debug, debug_);
 define_log_macro!(trace, trace_);
-define_log_macro!(launch_info: warn, "rocket::launch", $);
-define_log_macro!(launch_info_: warn, "rocket::launch_", $);
+define_log_macro!(launch_info: info, "rocket::launch", $);
+define_log_macro!(launch_info_: info, "rocket::launch_", $);
 
 #[derive(Debug)]
 struct RocketLogger;


### PR DESCRIPTION
Fixes #1828. Since the launch messages are expected, it is unnatural to log them as warnings, in particular as they will not require action in almost all cases.