### PR TITLE
Update default Permission-Policy header to disable browsing-topics

### DIFF
--- a/core/lib/src/shield/policy.rs
+++ b/core/lib/src/shield/policy.rs
@@ -486,7 +486,7 @@ impl From<&Prefetch> for Header<'static> {
 /// # Default
 ///
 /// The default returned via [`Permission::default()`] blocks access to the
-/// `interest-cohort` feature, otherwise known as FLoC, which disables using the
+/// `browsing-topics` feature, the successor of FLoC, which disables using the
 /// current site in ad targeting tracking computations.
 ///
 /// [Permissions-Policy]: https://github.com/w3c/webappsec-permissions-policy/blob/a45df7b237e2a85e1909d7f226ca4eb4ce5095ba/permissions-policy-explainer.md
@@ -494,9 +494,9 @@ impl From<&Prefetch> for Header<'static> {
 pub struct Permission(IndexMap<Feature, Option<SmallVec<[Allow; 1]>>>);
 
 impl Default for Permission {
-    /// The default `Permission` policy blocks access to the `interest-cohort`
-    /// feature, otherwise known as FLoC, which disables using the current site
-    /// in ad targeting tracking computations.
+    /// The default `Permission` policy blocks access to the `browsing-topics`
+    /// feature, the successor of FLoC, which disables using the current site in
+    /// ad targeting tracking computations.
     fn default() -> Self {
         Permission::blocked(Feature::InterestCohort)
     }
@@ -666,7 +666,7 @@ impl From<&Permission> for Header<'static> {
         if perm == &Permission::default() {
             static DEFAULT: Header<'static> = Header {
                 name: Uncased::from_borrowed(Permission::NAME),
-                value: Cow::Borrowed("interest-cohort=()")
+                value: Cow::Borrowed("browsing-topics=()")
             };
 
             return DEFAULT.clone();
@@ -809,7 +809,7 @@ pub enum Feature {
     Gamepad,
     /// The "speaker-selection" feature.
     SpeakerSelection,
-    /// The "interest-cohort" feature.
+    /// The "browsing-topics" feature.
     InterestCohort,
 
     // Experimental.
@@ -878,7 +878,7 @@ impl Feature {
             ClipboardWrite => "clipboard-write",
             Gamepad => "gamepad",
             SpeakerSelection => "speaker-selection",
-            InterestCohort => "interest-cohort",
+            InterestCohort => "browsing-topics",
 
             ConversionMeasurement => "conversion-measurement",
             FocusWithoutUserActivation => "focus-without-user-activation",

--- a/core/lib/tests/shield.rs
+++ b/core/lib/tests/shield.rs
@@ -40,13 +40,13 @@ macro_rules! dispatch {
 fn default_shield() {
     let client = Client::debug(rocket::build()).unwrap();
     let response = client.get("/").dispatch();
-    assert_header!(response, "Permissions-Policy", "interest-cohort=()");
+    assert_header!(response, "Permissions-Policy", "browsing-topics=()");
     assert_header!(response, "X-Frame-Options", "SAMEORIGIN");
     assert_header!(response, "X-Content-Type-Options", "nosniff");
 
     let client = Client::debug(rocket::custom(Config::debug_default())).unwrap();
     let response = client.get("/").dispatch();
-    assert_header!(response, "Permissions-Policy", "interest-cohort=()");
+    assert_header!(response, "Permissions-Policy", "browsing-topics=()");
     assert_header!(response, "X-Frame-Options", "SAMEORIGIN");
     assert_header!(response, "X-Content-Type-Options", "nosniff");
 }
@@ -71,7 +71,7 @@ fn shield_singleton() {
 #[test]
 fn default_headers_test() {
     dispatch!(Shield::default(), |response: LocalResponse<'_>| {
-        assert_header!(response, "Permissions-Policy", "interest-cohort=()");
+        assert_header!(response, "Permissions-Policy", "browsing-topics=()");
         assert_header!(response, "X-Frame-Options", "SAMEORIGIN");
         assert_header!(response, "X-Content-Type-Options", "nosniff");
     })
@@ -88,7 +88,7 @@ fn disable_headers_test() {
 
     let shield = Shield::default().disable::<Frame>();
     dispatch!(shield, |response: LocalResponse<'_>| {
-        assert_header!(response, "Permissions-Policy", "interest-cohort=()");
+        assert_header!(response, "Permissions-Policy", "browsing-topics=()");
         assert_header!(response, "X-Content-Type-Options", "nosniff");
         assert_no_header!(response, "X-Frame-Options");
     });
@@ -183,7 +183,7 @@ fn bad_uri_permission_test2() {
 fn permission_test() {
     let shield = Shield::default().enable(Permission::default());
     dispatch!(shield, |response: LocalResponse<'_>| {
-        assert_header!(response, "Permissions-Policy", "interest-cohort=()");
+        assert_header!(response, "Permissions-Policy", "browsing-topics=()");
     });
 
     let shield = Shield::default().enable(Permission::blocked(Feature::Usb));


### PR DESCRIPTION
Since Google abandoned FLoC, and introduced Topics, hereby suggesting these changes. The feature itself is still experimental: https://bugs.chromium.org/p/chromium/issues/detail?id=1294456