### PR TITLE
Fix  panic on shutting down with sync_db_pool

### DIFF
--- a/contrib/sync_db_pools/lib/tests/shutdown.rs
+++ b/contrib/sync_db_pools/lib/tests/shutdown.rs
@@ -1,7 +1,7 @@
 #[cfg(all(feature = "diesel_sqlite_pool"))]
 #[cfg(test)]
 mod sqlite_shutdown_test {
-    use rocket::{async_run, Build, Rocket};
+    use rocket::{async_test, Build, Rocket};
     use rocket_sync_db_pools::database;
 
     #[database("test")]
@@ -19,17 +19,14 @@ mod sqlite_shutdown_test {
 
     #[test]
     fn test_shutdown() {
-        let _ = async_run(
+        let _rocket = async_test(
             async {
                 let rocket = rocket().await.ignite().await.expect("unable to ignite");
                 // request shutdown
                 rocket.shutdown().notify();
                 rocket.launch().await.expect("unable to launch")
-            },
-            1,
-            32,
-            true, // if `force_end` is set to true, then the runtime is stopped before the Pool is dropped
-            "rocket-worker-shutdown-test-thread",
+            }
         );
+        // _rocket is dropped here after the runtime is dropped
     }
 }

--- a/contrib/sync_db_pools/lib/tests/shutdown.rs
+++ b/contrib/sync_db_pools/lib/tests/shutdown.rs
@@ -1,0 +1,35 @@
+#[cfg(all(feature = "diesel_sqlite_pool"))]
+#[cfg(test)]
+mod sqlite_shutdown_test {
+    use rocket::{async_run, Build, Rocket};
+    use rocket_sync_db_pools::database;
+
+    #[database("test")]
+    struct Pool(diesel::SqliteConnection);
+
+    async fn rocket() -> Rocket<Build> {
+        use rocket::figment::{util::map, Figment};
+
+        let options = map!["url" => ":memory:"];
+        let config = Figment::from(rocket::Config::debug_default())
+            .merge(("databases", map!["test" => &options]));
+
+        rocket::custom(config).attach(Pool::fairing())
+    }
+
+    #[test]
+    fn test_shutdown() {
+        let _ = async_run(
+            async {
+                let rocket = rocket().await.ignite().await.expect("unable to ignite");
+                // request shutdown
+                rocket.shutdown().notify();
+                rocket.launch().await.expect("unable to launch")
+            },
+            1,
+            32,
+            true, // if `force_end` is set to true, then the runtime is stopped before the Pool is dropped
+            "rocket-worker-shutdown-test-thread",
+        );
+    }
+}


### PR DESCRIPTION
This PR fixes #2375 by using `spawn_blocking` only if the runtime is still available and dropping the `pool` on the current thread otherwise.

Also a test case is added which fails on master@6c3d35e7e5bceaf11c329623d48f81c276407030, but passes with the fix.