### PR TITLE
Update 'sqlite' contrib dependencies

### DIFF
--- a/contrib/sync_db_pools/lib/Cargo.toml
+++ b/contrib/sync_db_pools/lib/Cargo.toml
@@ -27,8 +27,8 @@ diesel = { version = "1.0", default-features = false, optional = true }
 postgres = { version = "0.19", optional = true }
 r2d2_postgres = { version = "0.18", optional = true }
 
-rusqlite = { version = "0.25", optional = true }
-r2d2_sqlite = { version = "0.18", optional = true }
+rusqlite = { version = "0.27", optional = true }
+r2d2_sqlite = { version = "0.20", optional = true }
 
 memcache = { version = "0.15", optional = true }
 r2d2-memcache = { version = "0.6", optional = true }


### PR DESCRIPTION
This bumps the dependencies needed for using SQLite + sync DB pools to their latest versions.

The same chore was tackled almost a year ago here: https://github.com/SergioBenitez/Rocket/commit/f4ecc3e3bdb01fa2f79b0f89acc8a80d0a11a677.