### PR TITLE
Add support for the anyhow Error as a Responder

### DIFF
--- a/core/lib/Cargo.toml
+++ b/core/lib/Cargo.toml
@@ -30,6 +30,9 @@ msgpack = ["rmp-serde", "tokio/io-util"]
 uuid = ["uuid_", "rocket_http/uuid"]
 
 [dependencies]
+# error dependencies
+anyhow = { version = "1.0", optional = true }
+
 # Serialization dependencies.
 serde_json = { version = "1.0.26", optional = true }
 rmp-serde = { version = "1", optional = true }

--- a/core/lib/src/anyhow.rs
+++ b/core/lib/src/anyhow.rs
@@ -1,0 +1,17 @@
+//! Support for using [`Error`](crate::anyhow::Error) from [`mod@anyhow`]
+//! as a [`Responder`].
+
+#[doc(inline)]
+pub use anyhow::*;
+
+use crate::http::Status;
+use crate::request::Request;
+use crate::response::{self, Responder};
+
+/// Prints a warning with the error and forwards to the `500` error catcher.
+impl<'r> Responder<'r, 'static> for anyhow::Error {
+    fn respond_to(self, _: &'r Request<'_>) -> response::Result<'static> {
+        warn_!("Error: {:#}", yansi::Paint::default(self));
+        Err(Status::InternalServerError)
+    }
+}

--- a/core/lib/src/lib.rs
+++ b/core/lib/src/lib.rs
@@ -68,6 +68,7 @@
 //! | `json`    | Support for [JSON (de)serialization].                   |
 //! | `msgpack` | Support for [MessagePack (de)serialization].            |
 //! | `uuid`    | Support for [UUID value parsing and (de)serialization]. |
+//! | `anyhow`  | Support for the [anyhow] Error type as a Responder.     |
 //!
 //! Disabled features can be selectively enabled in `Cargo.toml`:
 //!
@@ -89,6 +90,7 @@
 //! [private cookies]: https://rocket.rs/v0.5-rc/guide/requests/#private-cookies
 //! [TLS]: https://rocket.rs/v0.5-rc/guide/configuration/#tls
 //! [mutual TLS]: crate::mtls
+//! [anyhow]: crate::anyhow
 //!
 //! ## Configuration
 //!
@@ -163,6 +165,10 @@ pub mod http {
 #[cfg(feature = "mtls")]
 #[cfg_attr(nightly, doc(cfg(feature = "mtls")))]
 pub mod mtls;
+
+#[cfg(feature = "anyhow")]
+#[cfg_attr(nightly, doc(cfg(feature = "anyhow")))]
+pub mod anyhow;
 
 /// TODO: We need a futures mod or something.
 mod trip_wire;


### PR DESCRIPTION
This PR adds feature-gated support for the Error struct from anyhow as a Responder. I'm not even sure if you're interested in it, but I like using anyhow, and I think a lot of others do to. Feel free to close this PR if you don't want it in Rocket.

Fixes https://github.com/dtolnay/anyhow/issues/105

