### PR TITLE
Add Request::try_local_cache method

### DIFF
--- a/core/lib/src/request/request.rs
+++ b/core/lib/src/request/request.rs
@@ -730,6 +730,35 @@ impl<'r> Request<'r> {
             })
     }
 
+    /// Attempts to retrieve the global state for type `T`.
+    ///
+    /// Returns `Some` if the state has previously been [set](#method.set).
+    /// Otherwise returns `None`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # let c = rocket::local::blocking::Client::debug_with(vec![]).unwrap();
+    /// # let request = c.get("/");
+    /// // The first read returns None
+    /// let value: &str = request.try_local_cache();
+    /// assert_eq!(value, None);
+    /// // The first store into local cache for a given type wins.
+    /// let value = request.local_cache(|| "hello");
+    /// assert_eq!(value, Some("hello"));
+    /// assert_eq!(*request.local_cache(|| "hello"), "hello");
+    ///
+    /// // The following return the cached, previously stored value for the type.
+    /// assert_eq!(*request.local_cache(|| "goodbye"), "hello");
+    /// ```
+    #[inline]
+    pub fn try_local_cache<T>(&self) -> Option<&T>
+    where
+        T: Send + Sync + 'static,
+    {
+        self.state.cache.try_get()
+    }
+
     /// Retrieves the cached value for type `T` from the request-local cached
     /// state of `self`. If no such value has previously been cached for this
     /// request, `fut` is `await`ed to produce the value which is subsequently

--- a/core/lib/src/request/request.rs
+++ b/core/lib/src/request/request.rs
@@ -713,10 +713,10 @@ impl<'r> Request<'r> {
     /// # let request = c.get("/");
     /// // The first store into local cache for a given type wins.
     /// let value = request.local_cache(|| "hello");
-    /// assert_eq!(*request.local_cache(|| "hello"), "hello");
+    /// assert_eq!(request.local_cache(|| "hello"), "hello");
     ///
     /// // The following return the cached, previously stored value for the type.
-    /// assert_eq!(*request.local_cache(|| "goodbye"), "hello");
+    /// assert_eq!(request.local_cache(|| "goodbye"), "hello");
     /// ```
     #[inline]
     pub fn local_cache<T, F>(&self, f: F) -> &T
@@ -730,26 +730,31 @@ impl<'r> Request<'r> {
             })
     }
 
-    /// Attempts to retrieve the global state for type `T`.
+    /// Retrieves the cached value for type `T` from the request-local cached
+    /// state of `self`. If no such value has previously been cached for this
+    /// request, `None` is returned.
     ///
-    /// Returns `Some` if the state has previously been [set](#method.set).
-    /// Otherwise returns `None`.
+    /// Different values of the same type _cannot_ be cached without using a
+    /// proxy, wrapper type.
     ///
     /// # Example
     ///
     /// ```rust
     /// # let c = rocket::local::blocking::Client::debug_with(vec![]).unwrap();
     /// # let request = c.get("/");
-    /// // The first read returns None
-    /// let value: &str = request.try_local_cache();
+    /// // Without cached value it is None
+    /// let value: Option<&String> = request.try_local_cache();
     /// assert_eq!(value, None);
     /// // The first store into local cache for a given type wins.
-    /// let value = request.local_cache(|| "hello");
-    /// assert_eq!(value, Some("hello"));
-    /// assert_eq!(*request.local_cache(|| "hello"), "hello");
+    /// let value = request.local_cache(|| String::from("hello"));
+    /// assert_eq!(value.as_str(), "hello");
+    ///
+    /// assert_eq!(request.try_local_cache(), Some(&String::from("hello")));
     ///
     /// // The following return the cached, previously stored value for the type.
-    /// assert_eq!(*request.local_cache(|| "goodbye"), "hello");
+    /// assert_eq!(request.local_cache(|| String::from("goodbye")).as_str(), "hello");
+    /// // This is also the first cached value
+    /// assert_eq!(request.try_local_cache(), Some(&String::from("hello")));
     /// ```
     #[inline]
     pub fn try_local_cache<T>(&self) -> Option<&T>


### PR DESCRIPTION
In some cases we need to retrieve value from the cache only if it exists. This method returns Option<&T> without value creation.