### PR TITLE
websockets and upgrade mechanism

### DIFF
--- a/core/codegen/src/bang/mod.rs
+++ b/core/codegen/src/bang/mod.rs
@@ -4,6 +4,7 @@ mod test_guide;
 mod export;
 
 pub mod typed_stream;
+pub mod websocket;
 
 use devise::Result;
 use syn::{Path, punctuated::Punctuated, parse::Parser, Token};
@@ -75,5 +76,10 @@ pub fn export_internal(input: proc_macro::TokenStream) -> TokenStream {
 
 pub fn typed_stream(input: proc_macro::TokenStream) -> TokenStream {
     typed_stream::_macro(input)
+        .unwrap_or_else(|diag| diag.emit_as_item_tokens())
+}
+
+pub fn websocket(input: proc_macro::TokenStream) -> TokenStream {
+    websocket::_macro(input)
         .unwrap_or_else(|diag| diag.emit_as_item_tokens())
 }

--- a/core/codegen/src/bang/websocket.rs
+++ b/core/codegen/src/bang/websocket.rs
@@ -1,0 +1,56 @@
+use devise::{Level, Diagnostic, Spanned};
+use proc_macro2::TokenStream;
+use syn::{parse::{Parse, ParseStream, discouraged::Speculative}, Pat};
+
+pub fn _macro(input: proc_macro::TokenStream) -> devise::Result<TokenStream> {
+    let closure: syn::ExprClosure = syn::parse(input)?;
+
+    if closure.inputs.len() != 1 {
+        return Err(Diagnostic::spanned(
+            closure.inputs.span(),
+            Level::Error,
+            "rocket::response::websocket::CreateWebsocket! needs exactly one closure input"
+        ));
+    }
+
+    if closure.capture.is_none() {
+        return Err(
+            Diagnostic::spanned(
+                closure.span(),
+                Level::Error,
+                "rocket::response::websocket::CreateWebsocket! needs an closure that captures it's inputs"
+            )
+                .span_help(closure.or1_token.span(), "add the `move` keyword to the closure")
+        );
+    }
+
+    let inp = closure.inputs.first().unwrap();
+    match inp {
+        Pat::Ident(_) => {}
+        Pat::Type(_) => {}
+        _ => {
+            return Err(
+                Diagnostic::spanned(
+                    inp.span(),
+                    Level::Error,
+                    "rocket::response::websocket::CreateWebsocket! can only accept an identifier or a type ascription for closure input"
+                )
+            )
+        }
+    }
+
+    let body = closure.body;
+    let capture = closure.capture;
+    let tokens = quote!(
+        Websocket::create(|#inp| {
+            ::std::boxed::Box::new(
+                ::std::boxed::Box::pin(
+                    async #capture {
+                        #body
+                    }
+                )
+            )
+        })
+    );
+    Ok(tokens)
+}

--- a/core/codegen/src/bang/websocket.rs
+++ b/core/codegen/src/bang/websocket.rs
@@ -24,21 +24,7 @@ pub fn _macro(input: proc_macro::TokenStream) -> devise::Result<TokenStream> {
         );
     }
 
-    let inp = closure.inputs.first().unwrap();
-    match inp {
-        Pat::Ident(_) => {}
-        Pat::Type(_) => {}
-        _ => {
-            return Err(
-                Diagnostic::spanned(
-                    inp.span(),
-                    Level::Error,
-                    "rocket::response::websocket::CreateWebsocket! can only accept an identifier or a type ascription for closure input"
-                )
-            )
-        }
-    }
-
+    let inp = closure.inputs.first();
     let body = closure.body;
     let capture = closure.capture;
     let tokens = quote!(

--- a/core/codegen/src/bang/websocket.rs
+++ b/core/codegen/src/bang/websocket.rs
@@ -30,11 +30,9 @@ pub fn _macro(input: proc_macro::TokenStream) -> devise::Result<TokenStream> {
     let tokens = quote!(
         Websocket::create(#capture |#inp| {
             ::std::boxed::Box::new(
-                ::std::boxed::Box::pin(
-                    async #capture {
-                        #body
-                    }
-                )
+                async #capture {
+                    #body
+                }
             )
         })
     );

