### PR TITLE
Sqlx 0.7 update

### DIFF
--- a/contrib/db_pools/lib/Cargo.toml
+++ b/contrib/db_pools/lib/Cargo.toml
@@ -72,7 +72,7 @@ default-features = false
 optional = true
 
 [dependencies.sqlx]
-version = "0.6"
+version = "0.7"
 default-features = false
 features = ["runtime-tokio-rustls"]
 optional = true

--- a/contrib/db_pools/lib/Cargo.toml
+++ b/contrib/db_pools/lib/Cargo.toml
@@ -21,7 +21,6 @@ deadpool_redis = ["deadpool-redis", "deadpool"]
 sqlx_mysql = ["sqlx", "sqlx/mysql"]
 sqlx_postgres = ["sqlx", "sqlx/postgres"]
 sqlx_sqlite = ["sqlx", "sqlx/sqlite"]
-sqlx_mssql = ["sqlx", "sqlx/mssql"]
 sqlx_macros = ["sqlx/macros"]
 # diesel features
 diesel_postgres = ["diesel-async/postgres", "diesel-async/deadpool", "diesel", "deadpool"]

--- a/contrib/db_pools/lib/src/lib.rs
+++ b/contrib/db_pools/lib/src/lib.rs
@@ -113,7 +113,7 @@
 //! On shutdown, new connections are denied. Shutdown _does not_ wait for
 //! connections to be returned.
 //!
-//! ## `sqlx` (v0.6)
+//! ## `sqlx` (v0.7)
 //!
 //! | Database | Feature         | [`Pool`] Type        | [`Connection`] Deref                     |
 //! |----------|-----------------|----------------------|------------------------------------------|
@@ -160,7 +160,7 @@
 //!
 //! ```toml
 //! [dependencies.sqlx]
-//! version = "0.6"
+//! version = "0.7"
 //! default-features = false
 //! features = ["macros", "migrate"]
 //!

--- a/contrib/db_pools/lib/src/lib.rs
+++ b/contrib/db_pools/lib/src/lib.rs
@@ -120,16 +120,13 @@
 //! | Postgres | `sqlx_postgres` | [`sqlx::PgPool`]     | [`sqlx::pool::PoolConnection<Postgres>`] |
 //! | MySQL    | `sqlx_mysql`    | [`sqlx::MySqlPool`]  | [`sqlx::pool::PoolConnection<MySql>`]    |
 //! | SQLite   | `sqlx_sqlite`   | [`sqlx::SqlitePool`] | [`sqlx::pool::PoolConnection<Sqlite>`]   |
-//! | MSSQL    | `sqlx_mssql`    | [`sqlx::MssqlPool`]  | [`sqlx::pool::PoolConnection<Mssql>`]    |
 //!
 //! [`sqlx::PgPool`]: https://docs.rs/sqlx/0.6/sqlx/type.PgPool.html
 //! [`sqlx::MySqlPool`]: https://docs.rs/sqlx/0.6/sqlx/type.MySqlPool.html
 //! [`sqlx::SqlitePool`]: https://docs.rs/sqlx/0.6/sqlx/type.SqlitePool.html
-//! [`sqlx::MssqlPool`]: https://docs.rs/sqlx/0.6/sqlx/type.MssqlPool.html
 //! [`sqlx::pool::PoolConnection<Postgres>`]: https://docs.rs/sqlx/0.6/sqlx/pool/struct.PoolConnection.html
 //! [`sqlx::pool::PoolConnection<MySql>`]: https://docs.rs/sqlx/0.6/sqlx/pool/struct.PoolConnection.html
 //! [`sqlx::pool::PoolConnection<Sqlite>`]: https://docs.rs/sqlx/0.6/sqlx/pool/struct.PoolConnection.html
-//! [`sqlx::pool::PoolConnection<Mssql>`]: https://docs.rs/sqlx/0.6/sqlx/pool/struct.PoolConnection.html
 //!
 //! On shutdown, new connections are denied. Shutdown waits for connections to
 //! be returned.

--- a/contrib/db_pools/lib/src/lib.rs
+++ b/contrib/db_pools/lib/src/lib.rs
@@ -62,7 +62,7 @@
 //!    #[get("/<id>")]
 //!    async fn read(mut db: Connection<Logs>, id: i64) -> Option<Log> {
 //!        sqlx::query("SELECT content FROM logs WHERE id = ?").bind(id)
