### PR TITLE
Fix #1224 by searching routes after failed match

### DIFF
--- a/core/codegen/tests/route-format.rs
+++ b/core/codegen/tests/route-format.rs
@@ -61,7 +61,7 @@ fn test_formats() {
     assert_eq!(response.into_string().unwrap(), "plain");
 
     let response = client.put("/").header(ContentType::HTML).dispatch();
-    assert_eq!(response.status(), Status::NotFound);
+    assert_eq!(response.status(), Status::MethodNotAllowed);
 }
 
 // Test custom formats.
@@ -109,9 +109,12 @@ fn test_custom_formats() {
     let response = client.get("/").dispatch();
     assert_eq!(response.into_string().unwrap(), "get_foo");
 
+    let response = client.get("/").header(Accept::JPEG).dispatch();
+    assert_eq!(response.status(), Status::NotAcceptable); // Route can't produce JPEG
+
     let response = client.put("/").header(ContentType::HTML).dispatch();
-    assert_eq!(response.status(), Status::NotFound);
+    assert_eq!(response.status(), Status::UnsupportedMediaType); // Route expects "bar/baz"
 
     let response = client.post("/").header(ContentType::HTML).dispatch();
-    assert_eq!(response.status(), Status::NotFound);
+    assert_eq!(response.status(), Status::UnsupportedMediaType); // Route expects "foo"
 }

--- a/core/codegen/tests/route.rs
+++ b/core/codegen/tests/route.rs
@@ -105,7 +105,7 @@ fn test_full_route() {
     assert_eq!(response.status(), Status::NotFound);
 
     let response = client.post(format!("/1{}", uri)).body(simple).dispatch();
-    assert_eq!(response.status(), Status::NotFound);
+    assert_eq!(response.status(), Status::UnsupportedMediaType);
 
     let response = client
         .post(format!("/1{}", uri))
@@ -117,7 +117,7 @@ fn test_full_route() {
             sky, name.percent_decode().unwrap(), "A A", "inside", path, simple, expected_uri));
 
     let response = client.post(format!("/2{}", uri)).body(simple).dispatch();
-    assert_eq!(response.status(), Status::NotFound);
+    assert_eq!(response.status(), Status::UnsupportedMediaType);
 
     let response = client
         .post(format!("/2{}", uri))

--- a/core/lib/src/router/matcher.rs
+++ b/core/lib/src/router/matcher.rs
@@ -138,7 +138,7 @@ impl Catcher {
     }
 }
 
