### PR TITLE
[DRAFT] Add type safety to fairings availability

### DIFF
--- a/contrib/sync_db_pools/codegen/src/database.rs
+++ b/contrib/sync_db_pools/codegen/src/database.rs
@@ -92,7 +92,7 @@ pub fn database_attr(attr: TokenStream, input: TokenStream) -> Result<TokenStrea
             /// instance. Returns `Some` as long as `Self::fairing()` has been
             /// attached.
             pub async fn get_one<P>(__rocket: &#rocket::Rocket<P>) -> Option<Self>
-                where P: #rocket::Phase,
+                where P: #rocket::fairing::HasFairings,
             {
                 <#pool>::get_one(&__rocket).await.map(Self)
             }

--- a/contrib/sync_db_pools/lib/src/connection.rs
+++ b/contrib/sync_db_pools/lib/src/connection.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 
 use rocket::{Phase, Rocket, Ignite, Sentinel};
-use rocket::fairing::{AdHoc, Fairing};
+use rocket::fairing::{AdHoc, Fairing, HasFairings};
 use rocket::request::{Request, Outcome, FromRequest};
 use rocket::outcome::IntoOutcome;
 use rocket::http::Status;
@@ -120,7 +120,7 @@ impl<K: 'static, C: Poolable> ConnectionPool<K, C> {
     }
 
     #[inline]
-    pub async fn get_one<P: Phase>(rocket: &Rocket<P>) -> Option<Connection<K, C>> {
+    pub async fn get_one<P: HasFairings>(rocket: &Rocket<P>) -> Option<Connection<K, C>> {
         match rocket.state::<Self>() {
             Some(pool) => match pool.get().await.ok() {
                 Some(conn) => Some(conn),

--- a/core/lib/src/fairing/fairings.rs
+++ b/core/lib/src/fairing/fairings.rs
@@ -1,10 +1,22 @@
 use std::collections::HashSet;
 
-use crate::{Rocket, Request, Response, Data, Build, Orbit};
+use crate::{Rocket, Request, Response, Data, Build, Orbit, Ignite};
 use crate::fairing::{Fairing, Info, Kind};
 use crate::log::PaintExt;
 
 use yansi::Paint;
+
+mod private {
+    pub trait Sealed{}
+}
+
+pub trait HasFairings: private::Sealed {}
+
+impl private::Sealed for Rocket<Orbit> {}
+impl HasFairings for Rocket<Orbit> {}
+
+impl private::Sealed for Rocket<Ignite>{}
+impl HasFairings for Rocket<Ignite> {}
 
 #[derive(Default)]
 pub struct Fairings {


### PR DESCRIPTION
I was updating rocket, while having an issue where i wasn't aware that fairings can only be accessed after the `Ignite` state.
This change would be tell a user immediately what the problem is, as a compilation error.
This is only for means of showing what my intentions are and is not the final work i will commit.
If this is approved, i will test it and add a compilation error test.