### PR TITLE
Update the notify dependency to 5.0.0.

### DIFF
--- a/contrib/dyn_templates/Cargo.toml
+++ b/contrib/dyn_templates/Cargo.toml
@@ -18,7 +18,7 @@ handlebars = ["handlebars_"]
 
 [dependencies]
 glob = "0.3"
-notify = "4.0.6"
+notify = "5.0.0"
 normpath = "0.3"
 
 [dependencies.rocket]

--- a/contrib/dyn_templates/src/context.rs
+++ b/contrib/dyn_templates/src/context.rs
@@ -115,7 +115,7 @@ mod manager {
     use std::sync::{RwLock, Mutex};
     use std::sync::mpsc::{channel, Receiver};
 
-    use notify::{raw_watcher, RawEvent, RecommendedWatcher, RecursiveMode, Watcher};
+    use notify::{recommended_watcher, Error, Event, RecommendedWatcher, RecursiveMode, Watcher};
 
     use super::{Callback, Context};
 
@@ -125,14 +125,14 @@ mod manager {
         /// The current template context, inside an RwLock so it can be updated.
         context: RwLock<Context>,
         /// A filesystem watcher and the receive queue for its events.
-        watcher: Option<(RecommendedWatcher, Mutex<Receiver<RawEvent>>)>,
+        watcher: Option<(RecommendedWatcher, Mutex<Receiver<Result<Event, Error>>>)>,
     }
 
     impl ContextManager {
         pub fn new(ctxt: Context) -> ContextManager {
             let (tx, rx) = channel();
-            let watcher = raw_watcher(tx).and_then(|mut watcher| {
-                watcher.watch(ctxt.root.canonicalize()?, RecursiveMode::Recursive)?;
+            let watcher = recommended_watcher(tx).and_then(|mut watcher| {
+                watcher.watch(&ctxt.root.canonicalize()?, RecursiveMode::Recursive)?;
                 Ok(watcher)
             });
 


### PR DESCRIPTION
Addresses https://github.com/SergioBenitez/Rocket/issues/2337.

According to the notify upgrading advice, the `raw_watcher` has been removed in favor of the raw behavior being the default. And `RawEvent` has been updated to `Event`.

Where the example in 4.0.16 used a [raw watcher](https://github.com/notify-rs/notify/blob/v4.0.16/examples/monitor_raw.rs#L13), the example in 5.0.0 is updated to just use a [recommended watcher](https://github.com/notify-rs/notify/blob/notify-5.0.0/examples/monitor_raw.rs#L19).