### PR TITLE
Fix typo and imporve echo command in guide/pastebin

### DIFF
--- a/site/guide/10-pastebin.md
+++ b/site/guide/10-pastebin.md
@@ -307,7 +307,7 @@ using a type more specific than `&str` to represent IDs and then asking Rocket
 to validate the untrusted `id` input as that type. If validation fails, Rocket
 will take care to not call our routes with bad input.
 
-Typed validation for dynamic paramters like `id` is implemented via the
+Typed validation for dynamic parameters like `id` is implemented via the
 [`FromParam`] trait. Rocket uses `FromParam` to automatically validate and parse
 dynamic path parameters like `id`. We already have a type that represents valid
 paste IDs, `PasteId`, so we'll simply need to implement `FromParam` for
@@ -499,7 +499,7 @@ file using `curl` then retrieve the paste using the returned URL.
 cargo run
 
 ## in a separate terminal
-echo "Hello, Rocket!" | curl --data-binary @- http://localhost:8000
+echo Hello, Rocket! | curl --data-binary @- http://localhost:8000
 ## => http://localhost:8000/eGs
 
 ## confirm we can retrieve the paste (replace with URL from above)


### PR DESCRIPTION
1. Fix a typo.
2. A string in `echo` command does not need to be wrapped by double-quotes.
