### PR TITLE
Update return type of Responder in the docs.

### DIFF
--- a/core/lib/src/response/responder.rs
+++ b/core/lib/src/response/responder.rs
@@ -106,8 +106,7 @@ use crate::request::Request;
 ///
 /// # Return Value
 ///
-/// A `Responder` returns a `Future` whose output type is a `Result<Response,
-/// Status>`.
+/// A `Responder` returns a `Result<Response, Status>`.
 ///
 ///   * An `Ok(Response)` indicates success. The `Response` will be written out
 ///     to the client.


### PR DESCRIPTION
Addresses: https://github.com/SergioBenitez/Rocket/issues/2286

For testing I examined `Rocket/target/doc/rocket/response/trait.Responder.html` after `cargo doc`.