### PR TITLE
update diesel-async to 0.4.1

### DIFF
--- a/contrib/db_pools/lib/Cargo.toml
+++ b/contrib/db_pools/lib/Cargo.toml
@@ -61,7 +61,7 @@ features = ["tokio-runtime"]
 optional = true
 
 [dependencies.diesel-async]
-version = "0.3.1"
+version = "0.4.1"
 default-features = false
 optional = true
 


### PR DESCRIPTION
Updating diesel-async to 0.4.1 to support Diesel migrations. See https://github.com/weiznich/diesel_async/blob/main/CHANGELOG.md?plain=1#L17

This will probably solve the trait issue in https://github.com/SergioBenitez/Rocket/discussions/2640