-//!            .fetch_one(&mut *db).await
+//!            .fetch_one(&mut **db).await
 //!            .and_then(|r| Ok(Log(r.try_get(0)?)))
 //!            .ok()
 //!    }

--- a/contrib/db_pools/lib/src/lib.rs
+++ b/contrib/db_pools/lib/src/lib.rs
@@ -165,7 +165,7 @@
 //! [dependencies.sqlx]
 //! version = "0.6"
 //! default-features = false
-//! features = ["macros", "offline", "migrate"]
+//! features = ["macros", "migrate"]
 //!
 //! [dependencies.rocket_db_pools]
 //! version = "=0.1.0-rc.3"

--- a/contrib/db_pools/lib/src/pool.rs
+++ b/contrib/db_pools/lib/src/pool.rs
@@ -253,10 +253,10 @@ mod sqlx {
             let mut opts = config.url.parse::<Options<D>>().map_err(Error::Init)?;
             specialize(&mut opts, &config);
 
-            opts.disable_statement_logging();
+            opts = opts.disable_statement_logging();
             if let Ok(level) = figment.extract_inner::<LogLevel>(rocket::Config::LOG_LEVEL) {
                 if !matches!(level, LogLevel::Normal | LogLevel::Off) {
-                    opts.log_statements(level.into())
+                    opts = opts.log_statements(level.into())
                         .log_slow_statements(level.into(), Duration::default());
                 }
             }

--- a/contrib/db_pools/lib/tests/databases.rs
+++ b/contrib/db_pools/lib/tests/databases.rs
@@ -53,13 +53,6 @@ check_types_match!(
 );
 
 check_types_match!(
-    "sqlx_mssql",
-    sqlx_mssql,
-    sqlx::MssqlPool,
-    sqlx::pool::PoolConnection<sqlx::Mssql>,
-);
-
-check_types_match!(
     "mongodb",
     mongodb,
     mongodb::Client,

--- a/contrib/sync_db_pools/lib/Cargo.toml
+++ b/contrib/sync_db_pools/lib/Cargo.toml
@@ -28,8 +28,8 @@ diesel = { version = "2.0.0", default-features = false, optional = true }
 postgres = { version = "0.19", optional = true }
 r2d2_postgres = { version = "0.18", optional = true }
 
-rusqlite = { version = "0.27.0", optional = true }
-r2d2_sqlite = { version = "0.20.0", optional = true }
+rusqlite = { version = "0.29.0", optional = true }
+r2d2_sqlite = { version = "0.22.0", optional = true }
 
 memcache = { version = "0.15", optional = true }
 r2d2-memcache = { version = "0.6", optional = true }

--- a/core/codegen/tests/ui-fail-stable/from_form.stderr
+++ b/core/codegen/tests/ui-fail-stable/from_form.stderr
@@ -523,6 +523,9 @@ help: the type constructed contains `{integer}` due to the type of the argument 
     |                       ^^^ this argument influences the type of `Some`
 note: tuple variant defined here
    --> $RUST/core/src/option.rs
+    |
+    |     Some(#[stable(feature = "rust1", since = "1.0.0")] T),
+    |     ^^^^
 
 error[E0308]: mismatched types
    --> tests/ui-fail-stable/from_form.rs:203:33
@@ -542,6 +545,9 @@ help: the type constructed contains `&'static str` due to the type of the argume
     |                                 this argument influences the type of `Some`
 note: tuple variant defined here
    --> $RUST/core/src/option.rs
+    |
+    |     Some(#[stable(feature = "rust1", since = "1.0.0")] T),
+    |     ^^^^
 
 error[E0277]: the trait bound `bool: From<&str>` is not satisfied
    --> tests/ui-fail-stable/from_form.rs:209:23

--- a/examples/databases/.sqlx/query-11e3096becb72f427c8d3911ef4327afd9516143806981e11f8e34d069c14472.json
+++ b/examples/databases/.sqlx/query-11e3096becb72f427c8d3911ef4327afd9516143806981e11f8e34d069c14472.json
@@ -1,0 +1,32 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT id, title, text FROM posts WHERE id = ?",
+  "describe": {
+    "columns": [
+      {
+        "name": "id",
+        "ordinal": 0,
+        "type_info": "Int64"
+      },
+      {
+        "name": "title",
+        "ordinal": 1,
+        "type_info": "Text"
+      },
+      {
+        "name": "text",
+        "ordinal": 2,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "11e3096becb72f427c8d3911ef4327afd9516143806981e11f8e34d069c14472"
+}

--- a/examples/databases/.sqlx/query-3c289da9873097a11191dbedc5c78d86afd6a6d36771bfeb12f331abca6279cf.json
+++ b/examples/databases/.sqlx/query-3c289da9873097a11191dbedc5c78d86afd6a6d36771bfeb12f331abca6279cf.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "INSERT INTO posts (title, text) VALUES (?, ?)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": []
+  },
+  "hash": "3c289da9873097a11191dbedc5c78d86afd6a6d36771bfeb12f331abca6279cf"
+}

--- a/examples/databases/.sqlx/query-4415c35941e52a981b10707fe2e1ceb0bad0e473701e51ef21ecb2973c76b4df.json
+++ b/examples/databases/.sqlx/query-4415c35941e52a981b10707fe2e1ceb0bad0e473701e51ef21ecb2973c76b4df.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT id FROM posts",
+  "describe": {
+    "columns": [
+      {
+        "name": "id",
+        "ordinal": 0,
+        "type_info": "Int64"
+      }
+    ],
+    "parameters": {
+      "Right": 0
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "4415c35941e52a981b10707fe2e1ceb0bad0e473701e51ef21ecb2973c76b4df"
+}

--- a/examples/databases/.sqlx/query-668690acaca0a0c0b4ac306b14d82aa1bee940f0776fae3f9962639b78328858.json
+++ b/examples/databases/.sqlx/query-668690acaca0a0c0b4ac306b14d82aa1bee940f0776fae3f9962639b78328858.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "DELETE FROM posts",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 0
+    },
+    "nullable": []
+  },
+  "hash": "668690acaca0a0c0b4ac306b14d82aa1bee940f0776fae3f9962639b78328858"
+}

--- a/examples/databases/.sqlx/query-79301b44b77802e0096efd73b1e9adac27b27a3cf7bf853af3a9f130b1684d91.json
+++ b/examples/databases/.sqlx/query-79301b44b77802e0096efd73b1e9adac27b27a3cf7bf853af3a9f130b1684d91.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "DELETE FROM posts WHERE id = ?",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": []
+  },
+  "hash": "79301b44b77802e0096efd73b1e9adac27b27a3cf7bf853af3a9f130b1684d91"
+}

