### PR TITLE
Fix duplicate documentation heading in README.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
-# Version 0.5.0-rc.2 (May 9, 2022)
+# Version 0.5.0-rc.2 (May 09, 2022)
 
 ## Major Features and Improvements
 
   * Introduced [`rocket_db_pools`] for asynchronous database pooling.
   * Introduced support for [mutual TLS] and client [`Certificate`]s.
   * Added a [`local_cache_once!`] macro for request-local storage.
-  * Added a [v0.4 to v0.5 migration guide] and [FAQ] the Rocket's website.
+  * Added a [v0.4 to v0.5 migration guide] and [FAQ] to Rocket's website.
   * Introduced [shutdown fairings].
 
 ## Breaking Changes

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ suite with `TRYBUILD=overwrite` and inspect the `diff` of `.std*` files.
 
 [`trybuild`]: https://docs.rs/trybuild/1
 
-## Documentation
+### Building Documentation
 
 API documentation is built with `./scripts/mk-docs.sh`. The resulting assets are
 uploaded to [api.rocket.rs](https://api.rocket.rs/).

--- a/core/lib/src/rocket.rs
+++ b/core/lib/src/rocket.rs
@@ -42,7 +42,7 @@ use crate::log::PaintExt;
 /// * **Ignite**: _verification and finalization of configuration_
 ///
 ///   An instance in the [`Ignite`] phase is in its final configuration,
-///   available via [`Rocket::config()`]. Barring user-supplied iterior
+///   available via [`Rocket::config()`]. Barring user-supplied interior
 ///   mutation, application state is guaranteed to remain unchanged beyond this
 ///   point. An instance in the ignite phase can be launched into orbit to serve
 ///   requests via [`Rocket::launch()`].

--- a/site/news/2022-05-09-version-0.5-rc.2.md
+++ b/site/news/2022-05-09-version-0.5-rc.2.md
@@ -1,4 +1,4 @@
-# Rocket 2nd v0.5 Release Candidate
+# Rocket's 2nd v0.5 Release Candidate
 
 <p class="metadata"><strong>
   Posted by <a href="https://sergio.bz">Sergio Benitez</a> on May 09, 2022


### PR DESCRIPTION
Rename heading of content about building documentation to "Building Documentation" and change heading level to three, nesting the content under the heading "Building and Testing". Fixes having two "Documentation" headings at the same level.