### PR TITLE
Upgrade 'tokio-tungstenite' to 0.20.

### DIFF
--- a/contrib/ws/Cargo.toml
+++ b/contrib/ws/Cargo.toml
@@ -17,7 +17,7 @@ default = ["tungstenite"]
 tungstenite = ["tokio-tungstenite"]
 
 [dependencies]
-tokio-tungstenite = { version = "0.19", optional = true }
+tokio-tungstenite = { version = "0.20", optional = true }
 
 [dependencies.rocket]
 version = "=0.5.0-rc.3"


### PR DESCRIPTION
Cherry-Pick tungstenite  update to v0.5 branch.
This ensures applications which use the contrib/ws to use a patched version which has a known CVE https://github.com/snapview/tokio-tungstenite/blob/master/CHANGELOG.md#0201
