### PR TITLE
WIP: implement async diesel as a database driver

### DIFF
--- a/contrib/db_pools/lib/Cargo.toml
+++ b/contrib/db_pools/lib/Cargo.toml
@@ -22,7 +22,14 @@ sqlx_postgres = ["sqlx", "sqlx/postgres"]
 sqlx_sqlite = ["sqlx", "sqlx/sqlite"]
 sqlx_mssql = ["sqlx", "sqlx/mssql"]
 sqlx_macros = ["sqlx/macros"]
+# diesel features
+# diesel_mysql = ["diesel", "diesel-async", "diesel-async/mysql"]  # wont compile
+diesel_postgres = ["diesel", "diesel-async", "diesel-async/postgres"]
+
 # implicit features: mongodb
+
+# testing
+default = ["diesel_postgres"]
 
 [dependencies.rocket]
 path = "../../../core/lib"
@@ -61,6 +68,18 @@ optional = true
 version = "0.5"
 default-features = false
 features = ["runtime-tokio-rustls"]
+optional = true
+
+[dependencies.diesel]
+git = "https://github.com/diesel-rs/diesel"
+rev = "37ec18f46ced2d6e9197414156fdb705d7a61426"  # same as diesel-async
+default-features = false
+optional = true
+
+[dependencies.diesel-async]
+git = "https://github.com/ThouCheese/diesel_async"
+version = "0.1"
+default-features = false
 optional = true
 
 [dev-dependencies.rocket]

--- a/contrib/db_pools/lib/src/lib.rs
+++ b/contrib/db_pools/lib/src/lib.rs
@@ -212,7 +212,6 @@
 #![doc(html_root_url = "https://api.rocket.rs/master/rocket_db_pools")]
 #![doc(html_favicon_url = "https://rocket.rs/images/favicon.ico")]
 #![doc(html_logo_url = "https://rocket.rs/images/logo-boxed.png")]
-
 #![deny(missing_docs)]
 
 /// Re-export of the `figment` crate.
@@ -222,6 +221,7 @@ pub use rocket::figment;
 pub use rocket;
 #[cfg(feature = "deadpool_postgres")] pub use deadpool_postgres;
 #[cfg(feature = "deadpool_redis")] pub use deadpool_redis;
+#[cfg(feature = "diesel_postgres")] pub use diesel_async;
 #[cfg(feature = "mongodb")] pub use mongodb;
 #[cfg(feature = "sqlx")] pub use sqlx;
 
@@ -236,3 +236,7 @@ pub use self::pool::Pool;
 pub use self::config::Config;
 
 pub use rocket_db_pools_codegen::*;
+
+/// Wow
+#[cfg(feature = "diesel_postgres")]
+pub struct FakePool(String);


### PR DESCRIPTION
Lets you use `diesel-aysnc` as a database driver with `rocket_db_pools`. VERY WIP:

1. `diesel-async` is very much in pre-alpha
2. Doesn't do connection pooling
2. No MySQL, only Postgres
3. Depends on a fork of diesel-async.

## Example program:

### `Cargo.toml`
```toml
[package]
...

[dependencies]
rocket = { path = "../Rocket/core/lib" }
rocket_db_pools = { path = "../Rocket/contrib/db_pools/lib", features = ["diesel_postgres"] }
diesel-async = { git = "https://github.com/ThouCheese/diesel_async" }
diesel = { git = "https://github.com/diesel-rs/diesel", rev = "37ec18f46ced2d6e9197414156fdb705d7a61426", default-features = false}
```
### `main.rs`
```rust
#[macro_use]
extern crate diesel;
use diesel::prelude::QueryDsl;
use diesel_async::*;
use rocket_db_pools::{Connection, Database};

table! {
    tmp (id) {
        id -> Int4,
        field1 -> Varchar,
    }
}

#[derive(Debug, Queryable)]
struct Tmp {
    id: i32,
    field: String,
}

#[rocket::get("/")]
async fn hello(mut conn: Connection<TestDb>) {
    let tmp: Vec<Tmp> = tmp::table.get_results(&mut *conn).await.unwrap();
    println!("{tmp:?}");
}

#[derive(Database)]
#[database("postgres")]
struct TestDb(rocket_db_pools::FakePool);

#[rocket::launch]
fn rocket() -> _ {
    rocket::build()
        .mount("/", rocket::routes![hello])
        .attach(TestDb::init())
}
```
