### PR TITLE
FromData trait, Data Guards section: add context link for "iff"

### DIFF
--- a/core/lib/src/data/from_data.rs
+++ b/core/lib/src/data/from_data.rs
@@ -36,7 +36,7 @@ impl<'r, S, E> IntoOutcome<S, (Status, E), Data<'r>> for Result<S, E> {
 ///
 /// A data guard is a guard that operates on a request's body data. Data guards
 /// validate and parse request body data via implementations of `FromData`. In
-/// other words, a type is a data guard _iff_ it implements `FromData`.
+/// other words, a type is a data guard _[iff](https://en.wikipedia.org/wiki/If_and_only_if)_ it implements `FromData`.
 ///
 /// Data guards are the target of the `data` route attribute parameter:
 ///


### PR DESCRIPTION
Add context for what "iff" means.

For those unfamiliar with mathematics terminology, it may be beneficial to clarify what _iff_ means, as some may not know that this is a term, and see it as a spelling mistake (and thus miss its meaning).

For clarity, it may be best to expand from _iff_ to _if and only if_ or to point to the definition at a specific resource (such as Wikipedia).

I've added the second option to this commit, but am fine making other changes if something better is suggested.

This comes after me seeing the term and thinking it was a spelling error (thinking "if" was italic for emphasis rather than technical usage).


_Ignore from this line down. It's saved for posterity from when this was seen as a spelling error._

---
Spelling issue can be seen on the docs page for [FromData (§ Data Guards)](https://api.rocket.rs/v0.5-rc/rocket/data/trait.FromData.html#data-guards).

Original
>  In other words, a type is a data guard _iff_ it implements `FromData`.

Commit change
> In other words, a type is a data guard _if_ it implements `FromData`.


It seems to have come from commit 63a14525d86595a8033715e3bdcd2bf2581eecb1 ([ref. to line](https://github.com/SergioBenitez/Rocket/commit/63a14525d86595a8033715e3bdcd2bf2581eecb1#diff-a50bf8c7c0ff968d7b05542b7ed9ecde3e9a509b6de581c47dffcf217b8f39daR38)) on on Mar 4, 2021 with tag [`v0.5.0-rc.1`](https://github.com/SergioBenitez/Rocket/releases/tag/v0.5.0-rc.1)