### PR TITLE
Add missing 'return' to luhn validation example

### DIFF
--- a/core/lib/src/form/validate.rs
+++ b/core/lib/src/form/validate.rs
@@ -71,7 +71,7 @@
 //! fn luhn<'v>(number: &u64, cvv: u16, exp: &time::Date) -> form::Result<'v, ()> {
 //!     # let valid = false;
 //!     if !valid {
-//!         Err(Error::validation("invalid credit card number"))?;
+//!         return Err(Error::validation("invalid credit card number"))?;
 //!     }
 //!
 //!     Ok(())

--- a/site/guide/4-requests.md
+++ b/site/guide/4-requests.md
@@ -1044,7 +1044,7 @@ struct CreditCard {
 fn luhn<'v>(number: &u64, cvv: u16, exp: &Date) -> form::Result<'v, ()> {
     # let valid = false;
     if !valid {
-        Err(Error::validation("invalid credit card number"))?;
+        return Err(Error::validation("invalid credit card number"))?;
     }
 
     Ok(())


### PR DESCRIPTION
I copied this this code to write my own custom validation function and then noticed that the `return` was missing. This PR fixes that.