### PR TITLE
sync_db_pools: Expose connection pool

### DIFF
--- a/contrib/sync_db_pools/codegen/src/database.rs
+++ b/contrib/sync_db_pools/codegen/src/database.rs
@@ -108,6 +108,11 @@ pub fn database_attr(attr: TokenStream, input: TokenStream) -> Result<TokenStrea
             {
                 self.0.run(__f).await
             }
+
+            /// Retrieves a copy of the inner connection pool.
+            pub fn get_pool(&self) -> #root::r2d2::Pool<<#conn_type as #root::Poolable>::Manager> {
+                self.0.get_pool()
+            }
         }
 
         #[#rocket::async_trait]

--- a/contrib/sync_db_pools/codegen/src/lib.rs
+++ b/contrib/sync_db_pools/codegen/src/lib.rs
@@ -42,6 +42,10 @@ use proc_macro::TokenStream;
 ///     Retrieves a connection wrapper from the configured pool. Returns `Some`
 ///     as long as `Self::fairing()` has been attached.
 ///
+///   * `async fn get_pool(&self) -> r2d2::Pool`
+///
+///     Retrieves a cloned reference to the inner connection pool.
+///
 ///   * `async fn run<R: Send + 'static>(&self, impl FnOnce(&mut Db) -> R + Send + 'static) -> R`
 ///
 ///     Runs the specified function or closure, providing it access to the

--- a/contrib/sync_db_pools/lib/src/lib.rs
+++ b/contrib/sync_db_pools/lib/src/lib.rs
@@ -316,7 +316,7 @@
 //! The list below includes all presently supported database adapters and their
 //! corresponding [`Poolable`] type.
 //!
-// Note: Keep this table in sync with site/guite/6-state.md
+// Note: Keep this table in sync with site/guide/6-state.md
 //! | Kind     | Driver                | Version   | `Poolable` Type                | Feature                |
 //! |----------|-----------------------|-----------|--------------------------------|------------------------|
 //! | MySQL    | [Diesel]              | `1`       | [`diesel::MysqlConnection`]    | `diesel_mysql_pool`    |


### PR DESCRIPTION
This is a proposed fix for #1884.

It adds a connection pool reference to every connection handle and exposes that through a generated method.

Is this the right approach? If not, how else should it be implemented?