### PR TITLE
Use `Span::mixed_site` to avoid let unit value warnings

### DIFF
--- a/core/codegen/src/attribute/route/mod.rs
+++ b/core/codegen/src/attribute/route/mod.rs
@@ -242,7 +242,7 @@ fn responder_outcome_expr(route: &Route) -> TokenStream {
         .map(|a| quote_spanned!(a.span() => .await));
 
     define_spanned_export!(ret_span => __req, _route);
-    quote_spanned! { ret_span =>
+    quote_spanned! { Span::mixed_site().located_at(ret_span) =>
         let ___responder = #user_handler_fn_name(#(#parameter_names),*) #_await;
         #_route::Outcome::from(#__req, ___responder)
     }


### PR DESCRIPTION
Using `Span::mixed_site` changes the syntax context of the generated responder outcome expr to identify as macro-expanded, helping the `clippy::let_unit_value` lint and a potential `unit_bindings` rustc lint to avoid linting on generated code.

Closes #2568.
Avoids a potential rustc `unit_bindings` lint (if it is merged at https://github.com/rust-lang/rust/pull/112380).