### PR TITLE
Improvements to form example

### DIFF
--- a/examples/forms/templates/index.html.tera
+++ b/examples/forms/templates/index.html.tera
@@ -21,7 +21,7 @@
 
       {% if errors | length > 0 %}
           <small class="text-error" style="margin-top: -20px">
-              {{ errors | length }} field(s) have errors
+              {{ errors | length }} {{ errors | length | pluralize(singular="field has an error", plural="fields have errors")}}
           </small>
       {% endif %}
 

--- a/examples/forms/templates/index.html.tera
+++ b/examples/forms/templates/index.html.tera
@@ -19,7 +19,7 @@
     <div class="container">
       <h1>Form Example</h1>
 
-      {% if errors | length > 1 %}
+      {% if errors | length > 0 %}
           <small class="text-error" style="margin-top: -20px">
               {{ errors | length }} field(s) have errors
           </small>

--- a/examples/forms/templates/macros.html.tera
+++ b/examples/forms/templates/macros.html.tera
@@ -2,7 +2,7 @@
     {%- if name in values -%}
         {{- values | get(key=name) | first -}}
     {%- endif -%}
-{% endmacro %}
+{% endmacro value_for %}
 
 {% macro errors_for(name) %}
     {%- if name in errors -%}
@@ -11,7 +11,7 @@
             <p class="text-error is-marginless">{{ error.msg }}</p>
         {% endfor %}
     {%- endif -%}
-{% endmacro %}
+{% endmacro errors_for %}
 
 {% macro input(type, label, name, value="") %}
     <label for="{{ name }}">{{ label }}</label>
@@ -37,7 +37,7 @@
     >
         {{ label }}
     </label>
-{% endmacro input %}
+{% endmacro checkbox %}
 
 {% macro textarea(label, name, placeholder="", max=250) %}
     <label for="{{ name }}">{{ label }}</label>
@@ -49,7 +49,7 @@
     </textarea>
 
     {{ self::errors_for(name=name) }}
-{% endmacro input %}
+{% endmacro textarea %}
 
 {% macro select(label, name, options) %}
     <label for="{{ name }}">{{ label }}</label>
@@ -60,4 +60,4 @@
             >{{ value }}</option>
         {% endfor %}
     </select>
-{% endmacro input %}
+{% endmacro select %}


### PR DESCRIPTION
This pull request includes some improvements to the form example, including one bug fix, one cosmetic fix, and one nice-to-have feature (IMHO):

- bug fix: form error message is shown when there are at least two errors, not one
- cosmetic fix: some macros had the wrong macro name or missing macro name in the endmacro line
- nice-to-have: rather than saying "1 field(s) have errors" correct grammar to "1 field has an error"