### PR TITLE
Remove XssFilter shield

### DIFF
--- a/core/lib/src/shield/mod.rs
+++ b/core/lib/src/shield/mod.rs
@@ -12,7 +12,6 @@
 //!
 //! | HTTP Header                 | Description                            | Policy         | Default? |
 //! | --------------------------- | -------------------------------------- | -------------- | -------- |
-//! | [X-XSS-Protection]          | Prevents some reflected XSS attacks.   | [`XssFilter`]  | ✗        |
 //! | [X-Content-Type-Options]    | Prevents client sniffing of MIME type. | [`NoSniff`]    | ✔        |
 //! | [X-Frame-Options]           | Prevents [clickjacking].               | [`Frame`]      | ✔        |
 //! | [Strict-Transport-Security] | Enforces strict use of HTTPS.          | [`Hsts`]       | ?        |
@@ -24,7 +23,6 @@
 //! <small>? If TLS is enabled in a non-debug profile, HSTS is automatically
 //! enabled with its default policy and a warning is logged at liftoff.</small>
 //!
-//! [X-XSS-Protection]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection
 //! [X-Content-Type-Options]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options
 //! [X-Frame-Options]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
 //! [Strict-Transport-Security]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
@@ -34,7 +32,6 @@
 //! [clickjacking]: https://en.wikipedia.org/wiki/Clickjacking
 //! [Permissions-Policy]: https://github.com/w3c/webappsec-permissions-policy/blob/a45df7b237e2a85e1909d7f226ca4eb4ce5095ba/permissions-policy-explainer.md
 //!
-//! [`XssFilter`]: self::XssFilter
 //! [`NoSniff`]: self::NoSniff
 //! [`Frame`]: self::Frame
 //! [`Hsts`]: self::Hsts

--- a/core/lib/src/shield/policy.rs
+++ b/core/lib/src/shield/policy.rs
@@ -93,7 +93,6 @@ macro_rules! impl_policy {
 }
 
 // Keep this in-sync with the top-level module docs.
-impl_policy!(XssFilter, "X-XSS-Protection");
 impl_policy!(NoSniff, "X-Content-Type-Options");
 impl_policy!(Frame, "X-Frame-Options");
 impl_policy!(Hsts, "Strict-Transport-Security");
@@ -361,43 +360,6 @@ impl From<&Frame> for Header<'static> {
         };
 
         Header::new(Frame::NAME, policy_string)
-    }
-}
-
-/// The [X-XSS-Protection] header: filters some forms of reflected [XSS]
-/// attacks. Modern browsers do not support or enforce this header.
-///
-/// [X-XSS-Protection]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection
-/// [XSS]: https://developer.mozilla.org/en-US/docs/Glossary/Cross-site_scripting
-pub enum XssFilter {
-    /// Disables XSS filtering.
-    Disable,
-
-    /// Enables XSS filtering. If XSS is detected, the browser will sanitize
-    /// before rendering the page (_Shield default_).
-    Enable,
-
-    /// Enables XSS filtering. If XSS is detected, the browser will not
-    /// render the page.
-    EnableBlock,
-}
-
-/// Defaults to [`XssFilter::Enable`].
-impl Default for XssFilter {
-    fn default() -> XssFilter {
-        XssFilter::Enable
-    }
-}
-
-impl From<&XssFilter> for Header<'static> {
-    fn from(filter: &XssFilter) -> Self {
-        let policy_string: &'static str = match filter {
-            XssFilter::Disable => "0",
-            XssFilter::Enable => "1",
-            XssFilter::EnableBlock => "1; mode=block",
-        };
-
-        Header::new(XssFilter::NAME, policy_string)
     }
 }
 

--- a/core/lib/src/shield/shield.rs
+++ b/core/lib/src/shield/shield.rs
@@ -23,20 +23,20 @@ use crate::shield::*;
 ///
 /// ```rust
 /// use rocket::shield::Shield;
-/// use rocket::shield::{XssFilter, ExpectCt};
+/// use rocket::shield::{ExpectCt, NoSniff};
 ///
 /// // A `Shield` with the default headers:
 /// let shield = Shield::default();
 ///
-/// // A `Shield` with the default headers minus `XssFilter`:
-/// let shield = Shield::default().disable::<XssFilter>();
+/// // A `Shield` with the default headers minus `NoSniff`:
+/// let shield = Shield::default().disable::<NoSniff>();
 ///
 /// // A `Shield` with the default headers plus `ExpectCt`.
 /// let shield = Shield::default().enable(ExpectCt::default());
 ///
-/// // A `Shield` with only `XssFilter` and `ExpectCt`.
-/// let shield = Shield::default()
-///     .enable(XssFilter::default())
+/// // A `Shield` with only `NoSniff` and `ExpectCt`.
+/// let shield = Shield::new()
+///     .enable(NoSniff::default())
 ///     .enable(ExpectCt::default());
 /// ```
 ///


### PR DESCRIPTION
Modern web browsers don't support X-XSS-Protection anymore due to it enabling XS-Leak attacks.

This is a breaking change, but I think it's acceptable considering 0.5.0 wasn't released yet.

Alternatively, XssFilter could stay as IE11 still supports this header, but only with `Disable` configuration, anything else is insecure, the problem with that is however that policies need a default value, and this would involve changing that value, renaming the shield or removing `Default` bound from `Policy` trait.