### PR TITLE
Fixes Issue #2391 - Remove sqlx features from db_pools

### DIFF
--- a/contrib/db_pools/lib/Cargo.toml
+++ b/contrib/db_pools/lib/Cargo.toml
@@ -61,7 +61,7 @@ optional = true
 [dependencies.sqlx]
 version = "0.6"
 default-features = false
-features = ["runtime-tokio-rustls"]
+features = ["runtime-async-std-native-tls"]
 optional = true
 
 [dev-dependencies.rocket]

--- a/contrib/db_pools/lib/Cargo.toml
+++ b/contrib/db_pools/lib/Cargo.toml
@@ -61,7 +61,6 @@ optional = true
 [dependencies.sqlx]
 version = "0.6"
 default-features = false
-features = ["runtime-async-std-native-tls"]
 optional = true
 
 [dev-dependencies.rocket]


### PR DESCRIPTION
By removing sqlx features from the crate itself, the choice is put upon the user, which lets them choose between `rustls` and `native-tls`. 
