### PR TITLE
Add feature to support :param, {param} and <param>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
-# Version 0.5.0-rc.2 (May 9, 2022)
+# Version 0.5.0-rc.2 (May 09, 2022)
 
 ## Major Features and Improvements
 
   * Introduced [`rocket_db_pools`] for asynchronous database pooling.
   * Introduced support for [mutual TLS] and client [`Certificate`]s.
   * Added a [`local_cache_once!`] macro for request-local storage.
-  * Added a [v0.4 to v0.5 migration guide] and [FAQ] the Rocket's website.
+  * Added a [v0.4 to v0.5 migration guide] and [FAQ] to Rocket's website.
   * Introduced [shutdown fairings].
 
 ## Breaking Changes

--- a/core/lib/src/rocket.rs
+++ b/core/lib/src/rocket.rs
@@ -42,7 +42,7 @@ use crate::log::PaintExt;
 /// * **Ignite**: _verification and finalization of configuration_
 ///
 ///   An instance in the [`Ignite`] phase is in its final configuration,
-///   available via [`Rocket::config()`]. Barring user-supplied iterior
+///   available via [`Rocket::config()`]. Barring user-supplied interior
 ///   mutation, application state is guaranteed to remain unchanged beyond this
 ///   point. An instance in the ignite phase can be launched into orbit to serve
 ///   requests via [`Rocket::launch()`].

--- a/core/lib/src/route/segment.rs
+++ b/core/lib/src/route/segment.rs
@@ -12,10 +12,21 @@ impl Segment {
         let mut value = segment;
         let mut dynamic = false;
         let mut trailing = false;
+        let mut n = segment.len();
 
         if segment.starts_with('<') && segment.ends_with('>') {
             dynamic = true;
-            value = &segment[1..(segment.len() - 1)];
+            n -= 1;
+        }
+        else if segment.starts_with('{') && segment.ends_with('}') {
+            dynamic = true;
+            n -= 1;
+        } else if segment.starts_with(':') {
+            dynamic = true;
+        }
+
+        if dynamic {
+            value = &segment[1..n];
 
             if value.ends_with("..") {
                 trailing = true;

--- a/site/news/2022-05-09-version-0.5-rc.2.md
+++ b/site/news/2022-05-09-version-0.5-rc.2.md
@@ -1,4 +1,4 @@
-# Rocket 2nd v0.5 Release Candidate
+# Rocket's 2nd v0.5 Release Candidate
 
 <p class="metadata"><strong>
   Posted by <a href="https://sergio.bz">Sergio Benitez</a> on May 09, 2022


### PR DESCRIPTION
Hi Rocket

Reference to: https://github.com/SergioBenitez/Rocket/issues/2380

Would you audit this PR and merge to your v0.5-rc branch?  Thanks!
This PR added features to support three parameter syntaxes:
```
:param
{param}
<param>
```

example
```rust
#[get("/:name/{age}/<gender>")]
fn rest(name: &str, age: u8, gender: &str) -> String {
    format!("Hello {}, age: {}, gender: {}!", age, name, gender)
}
```

Tested with curl
```
curl http://localhost:8000/rest/mary/18/female
```