--- a/core/codegen/src/bang/websocket.rs
+++ b/core/codegen/src/bang/websocket.rs
@@ -42,7 +42,7 @@ pub fn _macro(input: proc_macro::TokenStream) -> devise::Result<TokenStream> {
     let body = closure.body;
     let capture = closure.capture;
     let tokens = quote!(
-        Websocket::create(|#inp| {
+        Websocket::create(#capture |#inp| {
             ::std::boxed::Box::new(
                 ::std::boxed::Box::pin(
                     async #capture {

--- a/core/codegen/src/lib.rs
+++ b/core/codegen/src/lib.rs
@@ -1490,18 +1490,7 @@ pub fn __typed_stream(input: TokenStream) -> TokenStream {
 #[proc_macro]
 #[doc(hidden)]
 pub fn __websocket(input: TokenStream) -> TokenStream {
-    let stmts = syn::Block::parse_within.parse(input).expect("Input to __websocket! should be statements");
-    quote!(
-        Websocket::create(|mut ch: WebsocketChannel| {
-            ::std::boxed::Box::new(
-                ::std::boxed::Box::pin(
-                    async move {
-                        #(#stmts)*
-                    }
-                )
-            )
-        })
-    ).into()
+    emit!(bang::websocket(input))
 }
 
 /// Private Rocket internal macro: `internal_guide_tests!`.

--- a/core/codegen/src/lib.rs
+++ b/core/codegen/src/lib.rs
@@ -56,6 +56,8 @@
 
 #[macro_use] extern crate quote;
 
+use syn::parse::Parser;
+
 use rocket_http as http;
 
 #[macro_use]
@@ -1482,6 +1484,24 @@ pub fn rocket_internal_uri(input: TokenStream) -> TokenStream {
 #[doc(hidden)]
 pub fn __typed_stream(input: TokenStream) -> TokenStream {
     emit!(bang::typed_stream(input))
+}
+
+/// Internal macro: `__websocket!`.
+#[proc_macro]
+#[doc(hidden)]
+pub fn __websocket(input: TokenStream) -> TokenStream {
+    let stmts = syn::Block::parse_within.parse(input).expect("Input to __websocket! should be statements");
+    quote!(
+        Websocket::create(|mut ch: WebsocketChannel| {
+            ::std::boxed::Box::new(
+                ::std::boxed::Box::pin(
+                    async move {
+                        #(#stmts)*
+                    }
+                )
+            )
+        })
+    ).into()
 }
 
 /// Private Rocket internal macro: `internal_guide_tests!`.

--- a/core/http/src/hyper.rs
+++ b/core/http/src/hyper.rs
@@ -5,7 +5,7 @@
 //! while necessary.
 
 pub use hyper::{Method, Error, Body, Uri, Version, Request, Response};
-pub use hyper::{body, server, service};
+pub use hyper::{body, server, service, upgrade};
 pub use http::{HeaderValue, request, uri};
 
 /// Reexported Hyper HTTP header types.

--- a/core/lib/Cargo.toml
+++ b/core/lib/Cargo.toml
@@ -60,6 +60,9 @@ async-stream = "0.3.2"
 multer = { version = "2", features = ["tokio-io"] }
 tokio-stream = { version = "0.1.6", features = ["signal", "time"] }
 state = "0.5.1"
+sha1 = "0.10.5"
+base64 = "0.13.0"
+websocket-codec = "0.5.2"
 
 [dependencies.rocket_codegen]
 version = "0.5.0-rc.2"
@@ -77,7 +80,7 @@ features = ["fs", "io-std", "io-util", "rt-multi-thread", "sync", "signal", "mac
 [dependencies.tokio-util]
 version = "0.7"
 default-features = false
-features = ["io"]
+features = ["io", "codec"]
 
 [dependencies.bytes]
 version = "1.0"

--- a/core/lib/src/lib.rs
+++ b/core/lib/src/lib.rs
@@ -123,6 +123,7 @@ pub use time;
 #[doc(hidden)] pub mod sentinel;
 pub mod local;
 pub mod request;
+pub mod upgrade;
 pub mod response;
 pub mod config;
 pub mod form;
@@ -175,6 +176,7 @@ mod rocket;
 mod router;
 mod phase;
 
+#[doc(inline)] pub use crate::upgrade::Upgrade;
 #[doc(inline)] pub use crate::response::Response;
 #[doc(inline)] pub use crate::data::Data;
 #[doc(inline)] pub use crate::config::Config;

--- a/core/lib/src/response/mod.rs
+++ b/core/lib/src/response/mod.rs
@@ -25,6 +25,7 @@ pub(crate) mod flash;
 pub mod content;
 pub mod status;
 pub mod stream;
+pub mod websocket;
 
 #[doc(hidden)]
 pub use rocket_codegen::Responder;

--- a/core/lib/src/response/response.rs
+++ b/core/lib/src/response/response.rs
@@ -5,6 +5,7 @@ use tokio::io::{AsyncRead, AsyncSeek};
 
 use crate::http::{Header, HeaderMap, Status, ContentType, Cookie};
 use crate::response::Body;
+use crate::upgrade::Upgrade;
 
 /// Builder for the [`Response`] type.
 ///
@@ -261,6 +262,13 @@ impl<'r> Builder<'r> {
         self
     }
 
+    /// Sets the upgrade of the `Response`.
+    #[inline(always)]
+    pub fn upgrade(&mut self, upgrade: Option<Box<dyn Upgrade<'static> + Send>>) -> &mut Builder<'r> {
+        self.response.set_upgrade(upgrade);
+        self
+    }
+
     /// Sets the max chunk size of a body, if any, to `size`.
     ///
     /// See [`Response::set_max_chunk_size()`] for notes.
@@ -413,6 +421,7 @@ pub struct Response<'r> {
     status: Option<Status>,
     headers: HeaderMap<'r>,
     body: Body<'r>,
+    upgrade: Option<Box<dyn Upgrade<'static> + Send>>,
 }
 
 impl<'r> Response<'r> {
@@ -805,6 +814,26 @@ impl<'r> Response<'r> {
         where B: AsyncRead + Send + 'r
     {
         self.body = Body::with_unsized(body);
+    }
+
+    /// Returns a instance of the `Upgrade`-trait when the `Response` is upgradeable
+    #[inline(always)]
+    pub fn upgrade(&self) -> &Option<Box<dyn Upgrade<'static> + Send>> {
+        &self.upgrade
+    }
+
+    /// Returns a mutable instance of the `Upgrade`-trait when the `Response` is upgradeable
+    #[inline(always)]
+    pub fn upgrade_mut(&mut self) -> &mut Option<Box<dyn Upgrade<'static> + Send>> {
+        &mut self.upgrade
+    }
+
+    /// Sets the upgrade contained in this `Response`
+    /// 
+    /// While the response also need to have status 101 SwitchingProtocols in order to be a valid upgrade,
+    /// this method doesn't set this, and it's expected that the caller sets this.
+    pub fn set_upgrade(&mut self, upgrade: Option<Box<dyn Upgrade<'static> + Send>>) {
+        self.upgrade = upgrade;
     }
 
     /// Sets the body's maximum chunk size to `size` bytes.

--- a/core/lib/src/response/response.rs
+++ b/core/lib/src/response/response.rs
@@ -818,14 +818,14 @@ impl<'r> Response<'r> {
 
     /// Returns a instance of the `Upgrade`-trait when the `Response` is upgradeable
     #[inline(always)]
-    pub fn upgrade(&self) -> &Option<Box<dyn Upgrade<'static> + Send>> {
-        &self.upgrade
+    pub fn upgrade(&self) -> Option<&Box<dyn Upgrade<'static> + Send>> {
+        self.upgrade.as_ref()
     }
 
-    /// Returns a mutable instance of the `Upgrade`-trait when the `Response` is upgradeable
+    /// Takes the upgrade out of the response, leaving a [`None`] in it's place
     #[inline(always)]
-    pub fn upgrade_mut(&mut self) -> &mut Option<Box<dyn Upgrade<'static> + Send>> {
-        &mut self.upgrade
+    pub fn take_upgrade(&mut self) -> Option<Box<dyn Upgrade<'static> + Send>> {
+        self.upgrade.take()
     }
 
     /// Sets the upgrade contained in this `Response`

--- a/core/lib/src/response/websocket/mod.rs
+++ b/core/lib/src/response/websocket/mod.rs
@@ -1,0 +1,337 @@
+//! Contains the websocket implemetation of rocket, based on websocket_codec and rockets own upgrade mecanism.
+
+use bytes::BytesMut;
+use futures::Future;
+use rocket_http::Status;
+use sha1::{Sha1, Digest};
+use tokio::io::{AsyncWriteExt, ReadHalf, WriteHalf, AsyncReadExt};
+use tokio::sync::mpsc;
+use tokio_util::codec::{Decoder, Encoder};
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+use std::borrow::Cow;
+
+use crate::http::hyper::upgrade::Upgraded;
+use crate::request::Request;
+use crate::response::{self, Response, Responder};
+use crate::upgrade::Upgrade;
+
+pub use websocket_codec::Message as WebsocketMessage;
+
+/*
+    TODO's:
+    - IntoMessage trait
+    - websocket extension handling
+    - subprotocol handling
+*/
+
+/// Represents a close status for a websocket connection.
+#[derive(Debug, Clone, Eq)]
+pub struct WebsocketStatus<'a> {
+    code: u16,
+    reason: Cow<'a, str>,
+}
+
+impl<'a> PartialEq for WebsocketStatus<'a> {
+    fn eq(&self, other: &Self) -> bool {
+        self.code == other.code
+    }
+}
+
+macro_rules! websocket_status_impl {
+    ($($name:ident => $code:expr),*) => {
+        $(
+            /// Websocket pre-defined Status code
+            #[allow(non_upper_case_globals)]
+            pub const $name: WebsocketStatus<'static> = WebsocketStatus {
+                code: $code,
+                reason: Cow::Borrowed(stringify!($name))
+            };
+        )*
+    }
+}
+
+impl<'a> WebsocketStatus<'a> {
+    websocket_status_impl! {
+        Ok => 1000,
+        GoingAway => 1001,
+        ProtocolError => 1002,
+        UnknownMessageType => 1003,
+        Reserved => 1004,
+        NoStatusCode => 1005,
+        AbnormalClose => 1006,
+        InvalidDataType => 1007,
+        PolicyViolation => 1008,
+        MessageTooLarge => 1009,
+        ExtensionRequired => 1010,
+        InternalServerError => 1011,
+        TlsFailure => 1015
+    }
+
+    /// Creates a new status with a code and a reason.
+    pub fn new(code: u16, reason: Cow<'a, str>) -> Self {
+        match code {
+            0000..=0999 => panic!("Status codes in the range 0-999 are not used"),
+            1000..=2999 => panic!(
+                "Status codes in the range 1000-2999 are reserved for the WebSocket protocol"
+            ),
+            3000..=3999 => (),
+            4000..=4999 => (),
+            _ => panic!("Cannot create a status code outside the allowed range"),
+        }
+        Self { code, reason }
+    }
+
+    /// Returns the code contained in this status.
+    pub fn code(&self) -> u16 {
+        self.code
+    }
+
+    /// Returns the reason contained in this status.
+    pub fn reason(&'a self) -> &'a str {
+        self.reason.as_ref()
+    }
+}
+
+impl<'a> Into<WebsocketMessage> for WebsocketStatus<'a> {
+    fn into(self) -> WebsocketMessage {
+        WebsocketMessage::close(Some((self.code, self.reason.into())))
+    }
+}
+
+/// Channel to send/recieve messages via a websocket connection.
+pub struct WebsocketChannel {
+    inner: mpsc::Receiver<WebsocketMessage>,
+    sender: mpsc::Sender<WebsocketMessage>,
+}
+
+const BUFFER_ALLOCATION_MIN: usize = 1024 * 4;
+
+impl WebsocketChannel {
+    fn new(upgrade: Upgraded) -> (Self, impl Future<Output = ()>, impl Future<Output = ()>) {
+        let (sender_tx, sender_rx) = mpsc::channel(50);
+        let (message_tx, message_rx) = mpsc::channel(1);
+        let (a, b) = Self::message_handler(upgrade, message_tx, sender_rx, sender_tx.clone());
+        (Self { inner: message_rx, sender: sender_tx }, a, b)
+    }
+
+    /// Sends a message over the websocket connection.
+    pub async fn send(&self, msg: impl Into<WebsocketMessage>) {
+        let _e = self.sender.send(msg.into()).await;
+    }
+
+    /// Recieves a message over the websocket connection.
+    /// 
+    /// This only contains text, binary and close messages; ping & pong is handled by the channel itself.
+    pub async fn next(&mut self) -> Option<WebsocketMessage> {
+        self.inner.recv().await
+    }
+
+    /// Sends a close message & closes the connection.
+    pub async fn close(&self, status: WebsocketStatus<'_>) {
+        let _e = self.sender.send(status.into()).await;
+    }
+
+    async fn send_close(sender_tx: &mpsc::Sender<WebsocketMessage>, status: WebsocketStatus<'_>) {
+        let _e = sender_tx.send(status.into()).await;
+    }
+
+    async fn reader(
+        recv_close: Arc<AtomicBool>,
+        mut read: ReadHalf<Upgraded>,
+        ping_tx: mpsc::Sender<WebsocketMessage>,
+        message_tx: mpsc::Sender<WebsocketMessage>,
+        sender_tx: mpsc::Sender<WebsocketMessage>,
+    ) {
+        let mut codec = websocket_codec::MessageCodec::server();
+        let mut read_buf = BytesMut::with_capacity(BUFFER_ALLOCATION_MIN);
+
+        loop {
+            let msg = match codec.decode(&mut read_buf) {
+                Ok(Some(msg)) => msg,
+                Ok(None) => {
+                    read_buf.reserve(BUFFER_ALLOCATION_MIN);
+                    match read.read_buf(&mut read_buf).await {
+                        Ok(0) => break,
+                        Ok(_n) => (),
+                        Err(e) => {
+                            error_!("IO error occured during WebSocket messages: {:?}", e);
+                            break;
+                        },
+                    }
+                    continue;
+                },
+                Err(e) => {
+                    error_!("WebSocket client broke protocol: {:?}", e);
+                    Self::send_close(&sender_tx, WebsocketStatus::ProtocolError).await;
+                    break;
+                }
+            };
+
+            // Handle ping-pong messages
+            if msg.opcode() == websocket_codec::Opcode::Ping {
+                let _e = ping_tx.send(msg).await;
+                continue;
+            } else if msg.opcode() == websocket_codec::Opcode::Pong {
+                continue;
+            }
+
+            let _e = message_tx.send(msg).await;
+        }
+
+        // Set the close flag one last time, just to be sure...
+        recv_close.store(true, atomic::Ordering::Release);
+    }
+
+    async fn writer(
+        recv_close: Arc<AtomicBool>,
+        mut write: WriteHalf<Upgraded>,
+        mut ping_rx: mpsc::Receiver<WebsocketMessage>,
+        mut sender_rx: mpsc::Receiver<WebsocketMessage>,
+    ) {
+        let mut codec = websocket_codec::MessageCodec::server();
+        let mut write_buf = BytesMut::with_capacity(BUFFER_ALLOCATION_MIN);
+        let mut close_send = false;
+        while let Some(message) = Self::await_or_ping(&mut sender_rx, &mut ping_rx).await {
+            if message.opcode() == websocket_codec::Opcode::Close {
+                close_send = true;
+            }
+
+            if let Err(err) = codec.encode(message, &mut write_buf) {
+                error_!("Codec error while trying to encode websocket message: {err:?}");
+                continue;
+            }
+
+            if let Err(err) = write.write_all_buf(&mut write_buf).await {
+                error_!("Io error while trying to send websocket message: {err:?}");
+                continue;
+            }
+
+            if close_send || recv_close.load(atomic::Ordering::Acquire) {
+                break;
+            }
+        }
+
+        if !close_send {
+            warn_!("WebSocket Writer task did not send close");
+        }
+        let _e = write.shutdown().await;
+    }
+
+    fn message_handler(
+        upgrade: Upgraded,
+        message_tx: mpsc::Sender<WebsocketMessage>,
+        sender_rx: mpsc::Receiver<WebsocketMessage>,
+        sender_tx: mpsc::Sender<WebsocketMessage>,
+    ) -> (impl Future<Output = ()>, impl Future<Output = ()>) {
+        let (read, write) = tokio::io::split(upgrade);
+        let recv_close = Arc::new(AtomicBool::new(false));
+        let (ping_tx, ping_rx) = mpsc::channel(1);
+        let reader = Self::reader(recv_close.clone(), read, ping_tx, message_tx, sender_tx);
+        let writer = Self::writer(recv_close, write, ping_rx, sender_rx);
+        (reader, writer)
+    }
+
+    async fn await_or_ping(
+        sender_rx: &mut mpsc::Receiver<WebsocketMessage>,
+        ping_rx: &mut mpsc::Receiver<WebsocketMessage>,
+    ) -> Option<WebsocketMessage> {
+        loop {
+            tokio::select! {
+                o = sender_rx.recv() => break o,
+                Some(p) = ping_rx.recv() => break WebsocketMessage::pong(p.into_data()).into(),
+            }
+        }
+    }
+}
+
+/// A `Responder` thats used to upgrade a http connection to an websocket connection.
+#[derive(Clone)]
+pub struct Websocket<F> {
+    task: F,
+}
+
+#[crate::async_trait]
+impl<F> Upgrade<'static> for Websocket<F>
+where
+    F: Fn(WebsocketChannel) -> Box<dyn Future<Output = ()> + Send + Unpin> + Sync + Send
+{
+    async fn start(&self, upgraded: crate::http::hyper::upgrade::Upgraded) {
+        println!("started this thing!");
+
+        // create an channel
+        let (ch, a, b) = WebsocketChannel::new(upgraded);
+
+        // run the event loop...
+        let event_loop = (self.task)(ch);
+
+        tokio::join!(a, b, event_loop);
+        println!("all things done, move on!");
+    }
+}
+
+impl<F> Websocket<F>
+where
+    F: Fn(WebsocketChannel) -> Box<dyn Future<Output = ()> + Send + Unpin> + Sync
+{
+    /// Creates a new websocket with the given handler function.
+    pub fn create(ws_task: F) -> Self {
+        Websocket { task: ws_task }
+    }
+}
+
+impl<'r, F> Responder<'r, 'r> for Websocket<F>
+where
+    F: Fn(WebsocketChannel) -> Box<dyn Future<Output = ()> + Send + Unpin> + Sync + Send + 'r + 'static
+{
+    fn respond_to(self, req: &'r Request<'_>) -> response::Result<'r> {
+        let ws_version = req.headers().get_one("Sec-Websocket-Version");
+        match ws_version {
+            Some(ws_version) => {
+                if ws_version != "13" {
+                    return Response::build().status(Status::BadRequest).ok();
+                }
+            }
+            None => {
+                return Response::build().status(Status::BadRequest).ok();
+            }
+        }
+
+        let ws_key = req.headers().get_one("Sec-WebSocket-Key");
+        let ws_accept;
+        match ws_key {
+            Some(ws_key) => {
+                // TODO: tidy this up
+                let mut s = Sha1::new();
+                s.update(ws_key.as_bytes());
+                s.update(b"258EAFA5-E914-47DA-95CA-C5AB0DC85B11");
+                let res = s.finalize().to_vec();
+                ws_accept = base64::encode(res);
+            }
+            None => {
+                return Response::build().status(Status::BadRequest).ok();
+            }
+        }
+
+        Response::build()
+            .status(Status::SwitchingProtocols)
+            .raw_header("Connection", "upgrade")
+            .raw_header("Upgrade", "websocket")
+            .raw_header("Sec-Websocket-Version", "13")
+            .raw_header("Sec-Websocket-Accept", ws_accept)
+            .upgrade(Some(Box::new(self)))
+            .ok()
+    }
+}
+
+pub use crate::__websocket as CreateWebsocket;
+
+crate::export! {
+    macro_rules! Websocket {
+        () => (
+            Websocket<
+                impl Fn(WebsocketChannel) -> Box<dyn Future<Output = ()> + Send + Unpin>
+            >
+        );
+    }
+}

--- a/core/lib/src/response/websocket/mod.rs
+++ b/core/lib/src/response/websocket/mod.rs
@@ -257,8 +257,6 @@ where
     F: Fn(WebsocketChannel) -> Box<dyn Future<Output = ()> + Send + Unpin> + Sync + Send
 {
     async fn start(&self, upgraded: crate::http::hyper::upgrade::Upgraded) {
-        println!("started this thing!");
-
         // create an channel
         let (ch, a, b) = WebsocketChannel::new(upgraded);
 
@@ -266,7 +264,6 @@ where
         let event_loop = (self.task)(ch);
 
         tokio::join!(a, b, event_loop);
-        println!("all things done, move on!");
     }
 }
 

--- a/core/lib/src/server.rs
+++ b/core/lib/src/server.rs
@@ -85,7 +85,7 @@ async fn hyper_service_fn(
                 let mut response = rocket.dispatch(token, &req, data).await;
 
                 if response.status() == Status::SwitchingProtocols {
-                    let may_upgrade = response.upgrade_mut().take();
+                    let may_upgrade = response.take_upgrade();
                     match may_upgrade {
                         Some(upgrade) => {
 

--- a/core/lib/src/server.rs
+++ b/core/lib/src/server.rs
@@ -64,7 +64,7 @@ async fn handle<Fut, T, F>(name: Option<&str>, run: F) -> Option<T>
 async fn hyper_service_fn(
     rocket: Arc<Rocket<Orbit>>,
     conn: ConnectionMeta,
-    hyp_req: hyper::Request<hyper::Body>,
+    mut hyp_req: hyper::Request<hyper::Body>,
 ) -> Result<hyper::Response<hyper::Body>, io::Error> {
     // This future must return a hyper::Response, but the response body might
     // borrow from the request. Instead, write the body in another future that
@@ -72,6 +72,9 @@ async fn hyper_service_fn(
     let (tx, rx) = oneshot::channel();
 
     tokio::spawn(async move {
+        // Upgrade before do any other; we handle errors below
+        let hyp_upgraded = hyper::upgrade::on(&mut hyp_req);
+
         // Convert a Hyper request into a Rocket request.
         let (h_parts, mut h_body) = hyp_req.into_parts();
         match Request::from_hyp(&rocket, &h_parts, Some(conn)) {
@@ -79,8 +82,40 @@ async fn hyper_service_fn(
                 // Convert into Rocket `Data`, dispatch request, write response.
                 let mut data = Data::from(&mut h_body);
                 let token = rocket.preprocess_request(&mut req, &mut data).await;
-                let response = rocket.dispatch(token, &mut req, data).await;
-                rocket.send_response(response, tx).await;
+                let mut response = rocket.dispatch(token, &req, data).await;
+
+                if response.status() == Status::SwitchingProtocols {
+                    let may_upgrade = response.upgrade_mut().take();
+                    match may_upgrade {
+                        Some(upgrade) => {
+
+                            // send the finishing response; needed so that hyper can upgrade the request
+                            rocket.send_response(response, tx).await;
+
+                            match hyp_upgraded.await {
+                                Ok(hyp_upgraded) => {
+                                    // let the upgrade take the upgraded hyper request
+                                    let fu = upgrade.start(hyp_upgraded);
+                                    fu.await;
+                                }
+                                Err(e) => {
+                                    error_!("Failed to upgrade request: {e}");
+                                    // NOTE: we *should* send a response here but since we send one earlier AND upgraded the request,
+                                    //       this cannot be done easily at this point...
+                                    // let response = rocket.handle_error(Status::InternalServerError, &req).await;
+                                    // rocket.send_response(response, tx).await;
+                                }
+                            }
+                        }
+                        None => {
+                            error_!("Status is 101 switching protocols, but response dosn't hold a upgrade");
+                            let response = rocket.handle_error(Status::InternalServerError, &req).await;
+                            rocket.send_response(response, tx).await;
+                        }
+                    }
+                } else {
+                    rocket.send_response(response, tx).await;
+                }
             },
             Err(e) => {
                 warn!("Bad incoming HTTP request.");

--- a/core/lib/src/upgrade/mod.rs
+++ b/core/lib/src/upgrade/mod.rs
@@ -1,0 +1,14 @@
+//! Upgrade wrapper to deal with hyper::upgarde::Upgraded
+
+use crate::http::hyper;
+
+/// Trait to determine if any given response in rocket is upgradeable.
+/// 
+/// When a response has the http code 101 SwitchingProtocols, and the response implements the Upgrade trait,
+/// then rocket aquires the hyper::upgarde::Upgraded struct and calls the start() method of the trait with the hyper upgrade
+/// and awaits the result.
+#[crate::async_trait]
+pub trait Upgrade<'a> {
+    /// Called with the hyper::upgarde::Upgraded struct when a rocket response should be upgraded
+    async fn start(&self, upgraded: hyper::upgrade::Upgraded);
+}


### PR DESCRIPTION
This PR implements websockets in rocket via a new API that exposes the hyper upgrade mechanism to applications using rocket. Potentially closes #90.

This is an WIP PR so people can start testing it. If it's needed I can split this PR into one for the upgrade mechanism and one for the websocket support.

- [x] Implementing an API to upgrade any connection from http to something custom via the `rocket::upgrade::Upgrade` trait.
- [x] Implementing an websocket integration via the new upgrade API.
- [x] Support for sending / recieving websocket messages

Roadmap / things left to do:
- [ ] Maybe a better way to send messages via a dedicated `IntoMessage` trait
- [ ] Handling of websocket extensions
 - [ ] Implementing the common extension `permessage-deflate`
- [ ] Handling of websocket sub-protocols
- [ ] Examples and tests

# Upgrade API

The upgrade api works by defining an custom upgrade handler and giving it to an response:
```rust
struct TestSocket {}

#[crate::async_trait]
impl Upgrade<'static> for TestSocket {
  async fn start(&self, upgraded: crate::http::hyper::upgrade::Upgraded) {
    // can fully use the hyper::upgrade::Upgraded struct
  }
}

impl<'r, F> Responder<'r, 'r> for TestSocket {
  fn respond_to(self, req: &'r Request<'_>) -> response::Result<'r> {
    Response::build()
      .status(Status::SwitchingProtocols)
      .raw_header("Connection", "upgrade")
      .raw_header("Upgrade", "testsocket")
      .upgrade(Some(Box::new(self)))
      .ok()
  }
}
``` 

# Websocket API

The websocket API is modeled loosely after this comment https://github.com/SergioBenitez/Rocket/issues/90#issuecomment-831610067 

```rust
use rocket::response::websocket::{WebsocketMessage, WebsocketChannel, CreateWebsocket, Websocket};

#[get("/ws")]
fn websock() -> Websocket![] {
  CreateWebsocket! {
    while let Some(msg) = ch.next().await {
      println!("handler {msg:?}");
      ch.send(msg);
    }
  }
}
```