### PR TITLE
Add link to GitHub in the quickstart page

### DIFF
--- a/docs/guide/02-quickstart.md
+++ b/docs/guide/02-quickstart.md
@@ -12,7 +12,7 @@ Started].
 ## Running Examples
 
 The absolute fastest way to start experimenting with Rocket is to clone the
-Rocket repository and run the included examples in the `examples/` directory.
+[Rocket repository](https://github.com/rwf2/Rocket) and run the included examples in the `examples/` directory.
 For instance, the following set of commands runs the `hello` example:
 
 ```sh


### PR DESCRIPTION
So you don't need to manually select the link with your mouse to view these examples.