### PR TITLE
Disable cookie's secure feature

### DIFF
--- a/core/codegen/tests/ui-fail-nightly/from_form.stderr
+++ b/core/codegen/tests/ui-fail-nightly/from_form.stderr
@@ -514,5 +514,4 @@ error[E0277]: the trait bound `bool: From<&str>` is not satisfied
 209 |     #[field(default = "no conversion")]
     |                       ^^^^^^^^^^^^^^^ the trait `From<&str>` is not implemented for `bool`
     |
-    = help: the trait `From<subtle::Choice>` is implemented for `bool`
     = note: required because of the requirements on the impl of `Into<bool>` for `&str`

--- a/core/codegen/tests/ui-fail-stable/from_form.stderr
+++ b/core/codegen/tests/ui-fail-stable/from_form.stderr
@@ -533,6 +533,4 @@ error[E0277]: the trait bound `bool: From<&str>` is not satisfied
 209 |     #[field(default = "no conversion")]
     |                       ^^^^^^^^^^^^^^^ the trait `From<&str>` is not implemented for `bool`
     |
-    = help: the following implementations were found:
-              <bool as From<subtle::Choice>>
     = note: required because of the requirements on the impl of `Into<bool>` for `&str`

--- a/core/http/Cargo.toml
+++ b/core/http/Cargo.toml
@@ -42,7 +42,7 @@ pear = "0.2.3"
 pin-project-lite = "0.2"
 memchr = "2"
 stable-pattern = "0.1"
-cookie = { version = "0.16.0", features = ["percent-encode", "secure"] }
+cookie = { version = "0.16.0", features = ["percent-encode"] }
 state = "0.5.3"
 futures = { version = "0.3", default-features = false }
 


### PR DESCRIPTION
`secure` feature enabled `private` and `key-expansion` features which were supposed to be enabled only with `private-cookies` feature.