-fn paths_match(route: &Route, req: &Request<'_>) -> bool {
+pub(crate) fn paths_match(route: &Route, req: &Request<'_>) -> bool {
     trace!("checking path match: route {} vs. request {}", route, req);
     let route_segments = &route.uri.metadata.uri_segments;
     let req_segments = req.uri().path().segments();
@@ -170,7 +170,7 @@ fn paths_match(route: &Route, req: &Request<'_>) -> bool {
     true
 }
 
-fn queries_match(route: &Route, req: &Request<'_>) -> bool {
+pub(crate) fn queries_match(route: &Route, req: &Request<'_>) -> bool {
     trace!("checking query match: route {} vs. request {}", route, req);
     if matches!(route.uri.metadata.query_color, None | Some(Color::Wild)) {
         return true;

--- a/core/lib/src/router/router.rs
+++ b/core/lib/src/router/router.rs
@@ -6,6 +6,8 @@ use crate::http::{Method, Status};
 use crate::{Route, Catcher};
 use crate::router::Collide;
 
+use super::matcher::{paths_match, queries_match};
+
 #[derive(Debug, Default)]
 pub(crate) struct Router {
     routes: HashMap<Method, Vec<Route>>,
@@ -62,7 +64,7 @@ impl Router {
         self.routes.get(&req.method())
             .into_iter()
             .flatten()
-            .any(|route| super::matcher::paths_match(route, req) && super::matcher::queries_match(route, req))
+            .any(|route| paths_match(route, req) && queries_match(route, req))
     }
 
     const ALL_METHODS: &[Method] = &[
@@ -79,7 +81,7 @@ impl Router {
             .filter(|method| *method != &req.method())
             .filter_map(|method| self.routes.get(method))
             .flatten()
-            .any(|route| super::matcher::paths_match(route, req))
+            .any(|route| paths_match(route, req))
     }
 
     // For many catchers, using aho-corasick or similar should be much faster.

--- a/core/lib/src/router/router.rs
+++ b/core/lib/src/router/router.rs
@@ -67,7 +67,7 @@ impl Router {
             .any(|route| paths_match(route, req) && queries_match(route, req))
     }
 
-    const ALL_METHODS: &[Method] = &[
+    const ALL_METHODS: &'static [Method] = &[
         Method::Get, Method::Put, Method::Post, Method::Delete, Method::Options,
         Method::Head, Method::Trace, Method::Connect, Method::Patch,
     ];

--- a/core/lib/src/router/router.rs
+++ b/core/lib/src/router/router.rs
@@ -55,6 +55,33 @@ impl Router {
             .flat_map(move |routes| routes.iter().filter(move |r| r.matches(req)))
     }
 
+    pub(crate) fn matches_except_formats<'r, 'a: 'r>(
+        &'a self,
+        req: &'r Request<'r>
+    ) -> bool {
+        self.routes.get(&req.method())
+            .into_iter()
+            .flatten()
+            .any(|route| super::matcher::paths_match(route, req) && super::matcher::queries_match(route, req))
+    }
+
+    const ALL_METHODS: &[Method] = &[
+        Method::Get, Method::Put, Method::Post, Method::Delete, Method::Options,
+        Method::Head, Method::Trace, Method::Connect, Method::Patch,
+    ];
+
+    pub(crate) fn matches_except_method<'r, 'a: 'r>(
+        &'a self,
+        req: &'r Request<'r>
+    ) -> bool {
+        Self::ALL_METHODS
+            .iter()
+            .filter(|method| *method != &req.method())
+            .filter_map(|method| self.routes.get(method))
+            .flatten()
+            .any(|route| super::matcher::paths_match(route, req))
+    }
+
     // For many catchers, using aho-corasick or similar should be much faster.
     pub fn catch<'r>(&self, status: Status, req: &'r Request<'r>) -> Option<&Catcher> {
         // Note that catchers are presorted by descending base length.
@@ -366,6 +393,22 @@ mod test {
         let router = router_with_routes(&["/prefix/<a..>"]);
         assert!(route(&router, Get, "/").is_none());
         assert!(route(&router, Get, "/prefi/").is_none());
+    }
+
+    fn has_mismatched_method<'a>(router: &'a Router, method: Method, uri: &'a str) -> bool {
+        let client = Client::debug_with(vec![]).expect("client");
+        let request = client.req(method, Origin::parse(uri).unwrap());
+        router.matches_except_method(&request)
+    }
+
+    #[test]
+    fn test_bad_method_routing() {
+        let router = router_with_routes(&["/hello"]);
+        assert!(route(&router, Put, "/hello").is_none());
+        assert!(has_mismatched_method(&router, Put, "/hello"));
+        assert!(has_mismatched_method(&router, Post, "/hello"));
+
+        assert!(! has_mismatched_method(&router, Get, "/hello"));
     }
 
     /// Asserts that `$to` routes to `$want` given `$routes` are present.

--- a/core/lib/src/server.rs
+++ b/core/lib/src/server.rs
@@ -342,6 +342,16 @@ impl Rocket<Orbit> {
         }
 
         error_!("No matching routes for {}.", request);
+        if request.route().is_none() {
+            // We failed to find a route which matches on path, query AND formats
+            if self.router.matches_except_formats(request) {
+                // Tailor the error code to the interpretation of the request in question.
+                status = if request.method().supports_payload() { Status::UnsupportedMediaType } else { Status::NotAcceptable };
+            } else if self.router.matches_except_method(request) {
+                // Found a more suitable error code from simple route paths implemented on different methods
+                status = Status::MethodNotAllowed;
+            }
+        }
         Outcome::Forward((data, status))
     }
 

--- a/core/lib/src/server.rs
+++ b/core/lib/src/server.rs
@@ -343,12 +343,16 @@ impl Rocket<Orbit> {
 
         error_!("No matching routes for {}.", request);
         if request.route().is_none() {
-            // We failed to find a route which matches on path, query AND formats
+            // We failed to find a route which matches on path, query AND formats.
             if self.router.matches_except_formats(request) {
                 // Tailor the error code to the interpretation of the request in question.
-                status = if request.method().supports_payload() { Status::UnsupportedMediaType } else { Status::NotAcceptable };
+                if request.method().supports_payload() {
+                    status = Status::UnsupportedMediaType;
+                } else {
+                    status = Status::NotAcceptable;
+                }
             } else if self.router.matches_except_method(request) {
-                // Found a more suitable error code from simple route paths implemented on different methods
+                // Found a more suitable error code for paths implemented on different methods.
                 status = Status::MethodNotAllowed;
             }
         }

--- a/core/lib/tests/form_method-issue-45.rs
+++ b/core/lib/tests/form_method-issue-45.rs
@@ -37,6 +37,6 @@ mod tests {
             .body("_method=patch&form_data=Form+data")
             .dispatch();
 
-        assert_eq!(response.status(), Status::NotFound);
+        assert_eq!(response.status(), Status::MethodNotAllowed);
     }
 }

--- a/core/lib/tests/precise-content-type-matching.rs
+++ b/core/lib/tests/precise-content-type-matching.rs
@@ -48,7 +48,7 @@ mod tests {
             let body: Option<&'static str> = $body;
             match body {
                 Some(string) => assert_eq!(body_str, Some(string.to_string())),
-                None => assert_eq!(status, Status::NotFound)
+                None => assert_eq!(status, Status::UnsupportedMediaType)
             }
         )
     }

--- a/examples/error-handling/src/tests.rs
+++ b/examples/error-handling/src/tests.rs
@@ -56,6 +56,15 @@ fn test_hello_invalid_age() {
 }
 
 #[test]
+fn test_method_not_allowed() {
+    let client = Client::tracked(super::rocket()).unwrap();
+    let (name, age) = ("Pat", 86);
+    let request = client.post(format!("/hello/{}/{}", name, age)).body("body");
+    let response = request.dispatch();
+    assert_eq!(response.status(), Status::MethodNotAllowed);
+}
+
+#[test]
 fn test_hello_sergio() {
     let client = Client::tracked(super::rocket()).unwrap();
 

--- a/examples/responders/src/tests.rs
+++ b/examples/responders/src/tests.rs
@@ -126,8 +126,7 @@ fn test_xml() {
     assert_eq!(r.into_string().unwrap(), r#"{ "payload": "I'm here" }"#);
 
     let r = client.get(uri!(super::xml)).header(Accept::CSV).dispatch();
-    assert_eq!(r.status(), Status::NotFound);
-    assert!(r.into_string().unwrap().contains("not supported"));
+    assert_eq!(r.status(), Status::NotAcceptable);
 
     let r = client.get("/content/i/dont/exist").header(Accept::HTML).dispatch();
     assert_eq!(r.content_type().unwrap(), ContentType::HTML);

--- a/examples/templating/src/tests.rs
+++ b/examples/templating/src/tests.rs
@@ -22,8 +22,7 @@ fn test_root(kind: &str) {
         let expected = Template::show(client.rocket(), format!("{}/error/404", kind), &context);
 
         let response = client.req(*method, format!("/{}", kind)).dispatch();
-        assert_eq!(response.status(), Status::NotFound);
-        assert_eq!(response.into_string(), expected);
+        assert_eq!(response.status(), Status::MethodNotAllowed);
     }
 }
 


### PR DESCRIPTION
This PR fixes #1224 by introducing more detailed HTTP status reporting.

If the request is matched, this patch does nothing. That way, routes which set their own HTTP status code are not affected even if they return 404.

If *no* route matches the request, this PR checks for "near matches", first looking to see if any routes failed only the format check, and afterwards checks for matching paths, but on a different HTTP method.

For format-check failures for POST and PUT, the HTTP status code will be 415 Unsupported Media Type (since this means that the Content-Type of the request didn't match what the route expected). For GET, etc., a failed format check will be 406 Not Acceptable, since the route couldn't produce what the client requested.

If the method and path didn't match at all, but the path *is* present as a route for one of the other HTTP methods, 405 Method Not Allowed is returned.

Otherwise, the 404 Not Found is left as is.

Tests were corrected as required.