### PR TITLE
build!: update MSRV 1.51.0

### DIFF
--- a/core/codegen/Cargo.toml
+++ b/core/codegen/Cargo.toml
@@ -11,6 +11,10 @@ keywords = ["rocket", "web", "framework", "code", "generation"]
 license = "MIT OR Apache-2.0"
 edition = "2018"
 
+[package.metadata]
+# minimum supported rust version 1.51.0 because of cargo resolver in dependency crate time
+msrv = "1.51.0"
+
 [lib]
 proc-macro = true
 

--- a/core/http/Cargo.toml
+++ b/core/http/Cargo.toml
@@ -14,6 +14,10 @@ license = "MIT OR Apache-2.0"
 categories = ["web-programming"]
 edition = "2018"
 
+[package.metadata]
+# minimum supported rust version 1.51.0 because of cargo resolver in dependency crate time
+msrv = "1.51.0"
+
 [features]
 default = []
 tls = ["rustls", "tokio-rustls"]

--- a/core/lib/Cargo.toml
+++ b/core/lib/Cargo.toml
@@ -15,6 +15,10 @@ build = "build.rs"
 categories = ["web-programming::http-server"]
 edition = "2018"
 
+[package.metadata]
+# minimum supported rust version 1.51.0 because of dependencies multer -> spin
+msrv = "1.51.0"
+
 [package.metadata.docs.rs]
 all-features = true
 

--- a/core/lib/build.rs
+++ b/core/lib/build.rs
@@ -3,7 +3,7 @@
 use yansi::{Paint, Color::{Red, Yellow}};
 
 fn main() {
-    const MIN_VERSION: &str = "1.46.0";
+    const MIN_VERSION: &str = "1.51.0";
 
     if let Some(version) = version_check::Version::read() {
         if !version.at_least(MIN_VERSION) {


### PR DESCRIPTION
A few up-to-date dependencies requires at least rust version 1.51.0.  
As this is also quite old, it should be no problem to move this on.