### PR TITLE
Fixes for dyn_template examples

### DIFF
--- a/contrib/dyn_templates/README.md
+++ b/contrib/dyn_templates/README.md
@@ -44,6 +44,7 @@ supports [Handlebars] and [Tera].
 
      #[get("/")]
      fn index() -> Template {
+         let context: HashMap<&str, &str> = HashMap::new();
          Template::render("template-name", &context)
      }
      ```

--- a/contrib/dyn_templates/src/lib.rs
+++ b/contrib/dyn_templates/src/lib.rs
@@ -368,8 +368,7 @@ impl Template {
     ///     let client = Client::untracked(rocket).expect("valid rocket");
     ///
     ///     // Create a `context`. Here, just an empty `HashMap`.
-    ///     let mut context = HashMap::new();
-    ///     # context.insert("test", "test");
+    ///     let context: HashMap<&str, &str> = HashMap::new();
     ///     let template = Template::show(client.rocket(), "index", context);
     /// }
     /// ```


### PR DESCRIPTION
- add context variable for readme example, its mandatory
- add types for HashMap in show function example, because it crashes with E0282 otherwise