### PR TITLE
Allowed testing of client certificates

### DIFF
--- a/examples/tls/src/tests.rs
+++ b/examples/tls/src/tests.rs
@@ -1,6 +1,16 @@
 use rocket::local::blocking::Client;
 
 #[test]
+fn hello_mutual() {
+    let client = Client::tracked(super::rocket()).unwrap();
+    let response = client
+        .get("/")
+        .identity("private/rsa_sha256_cert.pem".into())
+        .dispatch();
+    assert_eq!(response.into_string(), Some("Hello! Here's what we know: [301438261598342027628437991669560131935683596135] C=US, ST=CA, O=Rocket, CN=localhost".into()));
+}
+
+#[test]
 fn hello_world() {
     let client = Client::tracked(super::rocket()).unwrap();
     let response = client.get("/").dispatch();


### PR DESCRIPTION
Hello,

I'm fairly new to Rust/Rocket. I saw an opportunity to add a feature that would make unit testing my API a lot easier and I wanted to see what y'all thought. mTLS is a fairly new feature in Rocket, and as such, it does not seem that there is a way to unit test providing client certs to "route" functions. I looked at the tests in examples/tls and verified as much. I added an identity method to Client such that you can provide a String path to a client cert that would be provided to the route. I updated the tests in the TLS example to show how it can it can used.