### PR TITLE
Showcasing the ability to wrap guards in Option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
-# Version 0.5.0-rc.2 (May 9, 2022)
+# Version 0.5.0-rc.2 (May 09, 2022)
 
 ## Major Features and Improvements
 
   * Introduced [`rocket_db_pools`] for asynchronous database pooling.
   * Introduced support for [mutual TLS] and client [`Certificate`]s.
   * Added a [`local_cache_once!`] macro for request-local storage.
-  * Added a [v0.4 to v0.5 migration guide] and [FAQ] the Rocket's website.
+  * Added a [v0.4 to v0.5 migration guide] and [FAQ] to Rocket's website.
   * Introduced [shutdown fairings].
 
 ## Breaking Changes

--- a/core/lib/src/rocket.rs
+++ b/core/lib/src/rocket.rs
@@ -42,7 +42,7 @@ use crate::log::PaintExt;
 /// * **Ignite**: _verification and finalization of configuration_
 ///
 ///   An instance in the [`Ignite`] phase is in its final configuration,
-///   available via [`Rocket::config()`]. Barring user-supplied iterior
+///   available via [`Rocket::config()`]. Barring user-supplied interior
 ///   mutation, application state is guaranteed to remain unchanged beyond this
 ///   point. An instance in the ignite phase can be launched into orbit to serve
 ///   requests via [`Rocket::launch()`].

--- a/site/guide/4-requests.md
+++ b/site/guide/4-requests.md
@@ -486,6 +486,27 @@ authorization failure message is displayed. Finally, if a user isn't signed in,
 the `admin_panel_redirect` route is attempted. Since this route has no guards,
 it always succeeds. The user is redirected to a log in page.
 
+### Optional guards
+
+When you want verify whether a guard is validated or not from within your controller,
+you can wrap your guard in an `Option<T>`.
+If the guard was validated, the value will be `Some(T)`, otherwise it will be set to `None`:
+
+```rust
+# #[macro_use] extern crate rocket;
+# fn main() {}
+
+# type AdminUser = rocket::http::Method;
+
+#[get("/")]
+fn portal(maybe_authenticated: Option<AdminUser>) -> &'static str {
+    match maybe_authenticated {
+        Some(user) => "You're successfully logged in! Proceeding to the home page",
+        None => "You need to log in."
+    }
+}
+```
+
 ## Cookies
 
 A reference to a [`CookieJar`] is an important, built-in request guard: it

--- a/site/news/2022-05-09-version-0.5-rc.2.md
+++ b/site/news/2022-05-09-version-0.5-rc.2.md
@@ -1,4 +1,4 @@
-# Rocket 2nd v0.5 Release Candidate
+# Rocket's 2nd v0.5 Release Candidate
 
 <p class="metadata"><strong>
   Posted by <a href="https://sergio.bz">Sergio Benitez</a> on May 09, 2022


### PR DESCRIPTION
The ability to wrap guards in Option is useful for routes that may behave differently whether the guard is set or not, but where making two separate handlers isn't justified (for example, having this info passed to the template rendering, without any impact on the handler logic). I didn't see it documented, but I tested it as working as expected on my daemon, so I'm adding a bit of documentation on the topic.