### PR TITLE
Typo fixes with crate-ci/typos.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2054,7 +2054,7 @@ In addition to new features, Rocket saw the following smaller improvements:
 
 ## Core
 
-  * Typo in `Outcome` formatting fixed (Succcess -> Success).
+  * Typo in `Outcome` formatting fixed (Success -> Success).
   * Added `ContentType::CSV`.
   * Dynamic segments parameters are properly resolved, even when mounted.
   * Request methods are only overridden via `_method` field on POST.
@@ -2168,7 +2168,7 @@ the Rocket APIs. They are summarized through the following API changes:
   * Added `FromData` conversion trait and default implementation.
   * `FromData` is used to automatically derive the `data` parameter.
   * `Responder`s are now final: they cannot forward to other requests.
-  * `Responser`s may only forward to catchers.
+  * `Responder`s may only forward to catchers.
 
 ## Breaking
 

--- a/contrib/db_pools/lib/src/error.rs
+++ b/contrib/db_pools/lib/src/error.rs
@@ -5,10 +5,10 @@ use std::fmt;
 /// guard.
 #[derive(Debug)]
 pub enum Error<A, B = A> {
-    /// An error that occured during database/pool initialization.
+    /// An error that occurred during database/pool initialization.
     Init(A),
 
-    /// An error that ocurred while retrieving a connection from the pool.
+    /// An error that occurred while retrieving a connection from the pool.
     Get(B),
 
     /// A [`Figment`](crate::figment::Figment) configuration error.

--- a/contrib/db_pools/lib/src/lib.rs
+++ b/contrib/db_pools/lib/src/lib.rs
@@ -191,7 +191,7 @@
 //!
 //! ## Driver Defaults
 //!
-//! Some drivers provide configuration defaults different from the underyling
+//! Some drivers provide configuration defaults different from the underlying
 //! database's defaults. A best-effort attempt is made to document those
 //! differences below:
 //!
@@ -216,7 +216,7 @@
 //!
 //! # Extending
 //!
-//! Any database driver can implement support for this libary by implementing
+//! Any database driver can implement support for this library by implementing
 //! the [`Pool`] trait.
 
 #![doc(html_root_url = "https://api.rocket.rs/master/rocket_db_pools")]

--- a/contrib/db_pools/lib/src/pool.rs
+++ b/contrib/db_pools/lib/src/pool.rs
@@ -98,7 +98,7 @@ use {std::time::Duration, crate::{Error, Config}};
 ///         // `InitError` to `Error<InitError, _>` with `Error::Init`.
 ///         let pool = MyPool::new(config).map_err(Error::Init)?;
 ///
-///         // Return the fully intialized pool.
+///         // Return the fully initialized pool.
 ///         Ok(pool)
 ///     }
 ///

--- a/core/codegen/src/attribute/route/mod.rs
+++ b/core/codegen/src/attribute/route/mod.rs
@@ -259,7 +259,7 @@ fn sentinels_expr(route: &Route) -> TokenStream {
         .map(|p| &p.ident)
         .collect();
 
-    // Note: for a given route, we need to emit a valid graph of eligble
+    // Note: for a given route, we need to emit a valid graph of eligible
     // sentinels. This means that we don't have broken links, where a child
     // points to a parent that doesn't exist. The concern is that the
     // `is_concrete()` filter will cause a break in the graph.
@@ -273,7 +273,7 @@ fn sentinels_expr(route: &Route) -> TokenStream {
     //      * returns `false` for the parent. by 1) it will return false for
     //        _all_ parents of the type, so no node in the graph can consider,
     //        directly or indirectly, `T` to be a child, and thus there are no
-    //        broken links; the thereom holds
+    //        broken links; the theorem holds
     //      * returns `true` for the parent, and so the type has a parent, and
     //      the theorem holds.
     //    3. these are all the cases. QED.

--- a/core/codegen/src/bang/mod.rs
+++ b/core/codegen/src/bang/mod.rs
@@ -53,7 +53,7 @@ pub fn uri_macro(input: proc_macro::TokenStream) -> TokenStream {
 
 pub fn uri_internal_macro(input: proc_macro::TokenStream) -> TokenStream {
     // TODO: Ideally we would generate a perfect `Origin::ROOT` so that we don't
-    // assist in propoagate further errors. Alas, we can't set the span to the
+    // assist in propagating further errors. Alas, we can't set the span to the
     // invocation of `uri!` without access to `span.parent()`, and
     // `Span::call_site()` here points to the `#[route]`, immediate caller,
     // generating a rather confusing error message when there's a type-mismatch.

--- a/core/codegen/src/lib.rs
+++ b/core/codegen/src/lib.rs
@@ -1230,7 +1230,7 @@ pub fn catchers(input: TokenStream) -> TokenStream {
 /// A URI to a route name `foo` is generated using `uri!(foo(v1, v2, v3))` or
 /// `uri!(foo(a = v1, b = v2, c = v3))`, where `v1`, `v2`, `v3` are the values
 /// to fill in for route parameters named `a`, `b`, and `c`. If the named
-/// parameter sytnax is used (`a = v1`, etc.), parameters can appear in any
+/// parameter syntax is used (`a = v1`, etc.), parameters can appear in any
 /// order.
 ///
 /// More concretely, for the route `person` defined below:

--- a/core/http/src/header/content_type.rs
+++ b/core/http/src/header/content_type.rs
@@ -147,7 +147,7 @@ macro_rules! parse_flexible {
     ($($short:expr => $name:ident,)*) => (
     docify!([
         Flexibly parses @code{name} into a @code{ContentType}. The parse is
-        @[_flexible_] because, in addition to stricly correct content types, it
+        @[_flexible_] because, in addition to strictly correct content types, it
         recognizes the following shorthands:
 
         @nl

--- a/core/http/src/header/media_type.rs
+++ b/core/http/src/header/media_type.rs
@@ -214,7 +214,7 @@ macro_rules! parse_flexible {
     ($($short:expr => $name:ident,)*) => (
     docify!([
         Flexibly parses @code{name} into a @code{MediaType}. The parse is
-        @[_flexible_] because, in addition to stricly correct media types, it
+        @[_flexible_] because, in addition to strictly correct media types, it
         recognizes the following shorthands:
 
         @nl

--- a/core/http/src/parse/indexed.rs
+++ b/core/http/src/parse/indexed.rs
@@ -36,7 +36,7 @@ impl AsPtr for [u8] {
 pub enum Indexed<'a, T: ?Sized + ToOwned> {
     /// The start and end index of a string.
     Indexed(usize, usize),
-    /// A conrete string.
+    /// A concrete string.
     Concrete(Cow<'a, T>)
 }
 

--- a/core/http/src/tls/mtls.rs
+++ b/core/http/src/tls/mtls.rs
@@ -264,7 +264,7 @@ impl<'a> Certificate<'a> {
         self.inner().version.0
     }
 
-    /// Returns the subject (a "DN" or "Distinguised Name") of the X.509
+    /// Returns the subject (a "DN" or "Distinguished Name") of the X.509
     /// certificate.
     ///
     /// # Example
@@ -285,7 +285,7 @@ impl<'a> Certificate<'a> {
         Name::ref_cast(&self.inner().subject)
     }
 
-    /// Returns the issuer (a "DN" or "Distinguised Name") of the X.509
+    /// Returns the issuer (a "DN" or "Distinguished Name") of the X.509
     /// certificate.
     ///
     /// # Example
@@ -446,7 +446,7 @@ impl<'a> Name<'a> {
     /// `self`.
     ///
     /// Note that email addresses need not be UTF-8 strings, or strings at all.
-    /// This method filters the email addresss in `self` to those that are. Use
+    /// This method filters the email address in `self` to those that are. Use
     /// the raw [`iter_email()`](#method.iter_email) to iterate over all value
     /// types.
     ///

--- a/core/http/src/uri/fmt/formatter.rs
+++ b/core/http/src/uri/fmt/formatter.rs
@@ -34,7 +34,7 @@ use crate::uri::fmt::{UriDisplay, Part, Path, Query, Kind};
 ///
 ///   * When **nested named values** are written, typically by passing a value
 ///     to [`write_named_value()`] whose implementation of `UriDisplay` also
-///     calls `write_named_vlaue()`, the nested names are joined by a `.`,
+///     calls `write_named_value()`, the nested names are joined by a `.`,
 ///     written out followed by a `=`, followed by the value.
 ///
 /// # Usage

--- a/core/http/src/uri/host.rs
+++ b/core/http/src/uri/host.rs
@@ -10,7 +10,7 @@ use crate::uri::{Absolute, Authority};
 /// In HTTP/2 and HTTP/3, this information is instead communicated via the
 /// `:authority` and `:port` pseudo-header request fields. It is a
 /// client-controlled value via which the client communicates to the server the
-/// domain name and port it is attemping to communicate with. The following
+/// domain name and port it is attempting to communicate with. The following
 /// diagram illustrates the syntactic structure of a `Host`:
 ///
 /// ```text
@@ -113,7 +113,7 @@ impl<'a> Host<'a> {
 
     /// Parses the string `string` into a `Host`. Parsing will never allocate.
     /// Returns an `Error` if `string` is not a valid authority URI, meaning
-    /// that this parser accepts a `user_info` part for compatability but
+    /// that this parser accepts a `user_info` part for compatibility but
     /// discards it.
     ///
     /// # Example
@@ -156,7 +156,7 @@ impl<'a> Host<'a> {
     /// This method should be used instead of [`Host::parse()`] when the source
     /// is already a `String`. Returns an `Error` if `string` is not a valid
     /// authority URI, meaning that this parser accepts a `user_info` part for
-    /// compatability but discards it.
+    /// compatibility but discards it.
     ///
     /// # Example
     ///

--- a/core/http/src/uri/reference.rs
+++ b/core/http/src/uri/reference.rs
@@ -409,7 +409,7 @@ impl<'a> Reference<'a> {
         self.path = Data::new(path.into());
     }
 
-    /// Returns the conrete path and query.
+    /// Returns the concrete path and query.
     pub(crate) fn with_query_fragment_of(mut self, other: Reference<'a>) -> Self {
         if let Some(query) = other.query {
             if self.query().is_none() {

--- a/core/lib/src/config/config.rs
+++ b/core/lib/src/config/config.rs
@@ -391,7 +391,7 @@ impl Config {
         launch_meta_!("log level: {}", bold(self.log_level));
         launch_meta_!("cli colors: {}", bold(&self.cli_colors));
 
-        // Check for now depreacted config values.
+        // Check for now deprecated config values.
         for (key, replacement) in Self::DEPRECATED_KEYS {
             if let Some(md) = figment.find_metadata(key) {
                 warn!("found value for deprecated config key `{}`", Paint::white(key));

--- a/core/lib/src/config/shutdown.rs
+++ b/core/lib/src/config/shutdown.rs
@@ -165,7 +165,7 @@ impl fmt::Display for Sig {
 /// # }
 /// ```
 ///
-/// Or, as with all configuration options, programatically:
+/// Or, as with all configuration options, programmatically:
 ///
 /// ```rust
 /// # use rocket::figment::{Figment, providers::{Format, Toml}};

--- a/core/lib/src/config/tls.rs
+++ b/core/lib/src/config/tls.rs
@@ -503,7 +503,7 @@ impl TlsConfig {
     /// let tls_config = TlsConfig::from_bytes(certs_buf, key_buf);
     /// assert!(!tls_config.prefer_server_cipher_order());
     ///
-    /// // Which can be overriden with the eponymous builder method.
+    /// // Which can be overridden with the eponymous builder method.
     /// let tls_config = TlsConfig::from_bytes(certs_buf, key_buf)
     ///     .with_preferred_server_cipher_order(true);
     ///

--- a/core/lib/src/error.rs
+++ b/core/lib/src/error.rs
@@ -12,7 +12,7 @@ use crate::{Rocket, Orbit};
 /// An error that occurs during launch.
 ///
 /// An `Error` is returned by [`launch()`](Rocket::launch()) when launching an
-/// application fails or, more rarely, when the runtime fails after lauching.
+/// application fails or, more rarely, when the runtime fails after launching.
 ///
 /// # Panics
 ///

--- a/core/lib/src/fairing/mod.rs
+++ b/core/lib/src/fairing/mod.rs
@@ -482,7 +482,7 @@ pub trait Fairing: Send + Sync + Any + 'static {
     ///
     /// This method is called just after launching the application if
     /// `Kind::Liftoff` is in the `kind` field of the `Info` structure for this
-    /// fairing. The `Rocket` parameter corresponds to the lauched application.
+    /// fairing. The `Rocket` parameter corresponds to the launched application.
     ///
     /// ## Default Implementation
     ///

--- a/core/lib/src/form/context.rs
+++ b/core/lib/src/form/context.rs
@@ -247,7 +247,7 @@ impl<'v> Context<'v> {
     /// whose associated field name is _exactly_ `name` to be an error for the
     /// field named `name`. This is _not_ what is typically desired as it
     /// ignores errors that occur in the parent which will result in missing
-    /// errors associated with its chilren. Use [`Context::field_errors()`] in
+    /// errors associated with its children. Use [`Context::field_errors()`] in
     /// almost all cases.
     ///
     /// Lookup is case-sensitive but key-separator (`.` or `[]`) insensitive.
@@ -265,7 +265,7 @@ impl<'v> Context<'v> {
     ///     let id = form.context.exact_field_errors("id");
     ///
     ///     // Get all errors exactly for `foo.bar`. If `foo` failed, we will
-    ///     // this will return no erorrs. Use `Context::field_errors()`.
+    ///     // this will return no errors. Use `Context::field_errors()`.
     ///     let foo_bar = form.context.exact_field_errors("foo.bar");
     /// }
     /// ```

--- a/core/lib/src/form/error.rs
+++ b/core/lib/src/form/error.rs
@@ -138,7 +138,7 @@ pub struct Error<'v> {
     pub value: Option<Cow<'v, str>>,
     /// The kind of error that occurred.
     pub kind: ErrorKind<'v>,
-    /// The entitiy that caused the error.
+    /// The entity that caused the error.
     pub entity: Entity,
 }
 

--- a/core/lib/src/form/field.rs
+++ b/core/lib/src/form/field.rs
@@ -140,7 +140,7 @@ impl<'v> ValueField<'v> {
             .with_entity(Entity::ValueField)
     }
 
-    /// Creates a complete mising value field [`Error`] from `self`.
+    /// Creates a complete missing value field [`Error`] from `self`.
     ///
     /// The error will have the following properties:
     ///   * `kind`: [`ErrorKind::Missing`]

--- a/core/lib/src/form/from_form.rs
+++ b/core/lib/src/form/from_form.rs
@@ -411,7 +411,7 @@ use crate::http::uncased::AsUncased;
 /// }
 /// ```
 ///
-/// The lifetime `'r` correponds to the lifetime of the request.
+/// The lifetime `'r` corresponds to the lifetime of the request.
 ///
 /// ## A More Involved Example
 ///

--- a/core/lib/src/form/validate.rs
+++ b/core/lib/src/form/validate.rs
@@ -807,7 +807,7 @@ pub fn ext<'v>(file: &TempFile<'_>, r#type: ContentType) -> Result<'v, ()> {
 /// With validator: succeeds when an arbitrary function or closure does.
 ///
 /// This is the most generic validator and, for readability, should only be used
-/// when a more case-specific option does not exist. It succeeds excactly when
+/// when a more case-specific option does not exist. It succeeds exactly when
 /// `f` returns `true` and fails otherwise.
 ///
 /// On failure, returns a validation error with the message `msg`.
@@ -858,7 +858,7 @@ pub fn with<'v, V, F, M>(value: V, f: F, msg: M) -> Result<'v, ()>
 /// _Try_ With validator: succeeds when an arbitrary function or closure does.
 ///
 /// Along with [`with`], this is the most generic validator. It succeeds
-/// excactly when `f` returns `Ok` and fails otherwise.
+/// exactly when `f` returns `Ok` and fails otherwise.
 ///
 /// On failure, returns a validation error with the message in the `Err`
 /// variant converted into a string.

--- a/core/lib/src/fs/temp_file.rs
+++ b/core/lib/src/fs/temp_file.rs
@@ -57,7 +57,7 @@ use either::Either;
 /// guard, the extension is identified by the Content-Type of the request, if
 /// any. If there is no Content-Type, the limit `file` is used.
 ///
-/// # Cappable
+/// # Capable
 ///
 /// A data stream can be partially read into a `TempFile` even if the incoming
 /// stream exceeds the data limit via the [`Capped<TempFile>`] data and form
@@ -128,7 +128,7 @@ impl<'v> TempFile<'v> {
     ///
     /// # Cross-Device Persistence
     ///
-    /// Attemping to persist a temporary file across logical devices (or mount
+    /// Attempting to persist a temporary file across logical devices (or mount
     /// points) will result in an error. This is a limitation of the underlying
     /// OS. Your options are thus:
     ///

--- a/core/lib/src/request/request.rs
+++ b/core/lib/src/request/request.rs
@@ -398,7 +398,7 @@ impl<'r> Request<'r> {
     /// # let mut req = c.get("/");
     /// # let request = req.inner_mut();
     ///
-    /// // starting without an "X-Real-IP" header or remote addresss
+    /// // starting without an "X-Real-IP" header or remote address
     /// assert!(request.client_ip().is_none());
     ///
     /// // add a remote address; this is done by Rocket automatically

--- a/core/lib/src/rocket.rs
+++ b/core/lib/src/rocket.rs
@@ -66,7 +66,7 @@ use crate::log::PaintExt;
 ///   }
 ///   ```
 ///
-/// This generates a `main` funcion with an `async` runtime that runs the
+/// This generates a `main` function with an `async` runtime that runs the
 /// returned `Rocket` instance.
 ///
 /// * **Manual Launching**
@@ -197,7 +197,7 @@ impl Rocket<Build> {
     /// A [`Figment`] generated from the current `provider` can _always_ be
     /// retrieved via [`Rocket::figment()`]. However, because the provider can
     /// be changed at any point prior to ignition, a [`Config`] can only be
-    /// retrieved in the ignite or orbit phases, or by manually extracing one
+    /// retrieved in the ignite or orbit phases, or by manually extracting one
     /// from a particular figment.
     ///
     /// # Example
@@ -442,7 +442,7 @@ impl Rocket<Build> {
     }
 
     /// Attaches a fairing to this instance of Rocket. No fairings are eagerly
-    /// excuted; fairings are executed at their appropriate time.
+    /// executed; fairings are executed at their appropriate time.
     ///
     /// If the attached fairing is _fungible_ and a fairing of the same name
     /// already exists, this fairing replaces it.

--- a/core/lib/src/sentinel.rs
+++ b/core/lib/src/sentinel.rs
@@ -82,7 +82,7 @@ use crate::{Rocket, Ignite};
 ///
 /// # Embedded Sentinels
 ///
-/// Embedded types -- type parameters of already eligble types -- are also
+/// Embedded types -- type parameters of already eligible types -- are also
 /// eligible to be sentinels. Consider the following route:
 ///
 /// ```rust
@@ -102,7 +102,7 @@ use crate::{Rocket, Ignite};
 ///   * `Option<&State<String>>`
 ///   * `Either<Foo, Inner<Bar>>`
 ///
-/// In addition, all embedded types are _also_ eligble. These are:
+/// In addition, all embedded types are _also_ eligible. These are:
 ///
 ///   * `&State<String>`
 ///   * `State<String>`

--- a/core/lib/src/server.rs
+++ b/core/lib/src/server.rs
@@ -343,7 +343,7 @@ impl Rocket<Orbit> {
 
         // If it fails and it's not a 500, try the 500 catcher.
         if status != Status::InternalServerError {
-            error_!("Catcher failed. Attemping 500 error catcher.");
+            error_!("Catcher failed. Attempting 500 error catcher.");
             status = Status::InternalServerError;
             if let Ok(r) = self.invoke_catcher(status, req).await {
                 return r;

--- a/core/lib/src/shield/policy.rs
+++ b/core/lib/src/shield/policy.rs
@@ -461,7 +461,7 @@ impl From<&Prefetch> for Header<'static> {
 /// control exactly _which_ (if any) origins may access or request access to
 /// browser features.
 ///
-/// Features are enabled via the [`Permission::allowed()`] contructor and
+/// Features are enabled via the [`Permission::allowed()`] constructor and
 /// chainable [`allow()`](Self::allow()) build method. Features can be blocked
 /// via the [`Permission::blocked()`] and chainable [`block()`](Self::block())
 /// builder method.
@@ -553,7 +553,7 @@ impl Permission {
     /// be a single [`Allow`], a slice (`[Allow]` or `&[Allow]`), or a vector
     /// (`Vec<Allow>`).
     ///
-    /// This policy supercedes any previous policy set for `feature`.
+    /// This policy supersedes any previous policy set for `feature`.
     ///
     /// If `allow` is empty, the use of the feature is blocked unless another
     /// call to `allow()` allows it. If `allow` contains [`Allow::Any`], the
@@ -597,7 +597,7 @@ impl Permission {
         self
     }
 
-    /// Blocks `feature`. This policy supercedes any previous policy set for
+    /// Blocks `feature`. This policy supersedes any previous policy set for
     /// `feature`.
     ///
     /// # Example

--- a/core/lib/tests/many-cookie-jars-at-once.rs
+++ b/core/lib/tests/many-cookie-jars-at-once.rs
@@ -28,7 +28,7 @@ mod many_cookie_jars_tests {
     }
 
     #[test]
-    fn test_mutli_add() {
+    fn test_multi_add() {
         let client = Client::debug(rocket()).unwrap();
         let response = client.post("/").dispatch();
         let cookies = response.cookies();
@@ -38,7 +38,7 @@ mod many_cookie_jars_tests {
     }
 
     #[test]
-    fn test_mutli_get() {
+    fn test_multi_get() {
         let client = Client::debug(rocket()).unwrap();
         let response = client.get("/")
             .cookie(Cookie::new("a", "a_val"))

--- a/examples/databases/src/tests.rs
+++ b/examples/databases/src/tests.rs
@@ -14,7 +14,7 @@ fn test(base: &str, stage: AdHoc) {
     // Number of posts we're going to create/read/delete.
     const N: usize = 20;
 
-    // NOTE: If we had more than one test running concurently that dispatches
+    // NOTE: If we had more than one test running concurrently that dispatches
     // DB-accessing requests, we'd need transactions or to serialize all tests.
     let client = Client::tracked(rocket::build().attach(stage)).unwrap();
 

--- a/site/guide/01-upgrading.md
+++ b/site/guide/01-upgrading.md
@@ -117,7 +117,7 @@ rustup override set stable
 Using the stable release channel ensures that _no_ breakages will occur when
 upgrading your Rust compiler or Rocket. That being said, Rocket continues to
 take advantage of features only present in the nightly channel. As a result, the
-development experience will be superior on nightly for the forseeable future.
+development experience will be superior on nightly for the foreseeable future.
 For example, compiler diagnostics on `nightly` are more detailed and accurate:
 
 <details>
@@ -363,7 +363,7 @@ most important of these changes here. All users _must_:
 
   * Replace `ROCKET_ENV` environment variable use with `ROCKET_PROFILE`.
   * Replace `ROCKET_LOG` environment variable with `ROCKET_LOG_LEVEL`.
-  * Use only IP addreses for the `address` configuration parameter.
+  * Use only IP addresses for the `address` configuration parameter.
   * Replace the `dev` or `development` profile with `debug`.
   * Note that the `stage`, `staging`, `prod`, and `production` profiles carry no
     special meaning in v0.5.

--- a/site/guide/10-pastebin-tutorial.md
+++ b/site/guide/10-pastebin-tutorial.md
@@ -307,7 +307,7 @@ using a type more specific than `&str` to represent IDs and then asking Rocket
 to validate the untrusted `id` input as that type. If validation fails, Rocket
 will take care to not call our routes with bad input.
 
-Typed validation for dynamic paramters like `id` is implemented via the
+Typed validation for dynamic parameters like `id` is implemented via the
 [`FromParam`] trait. Rocket uses `FromParam` to automatically validate and parse
 dynamic path parameters like `id`. We already have a type that represents valid
 paste IDs, `PasteId`, so we'll simply need to implement `FromParam` for

--- a/site/guide/12-faq.md
+++ b/site/guide/12-faq.md
@@ -276,7 +276,7 @@ Can I, and if so how, do I use WebSockets?
 
 Rocket doesn't support WebSockets quite yet. We're [working on it].
 
-That being said, Rocket _does_ suport [Server-Sent Events], which allows for
+That being said, Rocket _does_ support [Server-Sent Events], which allows for
 real-time _unidirectional_ communication from the server to the client. This is
 often sufficient for many of the applications that WebSockets are typically used
 for. For instance, the [chat example] uses SSE to implement a real-time,

--- a/site/guide/7-fairings.md
+++ b/site/guide/7-fairings.md
@@ -73,7 +73,7 @@ order in which fairings are attached may be significant.
 ### Callbacks
 
 There are five events for which Rocket issues fairing callbacks. Each of these
-events is breifly described below and in details in the [`Fairing`] trait docs:
+events is briefly described below and in details in the [`Fairing`] trait docs:
 
   * **Ignite (`on_ignite`)**
 

--- a/site/news/2018-12-08-version-0.4.md
+++ b/site/news/2018-12-08-version-0.4.md
@@ -296,7 +296,7 @@ enum Error {
 }
 ```
 
-A value of this type can then be returned from a hander or used as part of
+A value of this type can then be returned from a handler or used as part of
 wrapping responders:
 
 ```rust


### PR DESCRIPTION
I ran this typo finding tool on Rocket and manually reviewed the findings. There was one false positive (the "pard" in Leopard, from core/http/src/raw_str.rs).