### PR TITLE
codegen: fix clippy::no-effect-underscore-bindings

### DIFF
--- a/core/codegen/src/bang/mod.rs
+++ b/core/codegen/src/bang/mod.rs
@@ -20,9 +20,9 @@ fn struct_maker_vec(
     // Parse a comma-separated list of paths.
     let paths = <Punctuated<Path, Token![,]>>::parse_terminated.parse(input)?;
     let exprs = paths.iter().map(|path| {
-        let expr = map(quote_spanned!(path.span() => ___struct));
+        let expr = map(quote_spanned!(path.span() => r#struct));
         quote_spanned!(path.span() => {
-            let ___struct = #path {};
+            let r#struct = #path {};
             let ___item: #ty = #expr;
             ___item
         })


### PR DESCRIPTION
This lint checks for binding to underscore prefixed variables without side-effects.

Further usage of such variables is not checked, which can lead to false positives if they are used later in the code.

To fix the false positive we use Rust's `r#` variable prefix to avoid collisions with Rust keywords.

Fixes first part of #2211 