### PR TITLE
FAQ: fix typo in production readiness question

### DIFF
--- a/site/guide/12-faq.md
+++ b/site/guide/12-faq.md
@@ -113,7 +113,7 @@ non-exhaustive list of caveats:
      DDoS attacks or certain DoS attacks which can be mitigated by an external
      service.
 
-  2. Use a TLS termination proxy (perhaps from 1.) for zero-downtown certificate
+  2. Use a TLS termination proxy (perhaps from 1.) for zero-downtime certificate
      rotation.
 
   3. Properly configure your databases and database pools, especially with


### PR DESCRIPTION
My assumption is that the intention is zero-downtime, not zero-downtown, certificate rotation.