### PR TITLE
Update Hyper from 0.14.9 -> 0.14.26 for security reasons

### DIFF
--- a/core/http/Cargo.toml
+++ b/core/http/Cargo.toml
@@ -51,7 +51,7 @@ version = "0.13"
 optional = true
 
 [dependencies.hyper]
-version = "0.14.9"
+version = "0.14.26"
 default-features = false
 features = ["http1", "runtime", "server", "stream"]
 


### PR DESCRIPTION
This upgrade the transitive dependency of H2 from <0.3.17 (0.3.9) -> 0.3.17.
This removes CVE-2023-26964 / GHSA-f8vr-r385-rh5r, see: https://github.com/advisories/GHSA-f8vr-r385-rh5r.