### PR TITLE
Fix typo in 0.5 upgrade guide.

### DIFF
--- a/site/guide/01-upgrading-from-0.4.md
+++ b/site/guide/01-upgrading-from-0.4.md
@@ -298,7 +298,7 @@ use rocket::tokio::task;
 use rocket::response::Debug;
 
 #[get("/")]
-async fn exepensive() -> Result<(), Debug<task::JoinError>> {
+async fn expensive() -> Result<(), Debug<task::JoinError>> {
     let result = task::spawn_blocking(move || {
         // perform the computation
     }).await?;


### PR DESCRIPTION
`exepensive` to `expensive`.