### PR TITLE
Fix `Result` namespacing in `context!` dyn templates macro

### DIFF
--- a/contrib/dyn_templates/src/lib.rs
+++ b/contrib/dyn_templates/src/lib.rs
@@ -520,6 +520,7 @@ macro_rules! context {
     ($($key:ident $(: $value:expr)?),*$(,)?) => {{
         use $crate::serde::ser::{Serialize, Serializer, SerializeMap};
         use ::std::fmt::{Debug, Formatter};
+        use ::std::result::Result;
 
         #[allow(non_camel_case_types)]
         struct ContextMacroCtxObject<$($key: Serialize),*> {


### PR DESCRIPTION
Hey!

I was getting an error while trying to use `context!` in any files where i have a `Result` alias scoped.

This quick patch should explicitly make the `Result` at line 532 be the std one.

PS: Also, thank you so much for this project! I've been keeping up with development for quite a while. It's my framework of choice for both work and personal projects, it's been a joy to see just how much polished Rocket gets with each and every update!