### PR TITLE
add option to use sqlx connect_lazy_with for rocket_db_pools

### DIFF
--- a/contrib/db_pools/lib/src/config.rs
+++ b/contrib/db_pools/lib/src/config.rs
@@ -80,4 +80,9 @@ pub struct Config {
     ///
     /// _Default:_ `None`.
     pub idle_timeout: Option<u64>,
+    /// Flag to allow sqlx to use `connect_lazy_with`
+    /// which only establish a connections as the pool is start to be used
+    /// 
+    /// _Default:_ `false`
+    pub lazy_connection: bool,
 }

--- a/contrib/db_pools/lib/src/database.rs
+++ b/contrib/db_pools/lib/src/database.rs
@@ -262,7 +262,8 @@ impl<D: Database> Fairing for Initializer<D> {
         let figment = rocket.figment()
             .focus(&format!("databases.{}", D::NAME))
             .merge(Serialized::default("max_connections", workers * 4))
-            .merge(Serialized::default("connect_timeout", 5));
+            .merge(Serialized::default("connect_timeout", 5))
+            .merge(Serialized::default("lazy_connection", false));
 
         match <D::Pool>::init(&figment).await {
             Ok(pool) => Ok(rocket.manage(D::from(pool))),

--- a/contrib/db_pools/lib/src/pool.rs
+++ b/contrib/db_pools/lib/src/pool.rs
@@ -223,14 +223,19 @@ mod sqlx {
                 }
             }
 
-            sqlx::pool::PoolOptions::new()
+            let pool = sqlx::pool::PoolOptions::new()
                 .max_connections(config.max_connections as u32)
                 .connect_timeout(Duration::from_secs(config.connect_timeout))
                 .idle_timeout(config.idle_timeout.map(Duration::from_secs))
-                .min_connections(config.min_connections.unwrap_or_default())
-                .connect_with(opts)
+                .min_connections(config.min_connections.unwrap_or_default());
+
+            if config.lazy_connection {
+                Ok(pool.connect_lazy_with(opts))
+            } else {
+                pool.connect_with(opts)
                 .await
                 .map_err(Error::Init)
+            }
         }
 
         async fn get(&self) -> Result<Self::Connection, Self::Error> {


### PR DESCRIPTION
currently rocket_db_pools use sqlx `connect_with` function which will try to create connection on launch

this create problem, if for some reason your DB goes down, and your app got restarted before the DB become available again, app will fail to launch

if for whatever reason you need your app to be still running without an active DB (especially on launch), you can use sqlx `connect_lazy_with` instead, which only return the pool, without any connection. the connection will be created once it is being used

on route, since you need to pass the pool connection via requestGuard, if you want it to still work even with the DB being down, you can simply create a wrapper requestGuard that always return `Outcome::Success` and handle the pool connection retrieval attempt yourself



```
#[get("/somepath")]
pub async fn somepath(pools_wrapper_guard: PoolsWrapperGuard) {
        let db_pool = get_db_pool(pools_wrapper_guard);
        // do whatever you want
}


use rocket::request::{FromRequest,Outcome};
use rocket_db_pools::sqlx::pool::PoolConnection;
use rocket_db_pools::{Connection, sqlx::MySql};

pub struct PoolsWrapperGuard {
        pub mydb:  Outcome<Connection<Mydb>, Option<rocket_db_pools::Error<rocket_db_pools::sqlx::Error, rocket_db_pools::sqlx::Error>>>
}

#[rocket::async_trait]
impl<'r> FromRequest<'r> for PoolsWrapperGuard {
    type Error = ();

    async fn from_request(request: &'r Request<'_>) -> Outcome<Self, ()> {
        Outcome::Success(
            PoolsWrapperGuard{
                mydb: request.guard::<Connection<Mydb>>().await
            }
        )

    }
}

pub fn get_db_pool(PoolsWrapperGuard { mydb }: PoolsWrapperGuard) -> Option<PoolConnection<MySql>> {
    // figure out the actual Outcome 
    match mydb {
            Outcome::Success(connect) => Some(connect.into_inner()),
            Outcome::Failure((_s, _e)) => None,
            Outcome::Forward(_f) => None
    }
}
```

this is my first attempt to contribute to any Project, so any suggestion to improve this PR / suggestion is very much appreciated
thanks!