### PR TITLE
Follow the Browser's `color-scheme` for Default Error Pages

### DIFF
--- a/core/lib/src/catcher/catcher.rs
+++ b/core/lib/src/catcher/catcher.rs
@@ -373,6 +373,7 @@ r#"<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8">
+    <meta name="color-scheme" content="light dark">
     <title>"#, $code, " ", $reason, r#"</title>
 </head>
 <body align="center">


### PR DESCRIPTION
<img src="https://github.com/SergioBenitez/Rocket/assets/4602612/47d19dde-1293-4fa6-9430-01823bac2802" width="400px" title="Screenshot of the 404 Error Page in Light Mode">
<img src="https://github.com/SergioBenitez/Rocket/assets/4602612/3f6b7510-8944-4f81-b888-200c6a8d7bd4" width="400px" title="Screenshot of the 404 Error Page in Dark Mode">
