### PR TITLE
Migrate to Edition 2021

### DIFF
--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rocket-benchmarks"
 version = "0.0.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [workspace]

--- a/contrib/db_pools/codegen/Cargo.toml
+++ b/contrib/db_pools/codegen/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/SergioBenitez/Rocket/contrib/db_pools"
 readme = "../README.md"
 keywords = ["rocket", "framework", "database", "pools"]
 license = "MIT OR Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 [lib]
 proc-macro = true

--- a/contrib/db_pools/codegen/Cargo.toml
+++ b/contrib/db_pools/codegen/Cargo.toml
@@ -8,6 +8,7 @@ readme = "../README.md"
 keywords = ["rocket", "framework", "database", "pools"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
+rust-version = "1.56"
 
 [lib]
 proc-macro = true

--- a/contrib/db_pools/lib/Cargo.toml
+++ b/contrib/db_pools/lib/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/SergioBenitez/Rocket/contrib/db_pools"
 readme = "../README.md"
 keywords = ["rocket", "framework", "database", "pools"]
 license = "MIT OR Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/contrib/db_pools/lib/Cargo.toml
+++ b/contrib/db_pools/lib/Cargo.toml
@@ -8,6 +8,7 @@ readme = "../README.md"
 keywords = ["rocket", "framework", "database", "pools"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
+rust-version = "1.56"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/contrib/dyn_templates/Cargo.toml
+++ b/contrib/dyn_templates/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/SergioBenitez/Rocket/tree/master/contrib/dyn_te
 readme = "README.md"
 keywords = ["rocket", "framework", "templates", "templating", "engine"]
 license = "MIT OR Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 [features]
 tera = ["tera_"]

--- a/contrib/dyn_templates/Cargo.toml
+++ b/contrib/dyn_templates/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 keywords = ["rocket", "framework", "templates", "templating", "engine"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
+rust-version = "1.56"
 
 [features]
 tera = ["tera_"]

--- a/contrib/sync_db_pools/codegen/Cargo.toml
+++ b/contrib/sync_db_pools/codegen/Cargo.toml
@@ -8,6 +8,7 @@ readme = "../README.md"
 keywords = ["rocket", "framework", "database", "pools"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
+rust-version = "1.56"
 
 [lib]
 proc-macro = true

--- a/contrib/sync_db_pools/codegen/Cargo.toml
+++ b/contrib/sync_db_pools/codegen/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/SergioBenitez/Rocket/contrib/sync_db_pools"
 readme = "../README.md"
 keywords = ["rocket", "framework", "database", "pools"]
 license = "MIT OR Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 [lib]
 proc-macro = true

--- a/contrib/sync_db_pools/lib/Cargo.toml
+++ b/contrib/sync_db_pools/lib/Cargo.toml
@@ -8,6 +8,7 @@ readme = "../README.md"
 keywords = ["rocket", "framework", "database", "pools"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
+rust-version = "1.56"
 
 [features]
 diesel_sqlite_pool = ["diesel/sqlite", "diesel/r2d2"]

--- a/contrib/sync_db_pools/lib/Cargo.toml
+++ b/contrib/sync_db_pools/lib/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/SergioBenitez/Rocket/tree/v0.5-rc/contrib/sync_
 readme = "../README.md"
 keywords = ["rocket", "framework", "database", "pools"]
 license = "MIT OR Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 [features]
 diesel_sqlite_pool = ["diesel/sqlite", "diesel/r2d2"]

--- a/contrib/sync_db_pools/lib/src/poolable.rs
+++ b/contrib/sync_db_pools/lib/src/poolable.rs
@@ -60,7 +60,7 @@ use crate::{Config, Error};
 /// #     impl self::r2d2::ManageConnection for ConnectionManager {
 /// #          type Connection = Connection;
 /// #          type Error = Error;
-/// #          fn connect(&self) -> Result<Connection> { panic!(()) }
+/// #          fn connect(&self) -> Result<Connection> { panic!() }
 /// #          fn is_valid(&self, _: &mut Connection) -> Result<()> { panic!() }
 /// #          fn has_broken(&self, _: &mut Connection) -> bool { panic!() }
 /// #     }

--- a/core/codegen/Cargo.toml
+++ b/core/codegen/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/SergioBenitez/Rocket"
 readme = "../../README.md"
 keywords = ["rocket", "web", "framework", "code", "generation"]
 license = "MIT OR Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 [lib]
 proc-macro = true

--- a/core/codegen/Cargo.toml
+++ b/core/codegen/Cargo.toml
@@ -10,6 +10,7 @@ readme = "../../README.md"
 keywords = ["rocket", "web", "framework", "code", "generation"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
+rust-version = "1.56"
 
 [lib]
 proc-macro = true

--- a/core/http/Cargo.toml
+++ b/core/http/Cargo.toml
@@ -13,6 +13,7 @@ keywords = ["rocket", "web", "framework", "http"]
 license = "MIT OR Apache-2.0"
 categories = ["web-programming"]
 edition = "2021"
+rust-version = "1.56"
 
 [features]
 default = []

--- a/core/http/Cargo.toml
+++ b/core/http/Cargo.toml
@@ -12,7 +12,7 @@ readme = "../../README.md"
 keywords = ["rocket", "web", "framework", "http"]
 license = "MIT OR Apache-2.0"
 categories = ["web-programming"]
-edition = "2018"
+edition = "2021"
 
 [features]
 default = []

--- a/core/http/src/ext.rs
+++ b/core/http/src/ext.rs
@@ -1,8 +1,5 @@
 //! Extension traits implemented by several HTTP types.
 
-// Temporarily allow `IntoIter::into_iter()` before Rust 2021 transition.
-#![allow(deprecated)]
-
 use smallvec::{Array, SmallVec};
 use state::Storage;
 
@@ -66,14 +63,14 @@ impl<T: Clone> IntoCollection<T> for &[T] {
 impl<T, const N: usize> IntoCollection<T> for [T; N] {
     #[inline(always)]
     fn into_collection<A: Array<Item=T>>(self) -> SmallVec<A> {
-        std::array::IntoIter::new(self).collect()
+        self.into_iter().collect()
     }
 
     #[inline]
     fn mapped<U, F, A: Array<Item=U>>(self, f: F) -> SmallVec<A>
         where F: FnMut(T) -> U
     {
-        std::array::IntoIter::new(self).map(f).collect()
+        self.into_iter().map(f).collect()
     }
 }
 

--- a/core/http/src/uri/uri.rs
+++ b/core/http/src/uri/uri.rs
@@ -1,5 +1,4 @@
 use std::fmt::{self, Display};
-use std::convert::TryFrom;
 use std::borrow::Cow;
 
 use crate::ext::IntoOwned;

--- a/core/lib/Cargo.toml
+++ b/core/lib/Cargo.toml
@@ -14,6 +14,7 @@ license = "MIT OR Apache-2.0"
 build = "build.rs"
 categories = ["web-programming::http-server"]
 edition = "2021"
+rust-version = "1.56"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/core/lib/Cargo.toml
+++ b/core/lib/Cargo.toml
@@ -82,7 +82,6 @@ features = ["io"]
 version = "1.0"
 
 [build-dependencies]
-yansi = "0.5"
 version_check = "0.9.1"
 
 [dev-dependencies]

--- a/core/lib/Cargo.toml
+++ b/core/lib/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["rocket", "web", "framework", "server"]
 license = "MIT OR Apache-2.0"
 build = "build.rs"
 categories = ["web-programming::http-server"]
-edition = "2018"
+edition = "2021"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/core/lib/build.rs
+++ b/core/lib/build.rs
@@ -1,23 +1,4 @@
-//! Ensures Rocket isn't compiled with an incompatible version of Rust.
-
-use yansi::{Paint, Color::{Red, Yellow}};
-
 fn main() {
-    const MIN_VERSION: &str = "1.46.0";
-
-    if let Some(version) = version_check::Version::read() {
-        if !version.at_least(MIN_VERSION) {
-            let msg = "Rocket requires a more recent version of rustc.";
-            eprintln!("{} {}", Red.paint("Error:").bold(), Paint::new(msg).bold());
-            eprintln!("Installed version: {}", Yellow.paint(version));
-            eprintln!("Minimum required:  {}", Yellow.paint(MIN_VERSION));
-            panic!("Aborting compilation due to incompatible compiler.")
-        }
-    } else {
-        println!("cargo:warning=Rocket was unable to check rustc compiler compatibility.");
-        println!("cargo:warning=Build may fail due to incompatible rustc version.");
-    }
-
     if let Some(true) = version_check::is_feature_flaggable() {
         println!("cargo:rustc-cfg=nightly");
     }

--- a/core/lib/fuzz/Cargo.toml
+++ b/core/lib/fuzz/Cargo.toml
@@ -4,7 +4,7 @@ name = "rocket-fuzz"
 version = "0.0.0"
 authors = ["Automatically generated"]
 publish = false
-edition = "2018"
+edition = "2021"
 
 [package.metadata]
 cargo-fuzz = true

--- a/core/lib/src/form/validate.rs
+++ b/core/lib/src/form/validate.rs
@@ -79,7 +79,6 @@
 //! ```
 
 use std::borrow::Cow;
-use std::convert::TryInto;
 use std::ops::{RangeBounds, Bound};
 use std::fmt::Debug;
 

--- a/core/lib/src/local/asynchronous/client.rs
+++ b/core/lib/src/local/asynchronous/client.rs
@@ -1,5 +1,4 @@
 use std::fmt;
-use std::convert::TryInto;
 
 use parking_lot::RwLock;
 

--- a/core/lib/src/local/asynchronous/request.rs
+++ b/core/lib/src/local/asynchronous/request.rs
@@ -1,5 +1,4 @@
 use std::fmt;
-use std::convert::TryInto;
 
 use crate::{Request, Data};
 use crate::http::{Status, Method};

--- a/core/lib/src/local/blocking/client.rs
+++ b/core/lib/src/local/blocking/client.rs
@@ -1,6 +1,5 @@
 use std::fmt;
 use std::cell::RefCell;
-use std::convert::TryInto;
 
 use crate::{Rocket, Phase, Orbit, Error};
 use crate::local::{asynchronous, blocking::{LocalRequest, LocalResponse}};

--- a/core/lib/src/local/blocking/request.rs
+++ b/core/lib/src/local/blocking/request.rs
@@ -1,5 +1,4 @@
 use std::fmt;
-use std::convert::TryInto;
 
 use crate::{Request, http::Method, local::asynchronous};
 use crate::http::uri::Origin;

--- a/core/lib/src/response/redirect.rs
+++ b/core/lib/src/response/redirect.rs
@@ -1,5 +1,3 @@
-use std::convert::TryInto;
-
 use crate::request::Request;
 use crate::response::{self, Response, Responder};
 use crate::http::uri::Reference;

--- a/core/lib/src/response/stream/sse.rs
+++ b/core/lib/src/response/stream/sse.rs
@@ -1,7 +1,3 @@
-// Temporarily allow `IntoIter::into_iter()` before Rust 2021 transition.
-#![allow(deprecated)]
-
-use std::array;
 use std::borrow::Cow;
 
 use tokio::io::AsyncRead;
@@ -340,7 +336,7 @@ impl Event {
             Some(RawLinedEvent::raw("")),
         ];
 
-        stream::iter(array::IntoIter::new(events)).filter_map(ready)
+        stream::iter(events).filter_map(ready)
     }
 }
 

--- a/core/lib/src/rocket.rs
+++ b/core/lib/src/rocket.rs
@@ -1,6 +1,5 @@
 use std::fmt;
 use std::ops::{Deref, DerefMut};
-use std::convert::TryInto;
 use std::net::SocketAddr;
 
 use yansi::Paint;

--- a/examples/chat/Cargo.toml
+++ b/examples/chat/Cargo.toml
@@ -2,7 +2,7 @@
 name = "chat"
 version = "0.0.0"
 workspace = "../"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/examples/config/Cargo.toml
+++ b/examples/config/Cargo.toml
@@ -2,7 +2,7 @@
 name = "config"
 version = "0.0.0"
 workspace = "../"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/examples/cookies/Cargo.toml
+++ b/examples/cookies/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cookies"
 version = "0.0.0"
 workspace = "../"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/examples/databases/Cargo.toml
+++ b/examples/databases/Cargo.toml
@@ -2,7 +2,7 @@
 name = "databases"
 version = "0.0.0"
 workspace = "../"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/examples/error-handling/Cargo.toml
+++ b/examples/error-handling/Cargo.toml
@@ -2,7 +2,7 @@
 name = "error-handling"
 version = "0.0.0"
 workspace = "../"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/examples/fairings/Cargo.toml
+++ b/examples/fairings/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fairings"
 version = "0.0.0"
 workspace = "../"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/examples/forms/Cargo.toml
+++ b/examples/forms/Cargo.toml
@@ -2,7 +2,7 @@
 name = "forms"
 version = "0.0.0"
 workspace = "../"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/examples/hello/Cargo.toml
+++ b/examples/hello/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hello"
 version = "0.0.0"
 workspace = "../"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/examples/manual-routing/Cargo.toml
+++ b/examples/manual-routing/Cargo.toml
@@ -2,7 +2,7 @@
 name = "manual_routes"
 version = "0.0.0"
 workspace = "../"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/examples/pastebin/Cargo.toml
+++ b/examples/pastebin/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pastebin"
 version = "0.0.0"
 workspace = "../"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/examples/responders/Cargo.toml
+++ b/examples/responders/Cargo.toml
@@ -2,7 +2,7 @@
 name = "responders"
 version = "0.0.0"
 workspace = "../"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/examples/serialization/Cargo.toml
+++ b/examples/serialization/Cargo.toml
@@ -2,7 +2,7 @@
 name = "serialization"
 version = "0.0.0"
 workspace = "../"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies.rocket]

--- a/examples/state/Cargo.toml
+++ b/examples/state/Cargo.toml
@@ -2,7 +2,7 @@
 name = "state"
 version = "0.0.0"
 workspace = "../"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/examples/static-files/Cargo.toml
+++ b/examples/static-files/Cargo.toml
@@ -2,7 +2,7 @@
 name = "static-files"
 version = "0.0.0"
 workspace = "../"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/examples/templating/Cargo.toml
+++ b/examples/templating/Cargo.toml
@@ -2,7 +2,7 @@
 name = "templating"
 version = "0.0.0"
 workspace = "../"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/examples/testing/Cargo.toml
+++ b/examples/testing/Cargo.toml
@@ -2,7 +2,7 @@
 name = "testing"
 version = "0.0.0"
 workspace = "../"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/examples/tls/Cargo.toml
+++ b/examples/tls/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tls"
 version = "0.0.0"
 workspace = "../"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/examples/todo/Cargo.toml
+++ b/examples/todo/Cargo.toml
@@ -2,7 +2,7 @@
 name = "todo"
 version = "0.0.0"
 workspace = "../"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/site/tests/Cargo.toml
+++ b/site/tests/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rocket_guide_tests"
 version = "0.5.0-rc.1"
 workspace = "../../"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]


### PR DESCRIPTION
Since Rocket 0.5 has not yet been released, this may be a good opportunity to increase MSRV so that it won't have to be done after its release.