### PR TITLE
Support of &[u8] for form fields

### DIFF
--- a/core/lib/src/form/from_form_field.rs
+++ b/core/lib/src/form/from_form_field.rs
@@ -324,6 +324,10 @@ impl<'v> FromFormField<'v> for bool {
 
 #[crate::async_trait]
 impl<'v> FromFormField<'v> for Capped<&'v [u8]> {
+    fn from_value(field: ValueField<'v>) -> Result<'v, Self> {
+        Ok(Capped::from(field.value.as_bytes()))
+    }
+
     async fn from_data(f: DataField<'v, '_>) -> Result<'v, Self> {
         use crate::data::{Capped, Outcome, FromData};
 

--- a/core/lib/src/form/from_form_field.rs
+++ b/core/lib/src/form/from_form_field.rs
@@ -323,6 +323,23 @@ impl<'v> FromFormField<'v> for bool {
 }
 
 #[crate::async_trait]
+impl<'v> FromFormField<'v> for Capped<&'v [u8]> {
+    async fn from_data(f: DataField<'v, '_>) -> Result<'v, Self> {
+        use crate::data::{Capped, Outcome, FromData};
+
+        match <Capped<&'v [u8]> as FromData>::from_data(f.request, f.data).await {
+            Outcome::Success(p) => Ok(p),
+            Outcome::Failure((_, e)) => Err(e)?,
+            Outcome::Forward(..) => {
+                Err(Error::from(ErrorKind::Unexpected).with_entity(Entity::DataField))?
+            }
+        }
+    }
+}
+
+impl_strict_from_form_field_from_capped!(&'v [u8]);
+
+#[crate::async_trait]
 impl<'v> FromFormField<'v> for Capped<Cow<'v, str>> {
     fn from_value(field: ValueField<'v>) -> Result<'v, Self> {
         let capped = <Capped<&'v str>>::from_value(field)?;

--- a/core/lib/tests/byte-slices-form-field-issue-2148.rs
+++ b/core/lib/tests/byte-slices-form-field-issue-2148.rs
@@ -1,0 +1,43 @@
+#[macro_use] extern crate rocket;
+
+use std::str::from_utf8;
+use rocket::form::Form;
+use rocket::http::ContentType;
+use rocket::local::blocking::Client;
+
+#[derive(FromForm)]
+struct Data<'r> {
+    foo: &'r [u8],
+    bar: &'r [u8],
+}
+
+#[rocket::post("/", data = "<form>")]
+fn form(form: Form<Data<'_>>) -> String {
+    from_utf8(form.foo).unwrap().to_string() + from_utf8(form.bar).unwrap()
+}
+
+#[test]
+fn test_multipart_byte_slices_from_files() {
+    let body = &[
+        "--X-BOUNDARY",
+        r#"Content-Disposition: form-data; name="foo"; filename="foo.txt""#,
+        "Content-Type: text/plain",
+        "",
+        "start>",
+        "--X-BOUNDARY",
+        r#"Content-Disposition: form-data; name="bar"; filename="bar.txt""#,
+        "Content-Type: text/plain",
+        "",
+        "<finish",
+        "--X-BOUNDARY--",
+        "",
+    ].join("\r\n");
+
+    let client = Client::debug_with(rocket::routes![form]).unwrap();
+    let response = client.post("/")
+        .header("multipart/form-data; boundary=X-BOUNDARY".parse::<ContentType>().unwrap())
+        .body(body)
+        .dispatch();
+
+    assert_eq!(response.into_string().unwrap(), "start><finish");
+}


### PR DESCRIPTION
Will allow to define forms with &[u8] fields, like
```rust
#[derive(FromForm)]
struct MyForm<'r> {
    foo: &'r [u8],
}
```

Should address the issue https://github.com/SergioBenitez/Rocket/issues/2148