### PR TITLE
Replace deprecated 'std::array::IntoIter::new()'

### DIFF
--- a/core/http/src/ext.rs
+++ b/core/http/src/ext.rs
@@ -1,8 +1,5 @@
 //! Extension traits implemented by several HTTP types.
 
-// Temporarily allow `IntoIter::into_iter()` before Rust 2021 transition.
-#![allow(deprecated)]
-
 use smallvec::{Array, SmallVec};
 use state::Storage;
 
@@ -66,14 +63,14 @@ impl<T: Clone> IntoCollection<T> for &[T] {
 impl<T, const N: usize> IntoCollection<T> for [T; N] {
     #[inline(always)]
     fn into_collection<A: Array<Item=T>>(self) -> SmallVec<A> {
-        std::array::IntoIter::new(self).collect()
+        Self::into_iter(self).collect()
     }
 
     #[inline]
     fn mapped<U, F, A: Array<Item=U>>(self, f: F) -> SmallVec<A>
         where F: FnMut(T) -> U
     {
-        std::array::IntoIter::new(self).map(f).collect()
+        Self::into_iter(self).map(f).collect()
     }
 }
 

--- a/core/lib/src/response/stream/sse.rs
+++ b/core/lib/src/response/stream/sse.rs
@@ -1,7 +1,3 @@
-// Temporarily allow `IntoIter::into_iter()` before Rust 2021 transition.
-#![allow(deprecated)]
-
-use std::array;
 use std::borrow::Cow;
 
 use tokio::io::AsyncRead;
@@ -340,7 +336,7 @@ impl Event {
             Some(RawLinedEvent::raw("")),
         ];
 
-        stream::iter(array::IntoIter::new(events)).filter_map(ready)
+        stream::iter(<[Option<RawLinedEvent>; 6]>::into_iter(events)).filter_map(ready)
     }
 }
 


### PR DESCRIPTION
Non-Functional-change.
Helps reduce noise from "deprecated" warnings :)