### PR TITLE
Avoid clippy lint in `uri!` macro

### DIFF
--- a/core/codegen/src/bang/uri.rs
+++ b/core/codegen/src/bang/uri.rs
@@ -127,7 +127,7 @@ fn add_binding<P: fmt::Part>(to: &mut Vec<TokenStream>, ident: &Ident, ty: &Type
     let let_stmt = quote_spanned!(span => let #tmp_ident = #expr);
 
     to.push(quote_spanned!(span =>
-        #[allow(non_snake_case)] #let_stmt;
+        #[allow(clippy::redundant_locals, non_snake_case)] #let_stmt;
         let #ident = <#ty as #_fmt::FromUriParam<#part, _>>::from_uri_param(#tmp_ident);
     ));
 }


### PR DESCRIPTION
Avoids the `clippy::redundant_locals` lint in `uri!` invocations (see https://stackoverflow.com/q/77366480/11423104 for reference).

This happens because the macro expands to `let parameter_name = argument_name;` which triggers the lint if `parameter_name == argument_name`. The fix is a simple `allow` attribute.