### PR TITLE
Convert Form Error impl to Const Generic

### DIFF
--- a/core/lib/src/form/error.rs
+++ b/core/lib/src/form/error.rs
@@ -947,18 +947,13 @@ impl From<(Option<ByteUnit>, Option<ByteUnit>)> for ErrorKind<'_> {
     }
 }
 
-macro_rules! impl_from_choices {
-    ($($size:literal),*) => ($(
-        impl<'a, 'v: 'a> From<&'static [Cow<'v, str>; $size]> for ErrorKind<'a> {
-            fn from(choices: &'static [Cow<'v, str>; $size]) -> Self {
-                let choices = &choices[..];
-                ErrorKind::InvalidChoice { choices: choices.into() }
-            }
-        }
-    )*)
+impl<'a, 'v: 'a, const N: usize> From<&'static [Cow<'v, str>; N]> for ErrorKind<'a> {
+    fn from(choices: &'static [Cow<'v, str>; N]) -> Self {
+        let choices = &choices[..];
+        ErrorKind::InvalidChoice { choices: choices.into() }
+    }
 }
 
-impl_from_choices!(1, 2, 3, 4, 5, 6, 7, 8);
 
 macro_rules! impl_from_for {
     (<$l:lifetime> $T:ty => $V:ty as $variant:ident) => (


### PR DESCRIPTION
Converts an older style array impl to use const generics, allowing any
length, not just the listed sizes.

I'm not sure if the old implementation was intentional (limiting the array to a length of 9), but I would assume it wasn't. I believe the minimum complier version for Rocket is high enough that const generics are guaranteed to be supported.

Please let me know if there are any issues with this.