### PR TITLE
Update form Error types to improve lifetimes

### DIFF
--- a/site/guide/4-requests.md
+++ b/site/guide/4-requests.md
@@ -1069,7 +1069,7 @@ struct CreditCard {
     expiration: Date,
 }
 
-fn luhn<'v>(number: &u64, cvv: u16, exp: &Date) -> form::Result<'v, ()> {
+fn luhn(number: &u64, cvv: u16, exp: &Date) -> form::Result<'static, ()> {
     # let valid = false;
     if !valid {
         Err(Error::validation("invalid credit card number"))?;
@@ -1082,6 +1082,14 @@ fn luhn<'v>(number: &u64, cvv: u16, exp: &Date) -> form::Result<'v, ()> {
 If a field's validation doesn't depend on other fields (validation is _local_),
 it is validated prior to those fields that do. For `CreditCard`, `cvv` and
 `expiration` will be validated prior to `number`.
+
+! NOTE Validator lifetimes
+
+  The lifetime of the field passed to the validator NEEDS to be different from the
+  lifetime returned in the Result. In the above example, the returned lifetime is
+  `'v`, while the number and exp date aren't given explicit lifetimes (i.e. they
+  are NOT `'v`). In general, the returned lifetime can be static, since it isn't
+  allowed to borrow from any of the parameters anyway.
 
 ### Wrapping Validators
 


### PR DESCRIPTION
Adds an override of the `extend` method that enables derived form
validators to return `form::Result<'static, ()>`. It appears the central
issue is the `Cow<'v, [Cow<'v, str>]>` potentially held by the
`ErrorKind` struct, which Rust can't automatically shorten the lifetime
for. In theory, it should be safe to perform the same transform via an
unsafe transmute, but I would rather avoid unsafe code, and rely on the
compiler to recogize that it's effectively a no-op.