### PR TITLE
Make HTTP/2 optional (closes #2030)

### DIFF
--- a/core/http/Cargo.toml
+++ b/core/http/Cargo.toml
@@ -18,6 +18,7 @@ edition = "2018"
 default = []
 tls = ["rustls", "tokio-rustls", "rustls-pemfile"]
 mtls = ["tls", "x509-parser"]
+http2 = ["hyper/http2"]
 private-cookies = ["cookie/private", "cookie/key-expansion"]
 serde = ["uncased/with-serde-alloc", "serde_"]
 uuid = ["uuid_"]
@@ -50,7 +51,7 @@ optional = true
 [dependencies.hyper]
 version = "0.14.9"
 default-features = false
-features = ["http1", "http2", "runtime", "server", "stream"]
+features = ["http1", "runtime", "server", "stream"]
 
 [dependencies.serde_]
 package = "serde"

--- a/core/http/src/tls/listener.rs
+++ b/core/http/src/tls/listener.rs
@@ -64,7 +64,12 @@ impl TlsListener {
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("bad TLS config: {}", e)))?;
 
         tls_config.ignore_client_order = c.prefer_server_order;
-        tls_config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
+
+        tls_config.alpn_protocols = vec![b"http/1.1".to_vec()];
+        if cfg!(feature = "http2") {
+            tls_config.alpn_protocols.insert(0, b"h2".to_vec());
+        }
+
         tls_config.session_storage = ServerSessionMemoryCache::new(1024);
         tls_config.ticketer = rustls::Ticketer::new()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("bad TLS ticketer: {}", e)))?;

--- a/core/lib/Cargo.toml
+++ b/core/lib/Cargo.toml
@@ -19,9 +19,10 @@ edition = "2018"
 all-features = true
 
 [features]
-default = []
+default = ["http2"]
 tls = ["rocket_http/tls"]
 mtls = ["rocket_http/mtls", "tls"]
+http2 = ["rocket_http/http2"]
 secrets = ["rocket_http/private-cookies"]
 json = ["serde_json", "tokio/io-util"]
 msgpack = ["rmp-serde", "tokio/io-util"]

--- a/core/lib/src/lib.rs
+++ b/core/lib/src/lib.rs
@@ -56,23 +56,31 @@
 //!
 //! ## Features
 //!
-//! To avoid compiling unused dependencies, Rocket gates certain features, all
-//! of which are disabled by default:
+//! To avoid compiling unused dependencies, Rocket gates certain features. With
+//! the exception of `http2`, all of them are disabled by default:
 //!
 //! | Feature   | Description                                             |
 //! |-----------|---------------------------------------------------------|
 //! | `secrets` | Support for authenticated, encrypted [private cookies]. |
 //! | `tls`     | Support for [TLS] encrypted connections.                |
 //! | `mtls`    | Support for verified clients via [mutual TLS].          |
+//! | `http2`   | Support for HTTP/2.                                     |
 //! | `json`    | Support for [JSON (de)serialization].                   |
 //! | `msgpack` | Support for [MessagePack (de)serialization].            |
 //! | `uuid`    | Support for [UUID value parsing and (de)serialization]. |
 //!
-//! Features can be selectively enabled in `Cargo.toml`:
+//! Disabled features can be selectively enabled in `Cargo.toml`:
 //!
 //! ```toml
 //! [dependencies]
 //! rocket = { version = "0.5.0-rc.1", features = ["secrets", "tls", "json"] }
+//! ```
+//!
+//! Conversely, HTTP/2 can be disabled:
+//!
+//! ```toml
+//! [dependencies]
+//! rocket = { version = "0.5.0-rc.1", default-features = false }
 //! ```
 //!
 //! [JSON (de)serialization]: crate::serde::json

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -118,6 +118,7 @@ function test_core() {
     secrets
     tls
     mtls
+    http2
     json
     msgpack
     uuid


### PR DESCRIPTION
See SergioBenitez/Rocket#2030

This very simple PR adds a new "`http2`" feature to `core/http`, that itself enables or disables `hyper`'s similarly-named feature. An  "`http2`" feature is also added to the main crate, `core/lib` and is set as default here.

All statements that depend on HTTP/2 are put behind `#[cfg]` attributes.

`rocket` compiles both with and without this new feature.