### PR TITLE
Add Diesel support

### DIFF
--- a/contrib/db_pools/lib/Cargo.toml
+++ b/contrib/db_pools/lib/Cargo.toml
@@ -23,6 +23,11 @@ sqlx_postgres = ["sqlx", "sqlx/postgres"]
 sqlx_sqlite = ["sqlx", "sqlx/sqlite"]
 sqlx_mssql = ["sqlx", "sqlx/mssql"]
 sqlx_macros = ["sqlx/macros"]
+# diesel features
+_diesel = ["r2d2", "diesel/r2d2"]
+diesel_postgres = ["_diesel", "diesel/postgres"]
+diesel_mysql = ["_diesel", "diesel/mysql"]
+diesel_sqlite = ["_diesel", "diesel/sqlite"]
 # implicit features: mongodb
 
 [dependencies.rocket]
@@ -50,6 +55,14 @@ optional = true
 version = "0.10"
 default-features = false
 features = ["rt_tokio_1"]
+optional = true
+
+[dependencies.diesel]
+version = "2.0.2"
+optional = true
+
+[dependencies.r2d2]
+version = "0.8.10"
 optional = true
 
 [dependencies.mongodb]


### PR DESCRIPTION
This PR adds support for the `postgres`, `mysql` and `sqlite` backends of Diesel ORM using the `r2d2` connection pool. There's no documentation yet but it works just fine in a real project without panics or perf problems. 

Questions:
* Is there a cleaner way to group together common dependencies without the `_diesel` feature?
* `r2d2::Pool` has no "close" or "destroy" method. Is the empty function `async fn close(&self) {}` the right way to implement this?