--- a/examples/databases/Cargo.toml
+++ b/examples/databases/Cargo.toml
@@ -11,7 +11,7 @@ diesel = "2"
 diesel_migrations = "2"
 
 [dependencies.sqlx]
-version = "0.6.0"
+version = "0.7.0"
 default-features = false
 features = ["macros", "migrate"]
 

--- a/examples/databases/Cargo.toml
+++ b/examples/databases/Cargo.toml
@@ -13,7 +13,7 @@ diesel_migrations = "2"
 [dependencies.sqlx]
 version = "0.6.0"
 default-features = false
-features = ["macros", "offline", "migrate"]
+features = ["macros", "migrate"]
 
 [dependencies.rocket_db_pools]
 path = "../../contrib/db_pools/lib/"

--- a/examples/databases/src/sqlx.rs
+++ b/examples/databases/src/sqlx.rs
@@ -26,7 +26,7 @@ struct Post {
 async fn create(mut db: Connection<Db>, post: Json<Post>) -> Result<Created<Json<Post>>> {
     // There is no support for `RETURNING`.
     sqlx::query!("INSERT INTO posts (title, text) VALUES (?, ?)", post.title, post.text)
-        .execute(&mut *db)
+        .execute(&mut **db)
         .await?;
 
     Ok(Created::new("/").body(post))
@@ -35,7 +35,7 @@ async fn create(mut db: Connection<Db>, post: Json<Post>) -> Result<Created<Json
 #[get("/")]
 async fn list(mut db: Connection<Db>) -> Result<Json<Vec<i64>>> {
     let ids = sqlx::query!("SELECT id FROM posts")
-        .fetch(&mut *db)
+        .fetch(&mut **db)
         .map_ok(|record| record.id)
         .try_collect::<Vec<_>>()
         .await?;
@@ -46,7 +46,7 @@ async fn list(mut db: Connection<Db>) -> Result<Json<Vec<i64>>> {
 #[get("/<id>")]
 async fn read(mut db: Connection<Db>, id: i64) -> Option<Json<Post>> {
     sqlx::query!("SELECT id, title, text FROM posts WHERE id = ?", id)
-        .fetch_one(&mut *db)
+        .fetch_one(&mut **db)
         .map_ok(|r| Json(Post { id: Some(r.id), title: r.title, text: r.text }))
         .await
         .ok()
@@ -55,7 +55,7 @@ async fn read(mut db: Connection<Db>, id: i64) -> Option<Json<Post>> {
 #[delete("/<id>")]
 async fn delete(mut db: Connection<Db>, id: i64) -> Result<Option<()>> {
     let result = sqlx::query!("DELETE FROM posts WHERE id = ?", id)
-        .execute(&mut *db)
+        .execute(&mut **db)
         .await?;
 
     Ok((result.rows_affected() == 1).then(|| ()))
@@ -63,7 +63,7 @@ async fn delete(mut db: Connection<Db>, id: i64) -> Result<Option<()>> {
 
 #[delete("/")]
 async fn destroy(mut db: Connection<Db>) -> Result<()> {
-    sqlx::query!("DELETE FROM posts").execute(&mut *db).await?;
+    sqlx::query!("DELETE FROM posts").execute(&mut **db).await?;
 
     Ok(())
 }

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -80,7 +80,6 @@ function test_contrib() {
     sqlx_mysql
     sqlx_postgres
     sqlx_sqlite
-    sqlx_mssql
     mongodb
     diesel_mysql
     diesel_postgres

--- a/site/guide/6-state.md
+++ b/site/guide/6-state.md
@@ -264,7 +264,7 @@ in three simple steps:
    #[get("/<id>")]
    async fn read(mut db: Connection<Logs>, id: i64) -> Option<String> {
        sqlx::query("SELECT content FROM logs WHERE id = ?").bind(id)
-           .fetch_one(&mut *db).await
+           .fetch_one(&mut **db).await
            .and_then(|r| Ok(r.try_get(0)?))
            .ok()
    }

--- a/site/guide/6-state.md
+++ b/site/guide/6-state.md
@@ -296,7 +296,7 @@ features enabled in `Cargo.toml`:
 [dependencies.sqlx]
 version = "0.6"
 default-features = false
-features = ["macros", "offline", "migrate"]
+features = ["macros", "migrate"]
 
 [dependencies.rocket_db_pools]
 version = "=0.1.0-rc.3"

--- a/site/guide/6-state.md
+++ b/site/guide/6-state.md
@@ -294,7 +294,7 @@ features enabled in `Cargo.toml`:
 
 ```toml
 [dependencies.sqlx]
-version = "0.6"
+version = "0.7"
 default-features = false
 features = ["macros", "migrate"]
 


### PR DESCRIPTION
[Changelog of sqlx]( https://github.com/launchbadge/sqlx/blob/main/CHANGELOG.md#breaking)
  **TL;DR:**
  - MSSQL feature gone -> https://github.com/SergioBenitez/Rocket/pull/2604/commits/66385706602b160297be5da70f979f04b6e61224
  - offline feature gone -> https://github.com/SergioBenitez/Rocket/pull/2604/commits/076343d06cdde1235af4fae797a7d091ec4ce9e1, https://github.com/SergioBenitez/Rocket/pull/2604/commits/cafcbbf0f5c8f9e7aed899dd715a2d1364bd55c8
  - another dereference needed for `mut db: Connection<Logs>` (🙏🏻[reddit](https://www.reddit.com/r/rust/comments/14pw35f/comment/jqmv7gy/)) -> https://github.com/SergioBenitez/Rocket/pull/2604/commits/5e15bc7b299e6baa1ae188186361c107245fc02f
  - [opt is consuming self](https://github.com/launchbadge/sqlx/commit/b72a52b0666f69965480c86137e5840d0b361d0a#diff-eab8ee12bc9e34ac092d051bbd03835c90f323cfc96d67956ca7b9be02db70cdR180), changed somewhere between 0.6.3 and 0.7.0-alpha.1 -> https://github.com/SergioBenitez/Rocket/pull/2604/commits/acf3b73a8ee92e85e47010e4e3d60fa3737c1e4d

Fixes: "use two different sqlx versions?" when using shuttle.rs

- [X] All tests are passing

---

I'm new to Rust. This is my first contribution to the Rust community. Please tell me, if you would have done this better. I'm willing to learn.
