### PR TITLE
Fix `clippy::unnecessary_lazy_evaluations` in FromForm derive

### DIFF
--- a/core/codegen/src/derive/from_form.rs
+++ b/core/codegen/src/derive/from_form.rs
@@ -284,7 +284,7 @@ pub fn derive_from_form(input: proc_macro::TokenStream) -> TokenStream {
                         .and_then(|#ident| {
                             let mut __es = #_form::Errors::new();
                             #(if let #_err(__e) = #validator { __es.extend(__e); })*
-                            __es.is_empty().then(|| #ident).ok_or(__es)
+                            __es.is_empty().then_some(#ident).ok_or(__es)
                         })
                         .map_err(|__e| match __name {
                             Some(__name) => __e.with_name(__name),


### PR DESCRIPTION
Fix clippy warning [unnecessary_lazy_evaluations](https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_lazy_evaluations) when using the `FromForm` derive macro.
I only tested it on the `v0.5-rc` branch.